### PR TITLE
Fix conditional comments for old versions of IE

### DIFF
--- a/CDA.xsl
+++ b/CDA.xsl
@@ -992,11 +992,11 @@
                         </img>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:comment>[if lte IE 9]&gt;</xsl:comment>
-                        <xsl:call-template name="getLocalizedString">
-                            <xsl:with-param name="key" select="'iframe-warning'"/>
-                        </xsl:call-template>
-                        <xsl:comment>&lt;![endif]</xsl:comment>
+                        <xsl:comment>[if lte IE 9]&gt;
+                            <xsl:call-template name="getLocalizedString">
+                                <xsl:with-param name="key" select="'iframe-warning'"/>
+                            </xsl:call-template>
+                        &lt;![endif]</xsl:comment>
                         <xsl:comment>[if gt IE 9]&gt;</xsl:comment>
                         <iframe name="{$renderID}" id="{$renderID}" width="100%" height="600" src="{$source}" title="{$renderAltText}" sandbox=""/>
                         <xsl:comment>&lt;![endif]</xsl:comment>
@@ -1018,11 +1018,11 @@
             </xsl:when>
             <!-- This is something base64 -->
             <xsl:when test="$renderElement[@representation = 'B64']">
-                <xsl:comment>[if lt IE 9]&gt;</xsl:comment>
-                <xsl:call-template name="getLocalizedString">
-                    <xsl:with-param name="key" select="'iframe-warning'"/>
-                </xsl:call-template>
-                <xsl:comment>&lt;![endif]</xsl:comment>
+                <xsl:comment>[if lte IE 9]&gt;
+                    <xsl:call-template name="getLocalizedString">
+                        <xsl:with-param name="key" select="'iframe-warning'"/>
+                    </xsl:call-template>
+                &lt;![endif]</xsl:comment>
                 <xsl:comment>[if gt IE 9]&gt;</xsl:comment>
                 <xsl:call-template name="getLocalizedString">
                     <xsl:with-param name="pre" select="' '"/>


### PR DESCRIPTION
Hey Alexander--in order to make the message about sandboxed iframes not being supported only show up in older versions of IE, I think it needs to work a little differently. For content that you do want to show in old versions of IE but *not* in newer browsers, you put the entire thing in a comment so that modern browsers ignore it but IE picks it up. (Also, it looks like for the base64 case it was written as just lt IE 9, not lte.)

Hope you can take a look at this tomorrow!