### PR TITLE
Add sdtc:raceCode and sdtc:ethnicGroupCode support

### DIFF
--- a/CDA.xsl
+++ b/CDA.xsl
@@ -1525,24 +1525,26 @@
                                         <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:administrativeGenderCode"/>
                                     </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:raceCode">
+                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:raceCode |
+                                              hl7:relatedSubject/hl7:subject/sdtc:raceCode">
                                     <xsl:text>, </xsl:text>
                                             <xsl:call-template name="getLocalizedString">
                                                 <xsl:with-param name="key" select="'Race'"/>
                                                 <xsl:with-param name="post" select="': '"/>
                                             </xsl:call-template>
                                             <xsl:call-template name="show-code-set">
-                                                <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:raceCode"/>
+                                                <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:raceCode | hl7:relatedSubject/hl7:subject/sdtc:raceCode"/>
                                             </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode">
+                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode |
+                                              hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode">
                                     <xsl:text>, </xsl:text>
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Ethnicity'"/>
                                         <xsl:with-param name="post" select="': '"/>
                                     </xsl:call-template>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode"/>
+                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode | hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode"/>
                                     </xsl:call-template>
                                 </xsl:if>
                                 <xsl:if test="hl7:relatedSubject/hl7:telecom">
@@ -4118,7 +4120,8 @@
                             </xsl:call-template>
                         </td>
                     </tr>
-                    <xsl:if test="hl7:patient/hl7:raceCode | hl7:patient/hl7:ethnicGroupCode">
+                    <xsl:if test="hl7:patient/hl7:raceCode | hl7:patient/hl7:ethnicGroupCode |
+                                  hl7:patient/sdtc:raceCode | hl7:patient/sdtc:ethnicGroupCode">
                         <tr>
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
@@ -4127,7 +4130,7 @@
                             </td>
                             <td style="width: 30%;">
                                 <xsl:call-template name="show-code-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:raceCode"/>
+                                    <xsl:with-param name="in" select="hl7:patient/hl7:raceCode | hl7:patient/sdtc:raceCode"/>
                                 </xsl:call-template>
                             </td>
                             <td class="td_label td_label_width">
@@ -4137,7 +4140,7 @@
                             </td>
                             <td>
                                 <xsl:call-template name="show-code-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:ethnicGroupCode"/>
+                                    <xsl:with-param name="in" select="hl7:patient/hl7:ethnicGroupCode | hl7:patient/sdtc:ethnicGroupCode"/>
                                 </xsl:call-template>
                             </td>
                         </tr>


### PR DESCRIPTION
Sample CCD, along with [before](https://gistpreview.github.io/?fb7b46ddf2cc5b9c1386a813b664245a/Sample-CCD-before.html) and [after](https://gistpreview.github.io/?fb7b46ddf2cc5b9c1386a813b664245a/Sample-CCD-after.html) renders, available [here](https://gist.github.com/mjszczep/fb7b46ddf2cc5b9c1386a813b664245a). (The only difference is in the Race and Ethnicity cells in the patient demographic info at the bottom of the document.)