### PR TITLE
Add French to l10n file

### DIFF
--- a/cda_l10n.xml
+++ b/cda_l10n.xml
@@ -1971,15 +1971,15 @@
         <value lang="fr-fr">couché</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-RTRD">
-        <comment>Label: ActClass reverse trendelenburg</comment>
-        <value lang="en-us">reverse trendelenburg</value>
-        <value lang="nl-nl">omgekeerde trendelenburg</value>
-        <value lang="fr-fr">trendelenburg inversé</value>
+        <comment>Label: ActClass reverse Trendelenburg</comment>
+        <value lang="en-us">reverse Trendelenburg</value>
+        <value lang="nl-nl">omgekeerde Trendelenburg</value>
+        <value lang="fr-fr">Trendelenburg inversé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TRD">
-        <comment>Label: ActClass trendelenburg</comment>
-        <value lang="en-us">trendelenburg</value>
-        <value lang="fr-fr">trendelenburg</value>
+        <comment>Label: ActClass Trendelenburg</comment>
+        <value lang="en-us">Trendelenburg</value>
+        <value lang="fr-fr">Trendelenburg</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PCPR">
         <comment>Label: ActClass care provision</comment>

--- a/cda_l10n.xml
+++ b/cda_l10n.xml
@@ -106,7 +106,7 @@
         <value lang="en-us">Custodian</value>
         <value lang="de-ch">Verwalter</value>
         <value lang="nl-nl">Beheerder</value>
-        <value lang="fr-fr">Organisation chargée de la conservation du document </value>
+        <value lang="fr-fr">Organisation chargée de la conservation du document</value>
     </translation>
     <translation key="dataEnterer">
         <comment>Label: Data enterer</comment>
@@ -115,20 +115,20 @@
         <value lang="fr-ch">Saisie par</value>
         <value lang="it-ch">Registrati da</value>
         <value lang="nl-nl">Ingevoerd door</value>
-        <value lang="fr-fr">Opérateur de saisie </value>
+        <value lang="fr-fr">Opérateur de saisie</value>
     </translation>
     <translation key="overseer">
         <comment>Label: Overseer</comment>
         <value lang="en-us">Overseer</value>
         <value lang="nl-nl">Mandaterende/eindverantwoordelijke</value>
-        <value lang="fr-fr">Superviseur </value>
+        <value lang="fr-fr">Superviseur</value>
     </translation>
     <translation key="recordTarget">
         <comment>Label: recordTarget</comment>
         <value lang="en-us">Patient</value>
         <value lang="it-ch">Paziente</value>
         <value lang="nl-nl">Patiënt</value>
-        <value lang="fr-fr">Patient </value>
+        <value lang="fr-fr">Patient</value>
     </translation>
     <translation key="informant">
         <comment>Label: Informant - An informant (or source of information) is a person that provides relevant information</comment>
@@ -136,12 +136,12 @@
         <value lang="de-ch">Informiert</value>
         <value lang="fr-ch">Informé</value>
         <value lang="it-ch">Informati</value>
-        <value lang="fr-fr">Informateur </value>
+        <value lang="fr-fr">Informateur</value>
     </translation>
     <translation key="Participant">
         <comment>Label: Participant</comment>
         <value lang="en-us">Participant</value>
-        <value lang="fr-fr">Participant </value>
+        <value lang="fr-fr">Participant</value>
     </translation>
     <translation key="Custodian_Organization">
         <comment>Label: Custodian Organization</comment>
@@ -150,38 +150,38 @@
         <value lang="fr-ch">Organisme de gestion</value>
         <value lang="it-ch">Organismo di gestione</value>
         <value lang="nl-nl">Beherende organisatie</value>
-        <value lang="fr-fr">Organisation chargée de la conservation du document </value>
+        <value lang="fr-fr">Organisation chargée de la conservation du document</value>
     </translation>
     <translation key="performer">
         <comment>Label: Performer</comment>
         <value lang="en-us">Performer</value>
         <value lang="de-ch">Heilberufler</value>
         <value lang="nl-nl">Zorgverlener</value>
-        <value lang="fr-fr">Exécutant </value>
+        <value lang="fr-fr">Exécutant</value>
     </translation>
     <translation key="responsibleParty">
         <comment>Label: responsibleParty</comment>
         <value lang="en-us">Responsible Party</value>
         <value lang="nl-nl">Verantwoordelijke</value>
-        <value lang="fr-fr">Responsable de la prise en charge </value>
+        <value lang="fr-fr">Responsable de la prise en charge</value>
     </translation>
     <translation key="encounterParticipant">
         <comment>Label: encounterParticipant</comment>
         <value lang="en-us">Encounter Participant</value>
         <value lang="nl-nl">Deelnemer contact</value>
-        <value lang="fr-fr">Participant à la prise en charge </value>
+        <value lang="fr-fr">Participant à la prise en charge</value>
     </translation>
     <translation key="location">
         <comment>Label: location</comment>
         <value lang="en-us">Location</value>
         <value lang="nl-nl">Lokatie</value>
-        <value lang="fr-fr">Lieu </value>
+        <value lang="fr-fr">Lieu</value>
     </translation>
     <translation key="subject">
         <comment>Label: subject</comment>
         <value lang="en-us">Subject</value>
         <value lang="nl-nl">Onderwerp</value>
-        <value lang="fr-fr">Sujet </value>
+        <value lang="fr-fr">Sujet</value>
     </translation>
     <!-- End: Header/Body Participations -->
     <!-- Start: Common Sub Classes of Participations -->
@@ -189,7 +189,7 @@
         <comment>Label: OrganizationPartOf</comment>
         <value lang="en-us">Organization Part Of</value>
         <value lang="nl-nl">Organisatie deel van</value>
-        <value lang="fr-fr">Organisation </value>
+        <value lang="fr-fr">Organisation</value>
     </translation>
     <translation key="organization">
         <comment>Label: Organization</comment>
@@ -201,25 +201,25 @@
         <comment>Label: Person</comment>
         <value lang="en-us">Person</value>
         <value lang="nl-nl">Persoon</value>
-        <value lang="fr-fr">Personne </value>
+        <value lang="fr-fr">Personne</value>
     </translation>
     <translation key="authoringDevice">
         <comment>Label: AuthoringDevice</comment>
         <value lang="en-us">Device</value>
         <value lang="nl-nl">Apparaat</value>
-        <value lang="fr-fr">Dispositif </value>
+        <value lang="fr-fr">Dispositif</value>
     </translation>
     <translation key="place">
         <comment>Label: Place</comment>
         <value lang="en-us">Place</value>
         <value lang="nl-nl">Plaats</value>
-        <value lang="fr-fr">Place </value>
+        <value lang="fr-fr">Place</value>
     </translation>
     <translation key="healthCareFacility">
         <comment>Label: HealthCareFacility</comment>
         <value lang="en-us">Health Care Facility</value>
         <value lang="nl-nl">Zorginstelling</value>
-        <value lang="fr-fr">Structure de santé </value>
+        <value lang="fr-fr">Structure de santé</value>
     </translation>
     <!-- End: Common Sub Classes of Participations -->
     <!-- Start: Patient Specific Stuff -->
@@ -228,7 +228,7 @@
         <value lang="en-us">MRN</value>
         <value lang="de-ch">PID</value>
         <value lang="nl-nl">PID</value>
-        <value lang="fr-fr">Id. patient </value>
+        <value lang="fr-fr">Id. patient</value>
     </translation>
     <translation key="patientIdLong">
         <comment>Label: Patient-ID long</comment>
@@ -237,7 +237,7 @@
         <value lang="fr-ch">ID patient</value>
         <value lang="it-ch">ID paziente</value>
         <value lang="nl-nl">Patiëntnummer</value>
-        <value lang="fr-fr">Id. patient </value>
+        <value lang="fr-fr">Id. patient</value>
     </translation>
     <translation key="patientIdsLong">
         <comment>Label: Patient-IDs long</comment>
@@ -246,7 +246,7 @@
         <value lang="fr-ch">IDs patient</value>
         <value lang="it-ch">ID paziente</value>
         <value lang="nl-nl">Patiëntnummers</value>
-        <value lang="fr-fr">Id. patient </value>
+        <value lang="fr-fr">Id. patient</value>
     </translation>
     <translation key="birthPlace">
         <comment>Label: Birthplace long</comment>
@@ -254,7 +254,7 @@
         <value lang="de-ch">Geburtsplatz</value>
         <value lang="fr-ch">Place de naissance</value>
         <value lang="nl-nl">Geboorteplaats</value>
-        <value lang="fr-fr">Lieu de naissance </value>
+        <value lang="fr-fr">Lieu de naissance</value>
     </translation>
     <translation key="birthTimeLong">
         <comment>Label: Birthdate long</comment>
@@ -263,7 +263,7 @@
         <value lang="fr-ch">Date de naissance</value>
         <value lang="it-ch">Data di nascita</value>
         <value lang="nl-nl">Geboortedatum</value>
-        <value lang="fr-fr">Date de naissance </value>
+        <value lang="fr-fr">Date de naissance</value>
     </translation>
     <translation key="birthTimeLongDeceased">
         <comment>Label: Birthdate long and deceased</comment>
@@ -272,7 +272,7 @@
         <value lang="fr-ch">Date de naissance/décédé</value>
         <value lang="it-ch">Data di nascita/defunto</value>
         <value lang="nl-nl">Geboren/overleden</value>
-        <value lang="fr-fr">Date de naissance/décédé </value>
+        <value lang="fr-fr">Date de naissance/décédé</value>
     </translation>
     <translation key="Deceased">
         <comment>Label: Deceased</comment>
@@ -281,7 +281,7 @@
         <value lang="fr-ch">Décédé</value>
         <value lang="it-ch">Defunto</value>
         <value lang="nl-nl">Overleden</value>
-        <value lang="fr-fr">Décédé </value>
+        <value lang="fr-fr">Décédé</value>
     </translation>
     <translation key="date_unknown">
         <comment>Label: date_unknown - used for saying you know patient has died, but unknown when</comment>
@@ -347,7 +347,7 @@
         <value lang="en-us">Gender</value>
         <value lang="de-ch">Geschlecht</value>
         <value lang="nl-nl">Geslacht</value>
-        <value lang="fr-fr">Sexe </value>
+        <value lang="fr-fr">Sexe</value>
     </translation>
     <translation key="maritalStatusCode">
         <comment>Label: MaritalStatusCode</comment>
@@ -365,7 +365,7 @@
         <comment>Label: preferredLanguage</comment>
         <value lang="en-us">preferred</value>
         <value lang="nl-nl">voorkeur</value>
-        <value lang="fr-fr">Langue préférée</value>
+        <value lang="fr-fr">langue préférée</value>
     </translation>
     <translation key="Ethnicity">
         <comment>Label: Ethnicity</comment>
@@ -546,19 +546,19 @@
         <comment>Label: ID</comment>
         <value lang="en-us">ID</value>
         <value lang="nl-nl">Id</value>
-        <value lang="fr-fr">Id </value>
+        <value lang="fr-fr">Id</value>
     </translation>
     <translation key="setId">
         <comment>Label: setId</comment>
         <value lang="en-us">Set‑ID</value>
         <value lang="nl-nl">Set‑Id</value>
-        <value lang="fr-fr">Lot </value>
+        <value lang="fr-fr">Lot</value>
     </translation>
     <translation key="versionNumber">
         <comment>Label: versionNumber</comment>
         <value lang="en-us">Version</value>
         <value lang="nl-nl">Versie</value>
-        <value lang="fr-fr">Version </value>
+        <value lang="fr-fr">Version</value>
     </translation>
     <translation key="code">
         <comment>Label: Code</comment>
@@ -568,7 +568,7 @@
         <comment>Label: Type</comment>
         <value lang="en-us">Type</value>
         <value lang="de-ch">Typ</value>
-        <value lang="fr-fr">Type </value>
+        <value lang="fr-fr">Type</value>
     </translation>
     <translation key="title">
         <comment>Label: Title</comment>
@@ -580,7 +580,7 @@
         <comment>Label: effectiveTime</comment>
         <value lang="en-us">Date/Time</value>
         <value lang="nl-nl">Datum/tijd</value>
-        <value lang="fr-fr">Date/Heure </value>
+        <value lang="fr-fr">Date/Heure</value>
     </translation>
     <translation key="versionCode">
         <comment>Label: versionCode</comment>
@@ -778,7 +778,7 @@
         <comment>Label: address not available</comment>
         <value lang="en-us">address not available</value>
         <value lang="nl-nl">adres niet beschikbaar</value>
-        <value lang="fr-fr">Adresse indisponible</value>
+        <value lang="fr-fr">adresse indisponible</value>
     </translation>
     <translation key="telecom">
         <comment>Label: telecom</comment>
@@ -789,7 +789,7 @@
         <comment>Label: telecom information not available</comment>
         <value lang="en-us">telecom information not available</value>
         <value lang="nl-nl">telecominformatie niet beschikbaar</value>
-        <value lang="fr-fr">Telecom indisponible</value>
+        <value lang="fr-fr">telecom indisponible</value>
     </translation>
     <translation key="name">
         <comment>Label: name</comment>
@@ -922,7 +922,7 @@
         <comment>Label: Authored on</comment>
         <value lang="en-us">Authored On</value>
         <value lang="nl-nl">Gemaakt op</value>
-        <value lang="fr-fr">Créé le </value>
+        <value lang="fr-fr">Créé le</value>
     </translation>
     <translation key="Authored">
         <comment>Label: Authored</comment>
@@ -1587,19 +1587,19 @@
         <comment>Label: ActCode: ActEncounterCode: Ambulatory</comment>
         <value lang="en-us">ambulatory</value>
         <value lang="nl-nl">ambulant</value>
-        <value lang="fr-fr">Ambulatoire</value>
+        <value lang="fr-fr">ambulatoire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-EMER">
         <comment>Label: ActCode: ActEncounterCode: Emergency</comment>
         <value lang="en-us">emergency</value>
         <value lang="nl-nl">noodgeval</value>
-        <value lang="fr-fr">Urgence</value>
+        <value lang="fr-fr">urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-FLD">
         <comment>Label: ActCode: ActEncounterCode: Field</comment>
         <value lang="en-us">field</value>
         <value lang="nl-nl">buiten</value>
-        <value lang="fr-fr">Sur le terrain (hors structure de soins et domicile du patient)</value>
+        <value lang="fr-fr">sur le terrain (hors structure de soins et domicile du patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-HH">
         <comment>Label: ActCode: ActEncounterCode: Home Health</comment>
@@ -1611,7 +1611,7 @@
         <comment>Label: ActCode: ActEncounterCode: Inpatient</comment>
         <value lang="en-us">inpatient</value>
         <value lang="nl-nl">klinisch</value>
-        <value lang="fr-fr">Hospitalisation</value>
+        <value lang="fr-fr">hospitalisation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-ACUTE">
         <comment>Label: ActCode: ActEncounterCode: Acute</comment>
@@ -1623,19 +1623,19 @@
         <comment>Label: ActCode: ActEncounterCode: Inpatient non-acute</comment>
         <value lang="en-us">inpatient non-acute</value>
         <value lang="nl-nl">klinisch niet-acuut</value>
-        <value lang="fr-fr">Hospitalisation non aigue</value>
+        <value lang="fr-fr">hospitalisation non aigue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-SS">
         <comment>Label: ActCode: ActEncounterCode: Short stay</comment>
         <value lang="en-us">short stay</value>
         <value lang="nl-nl">dagbehandeling</value>
-        <value lang="fr-fr">Court séjour</value>
+        <value lang="fr-fr">court séjour</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-VR">
         <comment>Label: ActCode: ActEncounterCode: Virtual</comment>
         <value lang="en-us">virtual</value>
         <value lang="nl-nl">virtueel</value>
-        <value lang="fr-fr">Virtuel</value>
+        <value lang="fr-fr">virtuel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACT">
         <comment>Label: ActClass act</comment>
@@ -1974,12 +1974,12 @@
         <comment>Label: ActClass reverse trendelenburg</comment>
         <value lang="en-us">reverse trendelenburg</value>
         <value lang="nl-nl">omgekeerde trendelenburg</value>
-        <value lang="fr-fr">Trendelenburg inversé</value>
+        <value lang="fr-fr">trendelenburg inversé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TRD">
         <comment>Label: ActClass trendelenburg</comment>
         <value lang="en-us">trendelenburg</value>
-        <value lang="fr-fr">Trendelenburg</value>
+        <value lang="fr-fr">trendelenburg</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PCPR">
         <comment>Label: ActClass care provision</comment>
@@ -2506,7 +2506,7 @@
         <comment>Label: ParticipationFunction caregiver information receiver</comment>
         <value lang="en-us">caregiver information receiver</value>
         <value lang="nl-nl">zorgverlener informatieontvanger</value>
-        <value lang="fr-fr">Destinataire d'informations sur le prestataire de soins</value>
+        <value lang="fr-fr">destinataire d'informations sur le prestataire de soins</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1002-APND">
         <comment>Label: Act Relationship Type APND</comment>
@@ -2646,12 +2646,12 @@
         <comment>Label: ParticipationFunction admitting physician</comment>
         <value lang="en-us">admitting physician</value>
         <value lang="nl-nl">opnamearts</value>
-        <value lang="fr-fr">Responsable de l'admission</value>
+        <value lang="fr-fr">responsable de l'admission</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ANEST">
         <comment>Label: ParticipationFunction anesthesist</comment>
         <value lang="en-us">anesthesist</value>
-        <value lang="fr-fr">Anesthésiste</value>
+        <value lang="fr-fr">anesthésiste</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ANRS">
         <comment>Label: ParticipationFunction anesthesia nurse</comment>
@@ -2663,13 +2663,13 @@
         <comment>Label: ParticipationFunction attending physician</comment>
         <value lang="en-us">attending physician</value>
         <value lang="nl-nl">behandelend arts</value>
-        <value lang="fr-fr">Référent - Responsable du patient dans la structure de soins</value>
+        <value lang="fr-fr">référent - responsable du patient dans la structure de soins</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-DISPHYS">
         <comment>Label: ParticipationFunction discharging physician</comment>
         <value lang="en-us">discharging physician</value>
         <value lang="nl-nl">ontslagarts</value>
-        <value lang="fr-fr">Responsable de la sortie</value>
+        <value lang="fr-fr">responsable de la sortie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-FASST">
         <comment>Label: ParticipationFunction first assistant surgeon</comment>
@@ -2693,7 +2693,7 @@
         <comment>Label: ParticipationFunction primary care physician</comment>
         <value lang="en-us">primary care physician</value>
         <value lang="nl-nl">eerstelijns arts</value>
-        <value lang="fr-fr">Médecin traitant</value>
+        <value lang="fr-fr">médecin traitant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-PRISURG">
         <comment>Label: ParticipationFunction primary surgeon</comment>
@@ -2749,53 +2749,53 @@
         <comment>Label: ParticipationType admitter</comment>
         <value lang="en-us">admitter</value>
         <value lang="nl-nl">opgenomen door</value>
-        <value lang="fr-fr">Responsable de l'admission</value>
+        <value lang="fr-fr">responsable de l'admission</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ATND">
         <comment>Label: ParticipationType attender</comment>
         <value lang="en-us">attender</value>
         <value lang="nl-nl">behandeld door</value>
-        <value lang="fr-fr">Superviseur</value>
+        <value lang="fr-fr">superviseur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CALLBCK">
         <comment>Label: ParticipationType callback contact</comment>
         <value lang="en-us">callback contact</value>
         <value lang="nl-nl">contactpersoon</value>
-        <value lang="fr-fr">Contact à rappeler</value>
+        <value lang="fr-fr">contact à rappeler</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CON">
         <comment>Label: ParticipationType consultant</comment>
         <value lang="en-us">consultant</value>
-        <value lang="fr-fr">Consultant</value>
+        <value lang="fr-fr">consultant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIS">
         <comment>Label: ParticipationType discharger</comment>
         <value lang="en-us">discharger</value>
         <value lang="nl-nl">ontslagen door</value>
-        <value lang="fr-fr">Responsable de la sortie</value>
+        <value lang="fr-fr">responsable de la sortie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ESC">
         <comment>Label: ParticipationType escort</comment>
         <value lang="en-us">escort</value>
         <value lang="nl-nl">begeleider</value>
-        <value lang="fr-fr">Accompagnateur</value>
+        <value lang="fr-fr">accompagnateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-REF">
         <comment>Label: ParticipationType referrer</comment>
         <value lang="en-us">referrer</value>
         <value lang="nl-nl">verwijzer</value>
-        <value lang="fr-fr">Référent / Prescripteur</value>
+        <value lang="fr-fr">référent / prescripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-AUT">
         <comment>Label: ParticipationType author (originator)</comment>
         <value lang="en-us">author (originator)</value>
         <value lang="nl-nl">auteur (oorspronkelijk)</value>
-        <value lang="fr-fr">Auteur</value>
+        <value lang="fr-fr">auteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-INF">
         <comment>Label: ParticipationType informant</comment>
         <value lang="en-us">informant</value>
-        <value lang="fr-fr">Informateur</value>
+        <value lang="fr-fr">informateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-TRANS">
         <comment>Label: ParticipationType Transcriber</comment>
@@ -2807,59 +2807,59 @@
         <comment>Label: ParticipationType data entry person</comment>
         <value lang="en-us">data entry person</value>
         <value lang="nl-nl">ingevoerd door</value>
-        <value lang="fr-fr">Opérateur de saisie</value>
+        <value lang="fr-fr">opérateur de saisie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-WIT">
         <comment>Label: ParticipationType witness</comment>
         <value lang="en-us">witness</value>
         <value lang="nl-nl">getuige</value>
-        <value lang="fr-fr">Témoin</value>
+        <value lang="fr-fr">témoin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CST">
         <comment>Label: ParticipationType custodian</comment>
         <value lang="en-us">custodian</value>
         <value lang="nl-nl">beheerder</value>
-        <value lang="fr-fr">Responsable de l'information</value>
+        <value lang="fr-fr">responsable de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIR">
         <comment>Label: ParticipationType direct target</comment>
         <value lang="en-us">direct target</value>
         <value lang="nl-nl">direct doel</value>
-        <value lang="fr-fr">Participant direct</value>
+        <value lang="fr-fr">participant direct</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-BBY">
         <comment>Label: ParticipationType baby</comment>
         <value lang="en-us">baby</value>
-        <value lang="fr-fr">Nouveau né</value>
+        <value lang="fr-fr">nouveau né</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CSM">
         <comment>Label: ParticipationType consumable</comment>
         <value lang="en-us">consumable</value>
         <value lang="nl-nl">eet- of drinkbaar</value>
-        <value lang="fr-fr">Consommable</value>
+        <value lang="fr-fr">consommable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DEV">
         <comment>Label: ParticipationType device</comment>
         <value lang="en-us">device</value>
         <value lang="nl-nl">apparaat</value>
-        <value lang="fr-fr">Dispositif automatique</value>
+        <value lang="fr-fr">dispositif automatique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-NRD">
         <comment>Label: ParticipationType non-reuseable device</comment>
         <value lang="en-us">non-reuseable device</value>
         <value lang="nl-nl">niet-herbruikbaar apparaat</value>
-        <value lang="fr-fr">Dispositif non réutilisable</value>
+        <value lang="fr-fr">dispositif non réutilisable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RDV">
         <comment>Label: ParticipationType reusable device</comment>
         <value lang="en-us">reusable device</value>
         <value lang="nl-nl">herbruikbaar apparaat</value>
-        <value lang="fr-fr">Dispositif réutilisable</value>
+        <value lang="fr-fr">dispositif réutilisable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DON">
         <comment>Label: ParticipationType donor</comment>
         <value lang="en-us">donor</value>
-        <value lang="fr-fr">Donneur</value>
+        <value lang="fr-fr">donneur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-EXPAGNT">
         <comment>Label: ParticipationType ExposureAgent</comment>
@@ -2884,84 +2884,84 @@
     <translation key="2.16.840.1.113883.5.90-PRD">
         <comment>Label: ParticipationType product</comment>
         <value lang="en-us">product</value>
-        <value lang="fr-fr">Produit</value>
+        <value lang="fr-fr">produit</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SBJ">
         <comment>Label: ParticipationType subject</comment>
         <value lang="en-us">subject</value>
-        <value lang="fr-fr">Sujet</value>
+        <value lang="fr-fr">sujet</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SPC">
         <comment>Label: ParticipationType specimen</comment>
         <value lang="en-us">specimen</value>
         <value lang="nl-nl">monster</value>
-        <value lang="fr-fr">Echantillon</value>
+        <value lang="fr-fr">echantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-IND">
         <comment>Label: ParticipationType indirect target</comment>
         <value lang="en-us">indirect target</value>
         <value lang="nl-nl">indirect doel</value>
-        <value lang="fr-fr">Cible indirecte</value>
+        <value lang="fr-fr">cible indirecte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-BEN">
         <comment>Label: ParticipationType beneficiary</comment>
         <value lang="en-us">beneficiary</value>
         <value lang="nl-nl">begunstigde</value>
-        <value lang="fr-fr">Bénéficiaire</value>
+        <value lang="fr-fr">bénéficiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CAGNT">
         <comment>Label: ParticipationType causative agent</comment>
         <value lang="en-us">causative agent</value>
         <value lang="nl-nl">veroorzakende agent</value>
-        <value lang="fr-fr">Agent causal</value>
+        <value lang="fr-fr">agent causal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-COV">
         <comment>Label: ParticipationType coverage target</comment>
         <value lang="en-us">coverage target</value>
         <value lang="nl-nl">verzekerde</value>
-        <value lang="fr-fr">Partie couverte (titulaire ou bénéficiaire)</value>
+        <value lang="fr-fr">partie couverte (titulaire ou bénéficiaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-GUAR">
         <comment>Label: ParticipationType guarantor party</comment>
         <value lang="en-us">guarantor party</value>
         <value lang="nl-nl">garantstaande partij</value>
-        <value lang="fr-fr">Garant</value>
+        <value lang="fr-fr">garant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-HLD">
         <comment>Label: ParticipationType holder</comment>
         <value lang="en-us">holder</value>
         <value lang="nl-nl">verzekeringshouder</value>
-        <value lang="fr-fr">Souscripteur</value>
+        <value lang="fr-fr">souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RCT">
         <comment>Label: ParticipationType record target</comment>
         <value lang="en-us">record target</value>
         <value lang="nl-nl">patiënt</value>
-        <value lang="fr-fr">Patient</value>
+        <value lang="fr-fr">patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RCV">
         <comment>Label: ParticipationType receiver</comment>
         <value lang="en-us">receiver</value>
         <value lang="nl-nl">ontvanger</value>
-        <value lang="fr-fr">Récepteur</value>
+        <value lang="fr-fr">récepteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-IRCP">
         <comment>Label: ParticipationType information recipient</comment>
         <value lang="en-us">information recipient</value>
         <value lang="nl-nl">informatieontvanger</value>
-        <value lang="fr-fr">Destinataire de l'information</value>
+        <value lang="fr-fr">destinataire de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-NOT">
         <comment>Label: ParticipationType ugent notification contact</comment>
         <value lang="en-us">urgent notification contact</value>
         <value lang="nl-nl">contactpersoon bij nood</value>
-        <value lang="fr-fr">Personne à prévenir en cas d'urgence</value>
+        <value lang="fr-fr">personne à prévenir en cas d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PRCP">
         <comment>Label: ParticipationType primary information recipient</comment>
         <value lang="en-us">primary information recipient</value>
         <value lang="nl-nl">bedoelde informatieontvanger</value>
-        <value lang="fr-fr">Destinataire principal de l'information</value>
+        <value lang="fr-fr">destinataire principal de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-REFB">
         <comment>Label: ParticipationType Referred By</comment>
@@ -2979,113 +2979,113 @@
         <comment>Label: ParticipationType tracker</comment>
         <value lang="en-us">tracker</value>
         <value lang="nl-nl">kopie-ontvanger</value>
-        <value lang="fr-fr">Personne recevant une copie de l'information</value>
+        <value lang="fr-fr">personne recevant une copie de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-LOC">
         <comment>Label: ParticipationType location</comment>
         <value lang="en-us">location</value>
         <value lang="nl-nl">lokatie</value>
-        <value lang="fr-fr">Emplacement principal</value>
+        <value lang="fr-fr">emplacement principal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DST">
         <comment>Label: ParticipationType destination</comment>
         <value lang="en-us">destination</value>
         <value lang="nl-nl">bestemming</value>
-        <value lang="fr-fr">Destination</value>
+        <value lang="fr-fr">destination</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ELOC">
         <comment>Label: ParticipationType entry location</comment>
         <value lang="en-us">entry location</value>
         <value lang="nl-nl">invoerlokatie</value>
-        <value lang="fr-fr">Emplacement où les données sont saisies</value>
+        <value lang="fr-fr">emplacement où les données sont saisies</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ORG">
         <comment>Label: ParticipationType origin</comment>
         <value lang="en-us">origin</value>
         <value lang="nl-nl">oorsprong</value>
-        <value lang="fr-fr">Lieu d'origine</value>
+        <value lang="fr-fr">lieu d'origine</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RML">
         <comment>Label: ParticipationType remote</comment>
         <value lang="en-us">remote</value>
         <value lang="nl-nl">extern</value>
-        <value lang="fr-fr">Emplacement distant</value>
+        <value lang="fr-fr">emplacement distant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-VIA">
         <comment>Label: ParticipationType via</comment>
         <value lang="en-us">via</value>
-        <value lang="fr-fr">Emplacement intermédiaire</value>
+        <value lang="fr-fr">emplacement intermédiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PRF">
         <comment>Label: ParticipationType performer</comment>
         <value lang="en-us">performer</value>
         <value lang="nl-nl">uitvoerende</value>
-        <value lang="fr-fr">Exécutant </value>
+        <value lang="fr-fr">exécutant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIST">
         <comment>Label: ParticipationType distributor</comment>
         <value lang="en-us">distributor</value>
         <value lang="nl-nl">distributeur</value>
-        <value lang="fr-fr">Distributeur </value>
+        <value lang="fr-fr">distributeur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PPRF">
         <comment>Label: ParticipationType primary performer</comment>
         <value lang="en-us">primary performer</value>
         <value lang="nl-nl">eerste uitvoerende</value>
-        <value lang="fr-fr">Exécutant principal </value>
+        <value lang="fr-fr">exécutant principal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SPRF">
         <comment>Label: ParticipationType secondary performer</comment>
         <value lang="en-us">secondary performer</value>
         <value lang="nl-nl">tweede uitvoerende</value>
-        <value lang="fr-fr">Exécutant secondaire </value>
+        <value lang="fr-fr">exécutant secondaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RESP">
         <comment>Label: ParticipationType responsible party</comment>
         <value lang="en-us">responsible party</value>
         <value lang="nl-nl">verantwoordelijke partij</value>
-        <value lang="fr-fr">Responsable de l'acte </value>
+        <value lang="fr-fr">responsable de l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-VRF">
         <comment>Label: ParticipationType verifier</comment>
         <value lang="en-us">verifier</value>
         <value lang="nl-nl">toezichthouder</value>
-        <value lang="fr-fr">Vérificateur </value>
+        <value lang="fr-fr">vérificateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-AUTHEN">
         <comment>Label: ParticipationType authenticator</comment>
         <value lang="en-us">authenticator</value>
         <value lang="nl-nl">onderetkenaar</value>
-        <value lang="fr-fr">Valideur des résultats </value>
+        <value lang="fr-fr">valideur des résultats</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-LA">
         <comment>Label: ParticipationType legal authenticator</comment>
         <value lang="en-us">legal authenticator</value>
         <value lang="nl-nl">wettelijke ondertekenaar</value>
-        <value lang="fr-fr">Responsable légal </value>
+        <value lang="fr-fr">responsable légal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CHILD">
         <comment>Label: RoleClass child</comment>
         <value lang="en-us">child</value>
         <value lang="nl-nl">kind</value>
-        <value lang="fr-fr">Enfant</value>
+        <value lang="fr-fr">enfant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRED">
         <comment>Label: RoleClass credentialed entity</comment>
         <value lang="en-us">credentialed entity</value>
         <value lang="nl-nl">bevoegde entiteit</value>
-        <value lang="fr-fr">Entité compétente</value>
+        <value lang="fr-fr">entité compétente</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NURPRAC">
         <comment>Label: RoleClass nurse practitioner</comment>
         <value lang="en-us">nurse practitioner</value>
-        <value lang="fr-fr">Infirmière praticienne</value>
+        <value lang="fr-fr">infirmière praticienne</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NURS">
         <comment>Label: RoleClass nurse</comment>
         <value lang="en-us">nurse</value>
         <value lang="nl-nl">verpleegkundige</value>
-        <value lang="fr-fr">Infirmière</value>
+        <value lang="fr-fr">infirmière</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PA">
         <comment>Label: RoleClass physician assistant</comment>
@@ -3096,13 +3096,13 @@
         <comment>Label: RoleClass physician</comment>
         <value lang="en-us">physician</value>
         <value lang="nl-nl">arts</value>
-        <value lang="fr-fr">Médecin</value>
+        <value lang="fr-fr">médecin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ROL">
         <comment>Label: RoleClass role</comment>
         <value lang="en-us">role</value>
         <value lang="nl-nl">rol</value>
-        <value lang="fr-fr">Rôle</value>
+        <value lang="fr-fr">rôle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-AFFL">
         <comment>Label: RoleClass affiliate</comment>
@@ -3112,117 +3112,117 @@
     <translation key="2.16.840.1.113883.5.110-AGNT">
         <comment>Label: RoleClass agent</comment>
         <value lang="en-us">agent</value>
-        <value lang="fr-fr">Agent</value>
+        <value lang="fr-fr">agent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ASSIGNED">
         <comment>Label: RoleClass assigned entity</comment>
         <value lang="en-us">assigned entity</value>
         <value lang="nl-nl">benoemde entiteit</value>
-        <value lang="fr-fr">Entité nommée</value>
+        <value lang="fr-fr">entité nommée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-COMPAR">
         <comment>Label: RoleClass commissioning party</comment>
         <value lang="en-us">commissioning party</value>
-        <value lang="fr-fr">Commissionnaire</value>
+        <value lang="fr-fr">commissionnaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SGNOFF">
         <comment>Label: RoleClass signing authority or officer</comment>
         <value lang="en-us">signing authority or officer</value>
         <value lang="nl-nl">ondertekenende autoriteit of functionaris</value>
-        <value lang="fr-fr">Autorité ou officier signataire</value>
+        <value lang="fr-fr">autorité ou officier signataire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CON">
         <comment>Label: RoleClass contact</comment>
         <value lang="en-us">contact</value>
-        <value lang="fr-fr">Contact</value>
+        <value lang="fr-fr">contact</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ECON">
         <comment>Label: RoleClass emergency contact</comment>
         <value lang="en-us">emergency contact</value>
         <value lang="nl-nl">noodcontact</value>
-        <value lang="fr-fr">Contact en cas d'urgence</value>
+        <value lang="fr-fr">contact en cas d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NOK">
         <comment>Label: RoleClass next of kin</comment>
         <value lang="en-us">next of kin</value>
         <value lang="nl-nl">familie</value>
-        <value lang="fr-fr">Plus proche parent</value>
+        <value lang="fr-fr">plus proche parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-GUARD">
         <comment>Label: RoleClass guardian</comment>
         <value lang="en-us">guardian</value>
         <value lang="nl-nl">voogd</value>
-        <value lang="fr-fr">Représentant du patient</value>
+        <value lang="fr-fr">représentant du patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CIT">
         <comment>Label: RoleClass citizen</comment>
         <value lang="en-us">citizen</value>
         <value lang="nl-nl">burger</value>
-        <value lang="fr-fr">Citoyen</value>
+        <value lang="fr-fr">citoyen</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-COVPTY">
         <comment>Label: RoleClass covered party</comment>
         <value lang="en-us">covered party</value>
         <value lang="nl-nl">verzekerde</value>
-        <value lang="fr-fr">Partie couverte</value>
+        <value lang="fr-fr">partie couverte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CLAIM">
         <comment>Label: RoleClass claimant</comment>
         <value lang="en-us">claimant</value>
-        <value lang="fr-fr">Demandeur</value>
+        <value lang="fr-fr">demandeur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NAMED">
         <comment>Label: RoleClass named insured</comment>
         <value lang="en-us">named insured</value>
         <value lang="nl-nl">benoemde verzekerde</value>
-        <value lang="fr-fr">Assuré désigné</value>
+        <value lang="fr-fr">assuré désigné</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DEPEN">
         <comment>Label: RoleClass dependent</comment>
         <value lang="en-us">dependent</value>
         <value lang="nl-nl">afhankelijke</value>
-        <value lang="fr-fr">Dépendant</value>
+        <value lang="fr-fr">dépendant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-INDIV">
         <comment>Label: RoleClass individual</comment>
         <value lang="en-us">individual</value>
         <value lang="nl-nl">individu</value>
-        <value lang="fr-fr">Individuel</value>
+        <value lang="fr-fr">individuel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SUBSCR">
         <comment>Label: RoleClass subscriber</comment>
         <value lang="en-us">subscriber</value>
         <value lang="nl-nl">abonnee</value>
-        <value lang="fr-fr">Souscripteur</value>
+        <value lang="fr-fr">souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PROG">
         <comment>Label: RoleClass program eligible</comment>
         <value lang="en-us">program eligible</value>
-        <value lang="fr-fr">Eligible au programme</value>
+        <value lang="fr-fr">eligible au programme</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRINV">
         <comment>Label: RoleClass clinical research investigator</comment>
         <value lang="en-us">clinical research investigator</value>
         <value lang="nl-nl">klinisch onderzoeker</value>
-        <value lang="fr-fr">Chercheur en recherche clinique</value>
+        <value lang="fr-fr">chercheur en recherche clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRSPNSR">
         <comment>Label: RoleClass clinical research sponsor</comment>
         <value lang="en-us">clinical research sponsor</value>
         <value lang="nl-nl">klinisch onderzoek sponsor</value>
-        <value lang="fr-fr">Sponsor en recherche clinique</value>
+        <value lang="fr-fr">sponsor en recherche clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EMP">
         <comment>Label: RoleClass employee</comment>
         <value lang="en-us">employee</value>
         <value lang="nl-nl">werknemer</value>
-        <value lang="fr-fr">Employé</value>
+        <value lang="fr-fr">employé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MIL">
         <comment>Label: RoleClass military person</comment>
         <value lang="en-us">military person</value>
         <value lang="nl-nl">militair</value>
-        <value lang="fr-fr">Militaire</value>
+        <value lang="fr-fr">militaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-INVSBJ">
         <comment>Label: RoleClass Investigation Subject</comment>
@@ -3239,88 +3239,88 @@
     <translation key="2.16.840.1.113883.5.110-RESBJ">
         <comment>Label: RoleClass research subject</comment>
         <value lang="en-us">research subject</value>
-        <value lang="fr-fr">Sujet de recherche</value>
+        <value lang="fr-fr">sujet de recherche</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-LIC">
         <comment>Label: RoleClass licensed entity</comment>
         <value lang="en-us">licensed entity</value>
         <value lang="nl-nl">gelicenseerde entiteit</value>
-        <value lang="fr-fr">Entité agréée</value>
+        <value lang="fr-fr">entité agréée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NOT">
         <comment>Label: RoleClass notary public</comment>
         <value lang="en-us">notary public</value>
-        <value lang="fr-fr">Notaire</value>
+        <value lang="fr-fr">notaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PROV">
         <comment>Label: RoleClass healthcare provider</comment>
         <value lang="en-us">healthcare provider</value>
         <value lang="nl-nl">zorgaanbieder</value>
-        <value lang="fr-fr">Profession </value>
+        <value lang="fr-fr">profession</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAT">
         <comment>Label: RoleClass patient</comment>
         <value lang="en-us">patient</value>
         <value lang="nl-nl">patiënt</value>
-        <value lang="fr-fr">Patient</value>
+        <value lang="fr-fr">patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAYEE">
         <comment>Label: RoleClass payee</comment>
         <value lang="en-us">payee</value>
         <value lang="nl-nl">begunstigde</value>
-        <value lang="fr-fr">Bénéficiaire</value>
+        <value lang="fr-fr">bénéficiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAYOR">
         <comment>Label: RoleClass invoice payor</comment>
         <value lang="en-us">invoice payor</value>
         <value lang="nl-nl">rekening betaler</value>
-        <value lang="fr-fr">Payeur de facture</value>
+        <value lang="fr-fr">payeur de facture</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-POLHOLD">
         <comment>Label: RoleClass policy holder</comment>
         <value lang="en-us">policy holder</value>
         <value lang="nl-nl">polishouder</value>
-        <value lang="fr-fr">Titulaire de l'assurance</value>
+        <value lang="fr-fr">titulaire de l'assurance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-QUAL">
         <comment>Label: RoleClass qualified entity</comment>
         <value lang="en-us">qualified entity</value>
         <value lang="nl-nl">gekwalificeerde entiteit</value>
-        <value lang="fr-fr">Entité qualifiée</value>
+        <value lang="fr-fr">entité qualifiée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SPNSR">
         <comment>Label: RoleClass coverage sponsor</comment>
         <value lang="en-us">coverage sponsor</value>
         <value lang="nl-nl">verzerkering sponsor</value>
-        <value lang="fr-fr">Promoteur d'assurance</value>
+        <value lang="fr-fr">promoteur d'assurance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-STD">
         <comment>Label: RoleClass student</comment>
         <value lang="en-us">student</value>
-        <value lang="fr-fr">Etudiant</value>
+        <value lang="fr-fr">etudiant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-UNDWRT">
         <comment>Label: RoleClass underwriter</comment>
         <value lang="en-us">underwriter</value>
-        <value lang="fr-fr">Souscripteur</value>
+        <value lang="fr-fr">souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CAREGIVER">
         <comment>Label: RoleClass caregiver</comment>
         <value lang="en-us">caregiver</value>
         <value lang="nl-nl">zorgverlener</value>
-        <value lang="fr-fr">Soignant</value>
+        <value lang="fr-fr">soignant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PRS">
         <comment>Label: RoleClass personal relationship</comment>
         <value lang="en-us">personal relationship</value>
         <value lang="nl-nl">persoonlijke relatie</value>
-        <value lang="fr-fr">Relation personnelle</value>
+        <value lang="fr-fr">relation personnelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACCESS">
         <comment>Label: RoleClass access</comment>
         <value lang="en-us">access</value>
         <value lang="nl-nl">toegang</value>
-        <value lang="fr-fr">Accès</value>
+        <value lang="fr-fr">accès</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ADMM">
         <comment>Label: RoleClass Administerable Material</comment>
@@ -3332,119 +3332,119 @@
         <comment>Label: RoleClass birthplace</comment>
         <value lang="en-us">birthplace</value>
         <value lang="nl-nl">geboorteplaats</value>
-        <value lang="fr-fr">Lieu de naissance</value>
+        <value lang="fr-fr">lieu de naissance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DEATHPLC">
         <comment>Label: RoleClass place of death</comment>
         <value lang="en-us">place of death</value>
         <value lang="nl-nl">plaats overlijden</value>
-        <value lang="fr-fr">Lieu du décès</value>
+        <value lang="fr-fr">lieu du décès</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DST">
         <comment>Label: RoleClass distributed material</comment>
         <value lang="en-us">distributed material</value>
         <value lang="nl-nl">gedistribueerd materiaal</value>
-        <value lang="fr-fr">Matériel distribué</value>
+        <value lang="fr-fr">matériel distribué</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-RET">
         <comment>Label: RoleClass retailed material</comment>
         <value lang="en-us">retailed material</value>
         <value lang="nl-nl">verkocht materiaal</value>
-        <value lang="fr-fr">Matériel vendu</value>
+        <value lang="fr-fr">matériel vendu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EXPR">
         <comment>Label: RoleClass exposed entity</comment>
         <value lang="en-us">exposed entity</value>
         <value lang="nl-nl">blootgestelde entiteit</value>
-        <value lang="fr-fr">Entité exposée</value>
+        <value lang="fr-fr">entité exposée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-HLD">
         <comment>Label: RoleClass held entity</comment>
         <value lang="en-us">held entity</value>
-        <value lang="fr-fr">Entité détenue</value>
+        <value lang="fr-fr">entité détenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-HLTHCHRT">
         <comment>Label: RoleClass health chart</comment>
         <value lang="en-us">health chart</value>
-        <value lang="fr-fr">Fiche de santé</value>
+        <value lang="fr-fr">fiche de santé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-IDENT">
         <comment>Label: RoleClass identified entity</comment>
         <value lang="en-us">identified entity</value>
         <value lang="nl-nl">geïdentificeerde entiteit</value>
-        <value lang="fr-fr">Entité identifiée</value>
+        <value lang="fr-fr">entité identifiée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MANU">
         <comment>Label: RoleClass manufactured product</comment>
         <value lang="en-us">manufactured product</value>
         <value lang="nl-nl">geproduceerd product</value>
-        <value lang="fr-fr">Produit manufacturé</value>
+        <value lang="fr-fr">produit manufacturé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-THER">
         <comment>Label: RoleClass therapeutic agent</comment>
         <value lang="en-us">therapeutic agent</value>
         <value lang="nl-nl">therapeutisch agent</value>
-        <value lang="fr-fr">Agent thérapeutique</value>
+        <value lang="fr-fr">agent thérapeutique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MNT">
         <comment>Label: RoleClass maintained entity</comment>
         <value lang="en-us">maintained entity</value>
         <value lang="nl-nl">beheerde entiteit</value>
-        <value lang="fr-fr">Entité maintenue</value>
+        <value lang="fr-fr">entité maintenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-OWN">
         <comment>Label: RoleClass owned entity</comment>
         <value lang="en-us">owned entity</value>
         <value lang="nl-nl">bezitte entiteit</value>
-        <value lang="fr-fr">Entité détenue</value>
+        <value lang="fr-fr">entité détenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-RGPR">
         <comment>Label: RoleClass regulated product</comment>
         <value lang="en-us">regulated product</value>
         <value lang="nl-nl">gereguleerd product</value>
-        <value lang="fr-fr">Produit réglementé</value>
+        <value lang="fr-fr">produit réglementé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SDLOC">
         <comment>Label: RoleClass service delivery location</comment>
         <value lang="en-us">service delivery location</value>
         <value lang="nl-nl">zorgverleningslokatie</value>
-        <value lang="fr-fr">Lieu de prestation de services</value>
+        <value lang="fr-fr">lieu de prestation de services</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DSDLOC">
         <comment>Label: RoleClass dedicated service delivery location</comment>
         <value lang="en-us">dedicated service delivery location</value>
         <value lang="nl-nl">lokatie bedoeld voor zorgverlening</value>
-        <value lang="fr-fr">Lieu de prestation de services dédié</value>
+        <value lang="fr-fr">lieu de prestation de services dédié</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ISDLOC">
         <comment>Label: RoleClass incidental service delivery location</comment>
         <value lang="en-us">incidental service delivery location</value>
         <value lang="nl-nl">toevallige zorgverleningslokatie</value>
-        <value lang="fr-fr">Lieu de prestation de services accessoire</value>
+        <value lang="fr-fr">lieu de prestation de services accessoire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-TERR">
         <comment>Label: RoleClass territory of authority</comment>
         <value lang="en-us">territory of authority</value>
         <value lang="nl-nl">autoriteitsregio</value>
-        <value lang="fr-fr">Territoire d'autorité</value>
+        <value lang="fr-fr">territoire d'autorité</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-USED">
         <comment>Label: RoleClass used entity</comment>
         <value lang="en-us">used entity</value>
         <value lang="nl-nl">gebruikte entiteit</value>
-        <value lang="fr-fr">Entité utilisée</value>
+        <value lang="fr-fr">entité utilisée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-WRTE">
         <comment>Label: RoleClass warranted product</comment>
         <value lang="en-us">warranted product</value>
         <value lang="nl-nl">product onder garantie</value>
-        <value lang="fr-fr">Produit garanti</value>
+        <value lang="fr-fr">produit garanti</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EQUIV">
         <comment>Label: RoleClass equivalent entity</comment>
         <value lang="en-us">equivalent entity</value>
         <value lang="nl-nl">equivalente entiteit</value>
-        <value lang="fr-fr">Entité équivalente</value>
+        <value lang="fr-fr">entité équivalente</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SAME">
         <comment>Label: RoleClass same</comment>
@@ -3577,25 +3577,25 @@
         <comment>Label: RoleClass located entity</comment>
         <value lang="en-us">located entity</value>
         <value lang="nl-nl">gelokaliseerde entiteit</value>
-        <value lang="fr-fr">Entité localisée</value>
+        <value lang="fr-fr">entité localisée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-STOR">
         <comment>Label: RoleClass stored entity</comment>
         <value lang="en-us">stored entity</value>
         <value lang="nl-nl">opgeslagen entiteit</value>
-        <value lang="fr-fr">Entité stockée</value>
+        <value lang="fr-fr">entité stockée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MBR">
         <comment>Label: RoleClass member</comment>
         <value lang="en-us">member</value>
         <value lang="nl-nl">lid</value>
-        <value lang="fr-fr">Membre</value>
+        <value lang="fr-fr">membre</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PART">
         <comment>Label: RoleClass part</comment>
         <value lang="en-us">part</value>
         <value lang="nl-nl">deel</value>
-        <value lang="fr-fr">Partie</value>
+        <value lang="fr-fr">partie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTM">
         <comment>Label: RoleClass active moiety</comment>
@@ -3606,18 +3606,18 @@
         <comment>Label: RoleClass specimen</comment>
         <value lang="en-us">specimen</value>
         <value lang="nl-nl">monster</value>
-        <value lang="fr-fr">Echantillon</value>
+        <value lang="fr-fr">echantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ALQT">
         <comment>Label: RoleClass aliquot</comment>
         <value lang="en-us">aliquot</value>
-        <value lang="fr-fr">Aliquote</value>
+        <value lang="fr-fr">aliquote</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ISLT">
         <comment>Label: RoleClass isolate</comment>
         <value lang="en-us">isolate</value>
         <value lang="nl-nl">isolaat</value>
-        <value lang="fr-fr">Isolat</value>
+        <value lang="fr-fr">isolat</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FAMMEMB">
         <comment>Label: RoleCode Family Member</comment>
@@ -3635,55 +3635,55 @@
         <comment>Label: RoleCode adopted child</comment>
         <value lang="en-us">adopted child</value>
         <value lang="nl-nl">geadopteerd kind</value>
-        <value lang="fr-fr">Enfant adopté</value>
+        <value lang="fr-fr">enfant adopté</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUADOPT">
         <comment>Label: RoleCode adopted daughter</comment>
         <value lang="en-us">adopted daughter</value>
         <value lang="nl-nl">geadopteerde dochter</value>
-        <value lang="fr-fr">Fille adoptive</value>
+        <value lang="fr-fr">fille adoptive</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONADOPT">
         <comment>Label: RoleCode adopted son</comment>
         <value lang="en-us">adopted son</value>
         <value lang="nl-nl">geadopteerde zoon</value>
-        <value lang="fr-fr">Fils adoptif</value>
+        <value lang="fr-fr">fils adoptif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHLDFOST">
         <comment>Label: RoleCode foster child</comment>
         <value lang="en-us">foster child</value>
         <value lang="nl-nl">pleegkind</value>
-        <value lang="fr-fr">Enfant placé en famille d'accueil</value>
+        <value lang="fr-fr">enfant placé en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUFOST">
         <comment>Label: RoleCode foster daughter</comment>
         <value lang="en-us">foster daughter</value>
         <value lang="nl-nl">pleegdochter</value>
-        <value lang="fr-fr">Fille placée en famille d'accueil</value>
+        <value lang="fr-fr">fille placée en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONFOST">
         <comment>Label: RoleCode foster son</comment>
         <value lang="en-us">foster son</value>
         <value lang="nl-nl">pleegzoon</value>
-        <value lang="fr-fr">Fils placé en famille d'accueil</value>
+        <value lang="fr-fr">fils placé en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHLDINLAW">
         <comment>Label: RoleCode child in-law</comment>
         <value lang="en-us">child in-law</value>
         <value lang="nl-nl">aangetrouwd kind</value>
-        <value lang="fr-fr">Gendre ou belle-fille</value>
+        <value lang="fr-fr">gendre ou belle-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUINLAW">
         <comment>Label: RoleCode daughter in-law</comment>
         <value lang="en-us">daughter in-law</value>
         <value lang="nl-nl">schoondochter</value>
-        <value lang="fr-fr">Belle-fille</value>
+        <value lang="fr-fr">belle-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONINLAW">
         <comment>Label: RoleCode son in-law</comment>
         <value lang="en-us">son in-law</value>
         <value lang="nl-nl">schoonzoon</value>
-        <value lang="fr-fr">Gendre</value>
+        <value lang="fr-fr">gendre</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUC">
         <comment>Label: RoleCode Daughter</comment>
@@ -3695,55 +3695,55 @@
         <comment>Label: RoleCode natural daughterDaughter </comment>
         <value lang="en-us">natural daughter</value>
         <value lang="nl-nl">natuurlijke dochter</value>
-        <value lang="fr-fr">Fille biologique</value>
+        <value lang="fr-fr">fille biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPDAU">
         <comment>Label: RoleCode stepdaughter</comment>
         <value lang="en-us">stepdaughter</value>
         <value lang="nl-nl">stiefdochter</value>
-        <value lang="fr-fr">Belle-fille - fille du conjoint ou de la conjointe</value>
+        <value lang="fr-fr">belle-fille - fille du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NCHILD">
         <comment>Label: RoleCode natural child</comment>
         <value lang="en-us">natural child</value>
         <value lang="nl-nl">natuurlijk kind</value>
-        <value lang="fr-fr">Enfant biologique</value>
+        <value lang="fr-fr">enfant biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SON">
         <comment>Label: RoleCode natural sonSon </comment>
         <value lang="en-us">natural son</value>
         <value lang="nl-nl">naturlijke zoon</value>
-        <value lang="fr-fr">Fils biologique</value>
+        <value lang="fr-fr">fils biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONC">
         <comment>Label: RoleCode son</comment>
         <value lang="en-us">son</value>
         <value lang="nl-nl">zoon</value>
-        <value lang="fr-fr">Fils</value>
+        <value lang="fr-fr">fils</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPSON">
         <comment>Label: RoleCode stepson</comment>
         <value lang="en-us">stepson</value>
         <value lang="nl-nl">stiefzoon</value>
-        <value lang="fr-fr">Beau-fils - fils du conjoint ou de la conjointe</value>
+        <value lang="fr-fr">beau-fils - fils du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPCHLD">
         <comment>Label: RoleCode step child</comment>
         <value lang="en-us">step child</value>
         <value lang="nl-nl">stiefkind</value>
-        <value lang="fr-fr">Enfant du conjoint ou de la conjointe</value>
+        <value lang="fr-fr">enfant du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-EXT">
         <comment>Label: RoleCode extended family member</comment>
         <value lang="en-us">extended family member</value>
         <value lang="nl-nl">ver familielid</value>
-        <value lang="fr-fr">Autre membre de la famille sans lien génétique direct</value>
+        <value lang="fr-fr">autre membre de la famille sans lien génétique direct</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-AUNT">
         <comment>Label: RoleCode aunt</comment>
         <value lang="en-us">aunt</value>
         <value lang="nl-nl">tante</value>
-        <value lang="fr-fr">Tante</value>
+        <value lang="fr-fr">tante</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MAUNT">
         <comment>Label: RoleCode MaternalAunt</comment>
@@ -3761,7 +3761,7 @@
         <comment>Label: RoleCode cousin</comment>
         <value lang="en-us">cousin</value>
         <value lang="nl-nl">neef/nicht</value>
-        <value lang="fr-fr">Cousin</value>
+        <value lang="fr-fr">cousin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MCOUSN">
         <comment>Label: RoleCode MaternalCousin</comment>
@@ -3779,19 +3779,19 @@
         <comment>Label: RoleCode great grandparent</comment>
         <value lang="en-us">great grandparent</value>
         <value lang="nl-nl">overgrootouder</value>
-        <value lang="fr-fr">Arrière-grand-parent</value>
+        <value lang="fr-fr">arrière-grand-parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GGRFTH">
         <comment>Label: RoleCode great grandfather</comment>
         <value lang="en-us">great grandfather</value>
         <value lang="nl-nl">overgrootvader</value>
-        <value lang="fr-fr">Arrière-grand-père</value>
+        <value lang="fr-fr">arrière-grand-père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GGRMTH">
         <comment>Label: RoleCode great grandmother</comment>
         <value lang="en-us">great grandmother</value>
         <value lang="nl-nl">overgrootmoeder</value>
-        <value lang="fr-fr">Arrière-grand-mère</value>
+        <value lang="fr-fr">arrière-grand-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGGRFTH">
         <comment>Label: RoleCode MaternalGreatgrandfather</comment>
@@ -3833,19 +3833,19 @@
         <comment>Label: RoleCode grandchild</comment>
         <value lang="en-us">grandchild</value>
         <value lang="nl-nl">kleinkind</value>
-        <value lang="fr-fr">Petit-enfant</value>
+        <value lang="fr-fr">petit-enfant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRNDDAU">
         <comment>Label: RoleCode granddaughter</comment>
         <value lang="en-us">granddaughter</value>
         <value lang="nl-nl">kleindochter</value>
-        <value lang="fr-fr">Petite-fille</value>
+        <value lang="fr-fr">petite-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRNDSON">
         <comment>Label: RoleCode grandson</comment>
         <value lang="en-us">grandson</value>
         <value lang="nl-nl">kleinzoon</value>
-        <value lang="fr-fr">Petit-fils</value>
+        <value lang="fr-fr">petit-fils</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRPRN">
         <comment>Label: RoleCode Grandparent</comment>
@@ -3904,19 +3904,19 @@
         <comment>Label: RoleCode niece/nephew</comment>
         <value lang="en-us">niece/nephew</value>
         <value lang="nl-nl">nicht/neef</value>
-        <value lang="fr-fr">Nièce / Neveu</value>
+        <value lang="fr-fr">nièce / neveu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NEPHEW">
         <comment>Label: RoleCode nephew</comment>
         <value lang="en-us">nephew</value>
         <value lang="nl-nl">neef</value>
-        <value lang="fr-fr">Neveu</value>
+        <value lang="fr-fr">neveu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NIECE">
         <comment>Label: RoleCode niece</comment>
         <value lang="en-us">niece</value>
         <value lang="nl-nl">nicht</value>
-        <value lang="fr-fr">Nièce</value>
+        <value lang="fr-fr">nièce</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-UNCLE">
         <comment>Label: RoleCode uncle</comment>
@@ -3957,61 +3957,61 @@
         <comment>Label: RoleCode natural parent</comment>
         <value lang="en-us">natural parent</value>
         <value lang="nl-nl">natuurlijke ouder</value>
-        <value lang="fr-fr">Parent biologique, au sens père ou mère</value>
+        <value lang="fr-fr">parent biologique, au sens père ou mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NFTH">
         <comment>Label: RoleCode natural father</comment>
         <value lang="en-us">natural father</value>
         <value lang="nl-nl">natuurlijke vader</value>
-        <value lang="fr-fr">Père biologique</value>
+        <value lang="fr-fr">père biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NFTHF">
         <comment>Label: RoleCode natural father of fetus</comment>
         <value lang="en-us">natural father of fetus</value>
         <value lang="nl-nl">natuurlijke vader van foetus</value>
-        <value lang="fr-fr">Père biologique du fœtus</value>
+        <value lang="fr-fr">père biologique du fœtus</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NMTH">
         <comment>Label: RoleCode natural mother</comment>
         <value lang="en-us">natural mother</value>
         <value lang="nl-nl">natuurlijke moeder</value>
-        <value lang="fr-fr">Mère biologique</value>
+        <value lang="fr-fr">mère biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PRNINLAW">
         <comment>Label: RoleCode parent in-law</comment>
         <value lang="en-us">parent in-law</value>
         <value lang="nl-nl">schoonouder</value>
-        <value lang="fr-fr">Beau-père ou belle-mère</value>
+        <value lang="fr-fr">beau-père ou belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FTHINLAW">
         <comment>Label: RoleCode father-in-law</comment>
         <value lang="en-us">father-in-law</value>
         <value lang="nl-nl">schoonvader</value>
-        <value lang="fr-fr">Beau-père</value>
+        <value lang="fr-fr">beau-père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MTHINLAW">
         <comment>Label: RoleCode mother-in-law</comment>
         <value lang="en-us">mother-in-law</value>
         <value lang="nl-nl">schoonmoeder</value>
-        <value lang="fr-fr">Belle-mère</value>
+        <value lang="fr-fr">belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPPRN">
         <comment>Label: RoleCode step parent</comment>
         <value lang="en-us">step parent</value>
         <value lang="nl-nl">stiefouder</value>
-        <value lang="fr-fr">Beau-père ou belle-mère - conjoint du père ou de la mère</value>
+        <value lang="fr-fr">beau-père ou belle-mère - conjoint du père ou de la mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPFTH">
         <comment>Label: RoleCode stepfather</comment>
         <value lang="en-us">stepfather</value>
         <value lang="nl-nl">stiefvader</value>
-        <value lang="fr-fr">Beau-père - époux de la mère</value>
+        <value lang="fr-fr">beau-père - époux de la mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPMTH">
         <comment>Label: RoleCode stepmother</comment>
         <value lang="en-us">stepmother</value>
         <value lang="nl-nl">stiefmoeder</value>
-        <value lang="fr-fr">Belle-mère - épouse du père</value>
+        <value lang="fr-fr">belle-mère - épouse du père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIB">
         <comment>Label: RoleCode Sibling</comment>
@@ -4029,55 +4029,55 @@
         <comment>Label: RoleCode half-sibling</comment>
         <value lang="en-us">half-sibling</value>
         <value lang="nl-nl">halfbroer/zus</value>
-        <value lang="fr-fr">Demi-frère ou demi-sœur</value>
+        <value lang="fr-fr">demi-frère ou demi-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HBRO">
         <comment>Label: RoleCode half-brother</comment>
         <value lang="en-us">half-brother</value>
         <value lang="nl-nl">halfbroer</value>
-        <value lang="fr-fr">Demi-frère</value>
+        <value lang="fr-fr">demi-frère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HSIS">
         <comment>Label: RoleCode half-sister</comment>
         <value lang="en-us">half-sister</value>
         <value lang="nl-nl">halfzus</value>
-        <value lang="fr-fr">Demi-sœur</value>
+        <value lang="fr-fr">demi-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NSIB">
         <comment>Label: RoleCode natural sibling</comment>
         <value lang="en-us">natural sibling</value>
         <value lang="nl-nl">natuurlijke broer/zus</value>
-        <value lang="fr-fr">Frère ou soeur biologique</value>
+        <value lang="fr-fr">frère ou soeur biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NBRO">
         <comment>Label: RoleCode natural brother</comment>
         <value lang="en-us">natural brother</value>
         <value lang="nl-nl">natuurlijke broer</value>
-        <value lang="fr-fr">Frère biologique</value>
+        <value lang="fr-fr">frère biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NSIS">
         <comment>Label: RoleCode natural sister</comment>
         <value lang="en-us">natural sister</value>
         <value lang="nl-nl">natuurlijke zus</value>
-        <value lang="fr-fr">Soeur biologique</value>
+        <value lang="fr-fr">soeur biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIBINLAW">
         <comment>Label: RoleCode sibling in-law</comment>
         <value lang="en-us">sibling in-law</value>
         <value lang="nl-nl">schoonbroer/zus</value>
-        <value lang="fr-fr">Beau-frère ou belle-sœur</value>
+        <value lang="fr-fr">beau-frère ou belle-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-BROINLAW">
         <comment>Label: RoleCode brother-in-law</comment>
         <value lang="en-us">brother-in-law</value>
         <value lang="nl-nl">zwager</value>
-        <value lang="fr-fr">Beau-frère</value>
+        <value lang="fr-fr">beau-frère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SISINLAW">
         <comment>Label: RoleCode sister-in-law</comment>
         <value lang="en-us">sister-in-law</value>
         <value lang="nl-nl">schoonzus</value>
-        <value lang="fr-fr">Belle-sœur</value>
+        <value lang="fr-fr">belle-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIS">
         <comment>Label: RoleCode Sister</comment>
@@ -4089,61 +4089,61 @@
         <comment>Label: RoleCode step sibling</comment>
         <value lang="en-us">step sibling</value>
         <value lang="nl-nl">stiefbroer/zus</value>
-        <value lang="fr-fr">Enfant du beau-père ou de la belle-mère</value>
+        <value lang="fr-fr">enfant du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPBRO">
         <comment>Label: RoleCode stepbrother</comment>
         <value lang="en-us">stepbrother</value>
         <value lang="nl-nl">stiefbroer</value>
-        <value lang="fr-fr">Fils du beau-père ou de la belle-mère</value>
+        <value lang="fr-fr">fils du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPSIS">
         <comment>Label: RoleCode stepsister</comment>
         <value lang="en-us">stepsister</value>
         <value lang="nl-nl">stiefzus</value>
-        <value lang="fr-fr">Fille du beau-père ou de la belle-mère</value>
+        <value lang="fr-fr">fille du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIGOTHR">
         <comment>Label: RoleCode significant other</comment>
         <value lang="en-us">significant other</value>
         <value lang="nl-nl">significante derde</value>
-        <value lang="fr-fr">Conjoint ou conjointe</value>
+        <value lang="fr-fr">conjoint ou conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DOMPART">
         <comment>Label: RoleCode domestic partner</comment>
         <value lang="en-us">domestic partner</value>
         <value lang="nl-nl">huisgenoot</value>
-        <value lang="fr-fr">Concubin(e) ou partenaire PACS</value>
+        <value lang="fr-fr">concubin(e) ou partenaire PACS</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SPS">
         <comment>Label: RoleCode spouse</comment>
         <value lang="en-us">spouse</value>
         <value lang="nl-nl">echtgenoot</value>
-        <value lang="fr-fr">Epoux ou épouse</value>
+        <value lang="fr-fr">epoux ou épouse</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HUSB">
         <comment>Label: RoleCode husband</comment>
         <value lang="en-us">husband</value>
         <value lang="nl-nl">echtgenoot</value>
-        <value lang="fr-fr">Epoux</value>
+        <value lang="fr-fr">epoux</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-WIFE">
         <comment>Label: RoleCode wife</comment>
         <value lang="en-us">wife</value>
         <value lang="nl-nl">echtgenote</value>
-        <value lang="fr-fr">Epouse</value>
+        <value lang="fr-fr">epouse</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FRND">
         <comment>Label: RoleCode unrelated friend</comment>
         <value lang="en-us">unrelated friend</value>
         <value lang="nl-nl">niet-gerelateerde vriend</value>
-        <value lang="fr-fr">Ami</value>
+        <value lang="fr-fr">ami</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NBOR">
         <comment>Label: RoleCode neighbor</comment>
         <value lang="en-us">neighbor</value>
         <value lang="nl-nl">buur</value>
-        <value lang="fr-fr">Voisin</value>
+        <value lang="fr-fr">voisin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-ROOM">
         <comment>Label: RoleCode Roommate</comment>
@@ -4258,38 +4258,38 @@
         <comment>Label: ServiceEventPerformer Performer</comment>
         <value lang="en-us">Performer</value>
         <value lang="nl-nl">Uitvoerende</value>
-        <value lang="fr-fr">Exécutant </value>
+        <value lang="fr-fr">Exécutant</value>
     </translation>
     <translation key="typeCode-PPRF">
         <comment>Label: ServiceEventPerformer Primary Performer</comment>
         <value lang="en-us">Primary Performer</value>
         <value lang="nl-nl">Eerste uitvoerende</value>
-        <value lang="fr-fr">Exécutant principal </value>
+        <value lang="fr-fr">Exécutant principal</value>
     </translation>
     <translation key="typeCode-RCT">
         <comment>Label: ParticipationType Record Target</comment>
         <value lang="en-us">Patient</value>
         <value lang="it-ch">Paziente</value>
         <value lang="nl-nl">Patiënt</value>
-        <value lang="fr-fr">Patient </value>
+        <value lang="fr-fr">Patient</value>
     </translation>
     <translation key="typeCode-RESP">
         <comment>Label: ParticipationType Responsible party</comment>
         <value lang="en-us">Responsible Party</value>
         <value lang="nl-nl">Verantwoordelijke</value>
-        <value lang="fr-fr">Responsable </value>
+        <value lang="fr-fr">Responsable</value>
     </translation>
     <translation key="typeCode-SPRF">
         <comment>Label: ServiceEventPerformer Supporting Performer</comment>
         <value lang="en-us">Supporting Performer</value>
         <value lang="nl-nl">Ondersteunend uitvoerende</value>
-        <value lang="fr-fr">Exécutant secondaire </value>
+        <value lang="fr-fr">Exécutant secondaire</value>
     </translation>
     <translation key="typeCode-TRC">
         <comment>Label: ParticipationType Tracker</comment>
         <value lang="en-us">Secondary Information Recipient</value>
         <value lang="nl-nl">Kopie-ontvanger</value>
-        <value lang="fr-fr">Destinataire secondaire </value>
+        <value lang="fr-fr">Destinataire secondaire</value>
     </translation>
     <translation key="typeCode-COMP">
         <comment>Label: ActRelationship Component</comment>
@@ -10403,7 +10403,7 @@
         <comment>Managing Organization</comment>
         <value lang="en-us">Managing Organization</value>
         <value lang="nl-nl">Verantwoordelijke organisatie</value>
-        <value lang="fr-fr">Organisation gestionnaire </value>
+        <value lang="fr-fr">Organisation gestionnaire</value>
     </translation>
     <translation key="Category">
         <comment>Category</comment>
@@ -10563,7 +10563,7 @@
         <comment>Organization</comment>
         <value lang="en-us">Organization</value>
         <value lang="nl-nl">Organisatie</value>
-        <value lang="fr-fr">Organisation </value>
+        <value lang="fr-fr">Organisation</value>
     </translation>
     <translation key="Nationality">
         <comment>Nationality</comment>
@@ -10784,7 +10784,7 @@
         <comment>frequency max</comment>
         <value lang="en-us">frequency max</value>
         <value lang="nl-nl">max frequentie</value>
-        <value lang="fr-fr">Fréquence max</value>
+        <value lang="fr-fr">fréquence max</value>
     </translation>
     <translation key="bounds">
         <comment>bounds</comment>
@@ -11011,7 +11011,7 @@
         <comment>As in: Intent of a CarePlan</comment>
         <value lang="en-us">Intent</value>
         <value lang="nl-nl">Intentie</value>
-        <value lang="fr-fr">Intention </value>
+        <value lang="fr-fr">Intention</value>
     </translation>
     <translation key="Entire Report">
         <comment>As in: Entire Report</comment>

--- a/cda_l10n.xml
+++ b/cda_l10n.xml
@@ -20,41 +20,48 @@
         <language description="German (Switzerland)" lang="de-ch"/>
         <language description="French (Switzerland)" lang="fr-ch"/>
         <language description="Italian (Switzerland)" lang="it-ch"/>
+        <language description="French (France)" lang="fr-fr"/>
     </languageList>
     <translation key="Display Disclaimer">
         <comment>Label: Display disclaimer</comment>
         <value lang="en-us">Disclaimer: the purpose of this stylesheet and the results it produces from xml messages is exclusively for testing. They are explicitly NOT suited for use in a medical practise.</value>
-        <value lang="nl-nl">Disclaimer: Deze stylesheet en de resulterende html weergave van xml berichten zijn uitsluitend bedoeld voor testdoeleinden. Zij zijn uitdrukkelijk niet bedoeld voor gebruik in de medische praktijk.</value>
+        <value lang="nl-nl">Disclaimer: Deze stylesheet en de resulterende html weergave van xml berichten zijn uitsluitend bedoeld voor testdoeleinden. Zij zijn uitdrukkelijk niet bedoeld voor gebruik in de medische praktijk.</value> 
+        <value lang="fr-fr">Clause de non-responsabilité : L'objectif de cette feuille de style et les résultats qu'elle produit à partir des messages XML sont exclusivement destinés à des fins de test. Ils ne sont explicitement PAS adaptés à une utilisation dans un cabinet médical.</value>
     </translation>
     <translation key="Table of Contents">
         <comment>Label: Table of Contents</comment>
         <value lang="en-us">Table of Contents</value>
         <value lang="nl-nl">Inhoudsopgave</value>
         <value lang="de-ch">Inhaltsverzeichnis</value>
+        <value lang="fr-fr">Table des matières</value>
     </translation>
     <translation key="Signed">
         <comment>Label: Signed</comment>
         <value lang="en-us">Signed</value>
         <value lang="nl-nl">Ondertekend</value>
         <value lang="de-ch">Unterzeichnet</value>
+        <value lang="fr-fr">Signé</value>
     </translation>
     <translation key="Signature present but not verified">
         <comment>Label: Signature present but not verified</comment>
         <value lang="en-us">Signature is present. Validity has not been checked.</value>
         <value lang="nl-nl">Handtekening is aanwezig. Geldigheid is niet gecontroleerd.</value>
         <value lang="de-ch">Unterschrift ist vorhanden. Gültigkeit werd nicht geprüft.</value>
+        <value lang="fr-fr">Signature présente mais non vérifiée.</value>
     </translation>
     <translation key="show revisions">
         <comment>Label: show revisions</comment>
         <value lang="en-us">Show Revisions</value>
         <value lang="nl-nl">Toon revisies</value>
         <value lang="de-ch">Zeige Revisionen</value>
+        <value lang="fr-fr">Montrer les révisions</value>
     </translation>
     <translation key="hide revisions">
         <comment>Label: hide revisions</comment>
         <value lang="en-us">Hide Revisions</value>
         <value lang="nl-nl">Verberg revisies</value>
         <value lang="de-ch">Verberg Revisionen</value>
+        <value lang="fr-fr">Cacher les révisions</value>
     </translation>
     <translation key="ClinicalDocument">
         <comment>Label: ClinicalDocument</comment>
@@ -68,6 +75,7 @@
         <value lang="fr-ch">Signé</value>
         <value lang="it-ch">Firmato</value>
         <value lang="nl-nl">Ondertekenaar</value>
+        <value lang="fr-fr">Approbateur</value>
     </translation>
     <translation key="legalAuthenticator">
         <comment>Label: Legal Authenticator</comment>
@@ -76,11 +84,13 @@
         <value lang="fr-ch">Légal signataires</value>
         <value lang="it-ch">Efficace legge firmato</value>
         <value lang="nl-nl">Juridische ondertekenaar</value>
+        <value lang="fr-fr">Signataire légal</value>
     </translation>
     <translation key="informationRecipient">
         <comment>Label: Information Recipient</comment>
         <value lang="en-us">Information Recipient</value>
         <value lang="nl-nl">Ontvanger</value>
+        <value lang="fr-fr">Destinataire prévu du document</value>
     </translation>
     <translation key="author">
         <comment>Label: Author</comment>
@@ -89,12 +99,14 @@
         <value lang="fr-ch">Auteur</value>
         <value lang="it-ch">Autore</value>
         <value lang="nl-nl">Auteur</value>
+        <value lang="fr-fr">Auteur</value>
     </translation>
     <translation key="custodian">
         <comment>Label: Custodian</comment>
         <value lang="en-us">Custodian</value>
         <value lang="de-ch">Verwalter</value>
         <value lang="nl-nl">Beheerder</value>
+        <value lang="fr-fr">Organisation chargée de la conservation du document </value>
     </translation>
     <translation key="dataEnterer">
         <comment>Label: Data enterer</comment>
@@ -103,17 +115,20 @@
         <value lang="fr-ch">Saisie par</value>
         <value lang="it-ch">Registrati da</value>
         <value lang="nl-nl">Ingevoerd door</value>
+        <value lang="fr-fr">Opérateur de saisie </value>
     </translation>
     <translation key="overseer">
         <comment>Label: Overseer</comment>
         <value lang="en-us">Overseer</value>
         <value lang="nl-nl">Mandaterende/eindverantwoordelijke</value>
+        <value lang="fr-fr">Superviseur </value>
     </translation>
     <translation key="recordTarget">
         <comment>Label: recordTarget</comment>
         <value lang="en-us">Patient</value>
         <value lang="it-ch">Paziente</value>
         <value lang="nl-nl">Patiënt</value>
+        <value lang="fr-fr">Patient </value>
     </translation>
     <translation key="informant">
         <comment>Label: Informant - An informant (or source of information) is a person that provides relevant information</comment>
@@ -121,10 +136,12 @@
         <value lang="de-ch">Informiert</value>
         <value lang="fr-ch">Informé</value>
         <value lang="it-ch">Informati</value>
+        <value lang="fr-fr">Informateur </value>
     </translation>
     <translation key="Participant">
         <comment>Label: Participant</comment>
         <value lang="en-us">Participant</value>
+        <value lang="fr-fr">Participant </value>
     </translation>
     <translation key="Custodian_Organization">
         <comment>Label: Custodian Organization</comment>
@@ -133,32 +150,38 @@
         <value lang="fr-ch">Organisme de gestion</value>
         <value lang="it-ch">Organismo di gestione</value>
         <value lang="nl-nl">Beherende organisatie</value>
+        <value lang="fr-fr">Organisation chargée de la conservation du document </value>
     </translation>
     <translation key="performer">
         <comment>Label: Performer</comment>
         <value lang="en-us">Performer</value>
         <value lang="de-ch">Heilberufler</value>
         <value lang="nl-nl">Zorgverlener</value>
+        <value lang="fr-fr">Exécutant </value>
     </translation>
     <translation key="responsibleParty">
         <comment>Label: responsibleParty</comment>
         <value lang="en-us">Responsible Party</value>
         <value lang="nl-nl">Verantwoordelijke</value>
+        <value lang="fr-fr">Responsable de la prise en charge </value>
     </translation>
     <translation key="encounterParticipant">
         <comment>Label: encounterParticipant</comment>
         <value lang="en-us">Encounter Participant</value>
         <value lang="nl-nl">Deelnemer contact</value>
+        <value lang="fr-fr">Participant à la prise en charge </value>
     </translation>
     <translation key="location">
         <comment>Label: location</comment>
         <value lang="en-us">Location</value>
         <value lang="nl-nl">Lokatie</value>
+        <value lang="fr-fr">Lieu </value>
     </translation>
     <translation key="subject">
         <comment>Label: subject</comment>
         <value lang="en-us">Subject</value>
         <value lang="nl-nl">Onderwerp</value>
+        <value lang="fr-fr">Sujet </value>
     </translation>
     <!-- End: Header/Body Participations -->
     <!-- Start: Common Sub Classes of Participations -->
@@ -166,31 +189,37 @@
         <comment>Label: OrganizationPartOf</comment>
         <value lang="en-us">Organization Part Of</value>
         <value lang="nl-nl">Organisatie deel van</value>
+        <value lang="fr-fr">Organisation </value>
     </translation>
     <translation key="organization">
         <comment>Label: Organization</comment>
         <value lang="en-us">Organization</value>
         <value lang="nl-nl">Organisatie</value>
+        <value lang="fr-fr">Organisation</value>
     </translation>
     <translation key="person">
         <comment>Label: Person</comment>
         <value lang="en-us">Person</value>
         <value lang="nl-nl">Persoon</value>
+        <value lang="fr-fr">Personne </value>
     </translation>
     <translation key="authoringDevice">
         <comment>Label: AuthoringDevice</comment>
         <value lang="en-us">Device</value>
         <value lang="nl-nl">Apparaat</value>
+        <value lang="fr-fr">Dispositif </value>
     </translation>
     <translation key="place">
         <comment>Label: Place</comment>
         <value lang="en-us">Place</value>
         <value lang="nl-nl">Plaats</value>
+        <value lang="fr-fr">Place </value>
     </translation>
     <translation key="healthCareFacility">
         <comment>Label: HealthCareFacility</comment>
         <value lang="en-us">Health Care Facility</value>
         <value lang="nl-nl">Zorginstelling</value>
+        <value lang="fr-fr">Structure de santé </value>
     </translation>
     <!-- End: Common Sub Classes of Participations -->
     <!-- Start: Patient Specific Stuff -->
@@ -199,6 +228,7 @@
         <value lang="en-us">MRN</value>
         <value lang="de-ch">PID</value>
         <value lang="nl-nl">PID</value>
+        <value lang="fr-fr">Id. patient </value>
     </translation>
     <translation key="patientIdLong">
         <comment>Label: Patient-ID long</comment>
@@ -207,6 +237,7 @@
         <value lang="fr-ch">ID patient</value>
         <value lang="it-ch">ID paziente</value>
         <value lang="nl-nl">Patiëntnummer</value>
+        <value lang="fr-fr">Id. patient </value>
     </translation>
     <translation key="patientIdsLong">
         <comment>Label: Patient-IDs long</comment>
@@ -215,6 +246,7 @@
         <value lang="fr-ch">IDs patient</value>
         <value lang="it-ch">ID paziente</value>
         <value lang="nl-nl">Patiëntnummers</value>
+        <value lang="fr-fr">Id. patient </value>
     </translation>
     <translation key="birthPlace">
         <comment>Label: Birthplace long</comment>
@@ -222,6 +254,7 @@
         <value lang="de-ch">Geburtsplatz</value>
         <value lang="fr-ch">Place de naissance</value>
         <value lang="nl-nl">Geboorteplaats</value>
+        <value lang="fr-fr">Lieu de naissance </value>
     </translation>
     <translation key="birthTimeLong">
         <comment>Label: Birthdate long</comment>
@@ -230,6 +263,7 @@
         <value lang="fr-ch">Date de naissance</value>
         <value lang="it-ch">Data di nascita</value>
         <value lang="nl-nl">Geboortedatum</value>
+        <value lang="fr-fr">Date de naissance </value>
     </translation>
     <translation key="birthTimeLongDeceased">
         <comment>Label: Birthdate long and deceased</comment>
@@ -238,6 +272,7 @@
         <value lang="fr-ch">Date de naissance/décédé</value>
         <value lang="it-ch">Data di nascita/defunto</value>
         <value lang="nl-nl">Geboren/overleden</value>
+        <value lang="fr-fr">Date de naissance/décédé </value>
     </translation>
     <translation key="Deceased">
         <comment>Label: Deceased</comment>
@@ -246,6 +281,7 @@
         <value lang="fr-ch">Décédé</value>
         <value lang="it-ch">Defunto</value>
         <value lang="nl-nl">Overleden</value>
+        <value lang="fr-fr">Décédé </value>
     </translation>
     <translation key="date_unknown">
         <comment>Label: date_unknown - used for saying you know patient has died, but unknown when</comment>
@@ -254,6 +290,7 @@
         <value lang="fr-ch">date inconnue</value>
         <value lang="it-ch">data sconosciuto</value>
         <value lang="nl-nl">datum onbekend</value>
+        <value lang="fr-fr">date inconnue</value>
     </translation>
     <translation key="boolean-true">
         <comment>Label: boolean-true - used for saying Deceased: yes</comment>
@@ -262,6 +299,7 @@
         <value lang="fr-ch">oui</value>
         <value lang="it-ch">si</value>
         <value lang="nl-nl">ja</value>
+        <value lang="fr-fr">oui</value>
     </translation>
     <translation key="boolean-false">
         <comment>Label: boolean-false - used for saying Deceased: no</comment>
@@ -270,74 +308,88 @@
         <value lang="fr-ch">non</value>
         <value lang="it-ch">no</value>
         <value lang="nl-nl">nee</value>
+        <value lang="fr-fr">non</value>
     </translation>
     <translation key="yr">
         <comment>Label: yr as in the age of someone in years</comment>
         <value lang="en-us">yr</value>
         <value lang="nl-nl">jr</value>
         <value lang="de-ch">Jahre</value>
+        <value lang="fr-fr">ans</value>
     </translation>
     <translation key="At the time of death">
         <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have date functions we need content based based relativity</comment>
         <value lang="en-us">At the time of death</value>
         <value lang="nl-nl">Bij overlijden</value>
+        <value lang="fr-fr">au décès</value>
     </translation>
     <translation key="At document creation time">
         <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have date functions we need content based based relativity</comment>
         <value lang="en-us">At document creation time</value>
         <value lang="nl-nl">Bij aanmaken van het document</value>
+        <value lang="fr-fr">à la date de création du document</value>
     </translation>
     <translation key="birthTimeShort">
         <comment>Label: DOB (Date of birth) short</comment>
         <value lang="en-us">DOB</value>
         <value lang="de-ch">Geburtsdatum</value>
         <value lang="nl-nl">Geboortedatum</value>
+        <value lang="fr-fr">Date naiss.</value>
     </translation>
     <translation key="partOfMultipleBirth">
         <comment>Label: person is part of a multiple birth</comment>
         <value lang="en-us">Multiple Birth</value>
         <value lang="nl-nl">Meerling</value>
+        <value lang="fr-fr">Naissance multiple</value>
     </translation>
     <translation key="administrativeGenderCode">
         <comment>Label: AdministrativeGenderCode</comment>
         <value lang="en-us">Gender</value>
         <value lang="de-ch">Geschlecht</value>
         <value lang="nl-nl">Geslacht</value>
+        <value lang="fr-fr">Sexe </value>
     </translation>
     <translation key="maritalStatusCode">
         <comment>Label: MaritalStatusCode</comment>
         <value lang="en-us">Marital Status</value>
         <value lang="nl-nl">Burgerlijke staat</value>
+        <value lang="fr-fr">Situation familiale</value>
     </translation>
     <translation key="languageCommunication">
         <comment>Label: LanguageCommunication</comment>
         <value lang="en-us">Language Communication</value>
         <value lang="nl-nl">Taal</value>
+        <value lang="fr-fr">Langue</value>
     </translation>
     <translation key="preferredLanguage">
         <comment>Label: preferredLanguage</comment>
         <value lang="en-us">preferred</value>
         <value lang="nl-nl">voorkeur</value>
+        <value lang="fr-fr">Langue préférée</value>
     </translation>
     <translation key="Ethnicity">
         <comment>Label: Ethnicity</comment>
         <value lang="en-us">Ethnicity</value>
         <value lang="nl-nl">Etniciteit</value>
+        <value lang="fr-fr">Ethnie</value>
     </translation>
     <translation key="proficiencyLevelCode">
         <comment>Label: ProficiencyLevelCode</comment>
         <value lang="en-us">Proficiency Level Code</value>
         <value lang="nl-nl">Mate van beheersing</value>
+        <value lang="fr-fr">Niveau de compétence</value>
     </translation>
     <translation key="Guardian">
         <comment>Label: Guardian (for recordTarget)</comment>
         <value lang="en-us">Guardian</value>
         <value lang="nl-nl">Voogd</value>
+        <value lang="fr-fr">Représentant du patient</value>
     </translation>
     <translation key="providerOrganization">
         <comment>Label: providerOrganization</comment>
         <value lang="en-us">Provider Organization</value>
         <value lang="nl-nl">Zorgaanbieder</value>
+        <value lang="fr-fr">Organisation</value>
     </translation>
     <!-- End: Patient Specific Stuff -->
     <!-- Start: ActRelations Header -->
@@ -345,66 +397,79 @@
         <comment>Label: relatedDocument</comment>
         <value lang="en-us">Related Document</value>
         <value lang="nl-nl">Gerelateerd document</value>
+        <value lang="fr-fr">Document remplacé</value>
     </translation>
     <translation key="relatingDocument">
         <comment>Label: relatingDocument not(inversionInd='true')</comment>
         <value lang="en-us">This document relates to document</value>
         <value lang="nl-nl">Dit document is gerelateerd aan document</value>
+        <value lang="fr-fr">Ce document est lié au document</value>
     </translation>
     <translation key="relatingDocumentInverted">
         <comment>Label: relatingDocument (inversionInd='true')</comment>
         <value lang="en-us">Document relating to this document</value>
         <value lang="nl-nl">Document gerelateerd aan dit document</value>
+        <value lang="fr-fr">Document lié à ce document</value>
     </translation>
     <translation key="parentDocument">
         <comment>Label: ParentDocument</comment>
         <value lang="en-us">Parent Document</value>
         <value lang="nl-nl">Voorgaand document</value>
+        <value lang="fr-fr">Document précédent</value>
     </translation>
     <translation key="Document">
         <comment>Label: Document</comment>
         <value lang="en-us">Document</value>
         <value lang="nl-nl">Document</value>
+        <value lang="fr-fr">Document</value>
     </translation>
     <translation key="Document Type">
         <comment>Label: Document Type</comment>
         <value lang="en-us">Document Type</value>
         <value lang="nl-nl">Document type</value>
+        <value lang="fr-fr">Type de document</value>
     </translation>
     <translation key="Document Version">
         <comment>Label: Document Version</comment>
         <value lang="en-us">Document Version</value>
         <value lang="nl-nl">Document versie</value>
+        <value lang="fr-fr">Version du document</value>
     </translation>
     <translation key="Document Version and Set ID">
         <comment>Label: Document Version and Set ID</comment>
         <value lang="en-us">Document Version and Set ID</value>
         <value lang="nl-nl">Document versie en set id</value>
+        <value lang="fr-fr">Version du lot</value>
     </translation>
     <translation key="documentationOf">
         <comment>Label: documentationOf</comment>
         <value lang="en-us">Documentation&#160;Of</value>
         <value lang="nl-nl">Documentatie&#160;van</value>
+        <value lang="fr-fr">Evènement documenté</value>
     </translation>
     <translation key="serviceEvent">
         <comment>Label: ServiceEvent</comment>
         <value lang="en-us">Service Event</value>
         <value lang="nl-nl">Uitgevoerde handeling</value>
+        <value lang="fr-fr">Evènement</value>
     </translation>
     <translation key="inFulfillmentOf">
         <comment>Label: InFulfillmentOf</comment>
         <value lang="en-us">In Fulfillment Of</value>
         <value lang="nl-nl">Conform</value>
+        <value lang="fr-fr">Prescription</value>
     </translation>
     <translation key="order">
         <comment>Label: Order</comment>
         <value lang="en-us">Order</value>
         <value lang="nl-nl">Aanvraag</value>
+        <value lang="fr-fr">Prescription</value>
     </translation>
     <translation key="authorization">
         <comment>Label: Authorization</comment>
         <value lang="en-us">Authorization</value>
         <value lang="nl-nl">Autorisatie</value>
+        <value lang="fr-fr">Authorisation</value>
     </translation>
     <translation key="consent">
         <comment>Label: Consent</comment>
@@ -413,46 +478,55 @@
         <value lang="fr-ch">Consentement éclairé</value>
         <value lang="it-ch">Dichiarazione di consenso</value>
         <value lang="nl-nl">Toestemmingsverklaring</value>
+        <value lang="fr-fr">Consentement</value>
     </translation>
     <translation key="componentOf">
         <comment>Label: componentOf</comment>
         <value lang="en-us">Component Of</value>
         <value lang="nl-nl">Component van</value>
+        <value lang="fr-fr">Prise en charge</value>
     </translation>
     <translation key="encompassingEncounter">
         <comment>Label: encompassingEncounter</comment>
         <value lang="en-us">Encounter</value>
         <value lang="nl-nl">Contact</value>
+        <value lang="fr-fr">Prise en charge</value>
     </translation>
     <translation key="Encounter Id">
         <comment>Label: Encounter Id</comment>
         <value lang="en-us">Encounter Id</value>
         <value lang="nl-nl">Contact-id</value>
+        <value lang="fr-fr">Id. prise en charge</value>
     </translation>
     <translation key="Encounter Type">
         <comment>Label: Encounter Type</comment>
         <value lang="en-us">Encounter Type</value>
         <value lang="nl-nl">Contacttype</value>
+        <value lang="fr-fr">Type de prise en charge</value>
     </translation>
     <translation key="Encounter Date">
         <comment>Label: Encounter Date</comment>
         <value lang="en-us">Encounter Date</value>
         <value lang="nl-nl">Contactdatum</value>
+        <value lang="fr-fr">Date de prise en charge</value>
     </translation>
     <translation key="Encounter Location">
         <comment>Label: Encounter Location</comment>
         <value lang="en-us">Encounter Location</value>
         <value lang="nl-nl">Contactlocatie</value>
+        <value lang="fr-fr">Lieu de prise en charge</value>
     </translation>
     <translation key="Encounter Admission Referral Source">
         <comment>Label: Encounter admissionReferralSourceCode</comment>
         <value lang="en-us">Admission Referral Source</value>
         <value lang="nl-nl">Opname verwijsbron</value>
+        <value lang="fr-fr">Admission</value>
     </translation>
     <translation key="Encounter Discharge Disposition">
         <comment>Label: Encounter dischargeDispositionCode</comment>
         <value lang="en-us">Discharge Disposition</value>
         <value lang="nl-nl">Ontslagwijze</value>
+        <value lang="fr-fr">Disposition de sortie</value>
     </translation>
     <!-- End: ActRelations Header -->
     <!-- Start: Common Class Attributes -->
@@ -460,26 +534,31 @@
         <comment>Label: Document Id</comment>
         <value lang="en-us">Document Id</value>
         <value lang="nl-nl">Document-id</value>
+        <value lang="fr-fr">Id. du document</value>
     </translation>
     <translation key="SetId and Version">
         <comment>Label: SetId and Version</comment>
         <value lang="en-us">SetId and Version</value>
         <value lang="nl-nl">Set‑Id en versie</value>
+        <value lang="fr-fr">Lot et version</value>
     </translation>
     <translation key="id">
         <comment>Label: ID</comment>
         <value lang="en-us">ID</value>
         <value lang="nl-nl">Id</value>
+        <value lang="fr-fr">Id </value>
     </translation>
     <translation key="setId">
         <comment>Label: setId</comment>
         <value lang="en-us">Set‑ID</value>
         <value lang="nl-nl">Set‑Id</value>
+        <value lang="fr-fr">Lot </value>
     </translation>
     <translation key="versionNumber">
         <comment>Label: versionNumber</comment>
         <value lang="en-us">Version</value>
         <value lang="nl-nl">Versie</value>
+        <value lang="fr-fr">Version </value>
     </translation>
     <translation key="code">
         <comment>Label: Code</comment>
@@ -489,213 +568,257 @@
         <comment>Label: Type</comment>
         <value lang="en-us">Type</value>
         <value lang="de-ch">Typ</value>
+        <value lang="fr-fr">Type </value>
     </translation>
     <translation key="title">
         <comment>Label: Title</comment>
         <value lang="en-us">Title</value>
         <value lang="nl-nl">Titel</value>
+        <value lang="fr-fr">Titre</value>
     </translation>
     <translation key="effectiveTime">
         <comment>Label: effectiveTime</comment>
         <value lang="en-us">Date/Time</value>
         <value lang="nl-nl">Datum/tijd</value>
+        <value lang="fr-fr">Date/Heure </value>
     </translation>
     <translation key="versionCode">
         <comment>Label: versionCode</comment>
         <value lang="en-us">Version Code</value>
         <value lang="nl-nl">Versiecode</value>
+        <value lang="fr-fr">Code de la version</value>
     </translation>
     <translation key="acknowledgement">
         <comment>Label: acknowledgement</comment>
         <value lang="en-us">Acknowledgement</value>
+        <value lang="fr-fr">Reconnaissance</value>
     </translation>
     <translation key="acknowledgementDetail">
         <comment>Label: acknowledgementDetail</comment>
         <value lang="en-us">Acknowledgement Detail</value>
+        <value lang="fr-fr">Détail reconnaissance</value>
     </translation>
     <translation key="attentionLine">
         <comment>Label: attentionLine</comment>
         <value lang="en-us">Attention Line</value>
+        <value lang="fr-fr">Ligne d'attention</value>
     </translation>
     <translation key="keyWordText">
         <comment>Label: keyWordText</comment>
         <value lang="en-us">Key Word</value>
+        <value lang="fr-fr">Mot clé</value>
     </translation>
     <translation key="sender">
         <comment>Label: sender</comment>
         <value lang="en-us">Sender</value>
         <value lang="nl-nl">Verzender</value>
+        <value lang="fr-fr">Expéditeur</value>
     </translation>
     <translation key="receiver">
         <comment>Label: receiver</comment>
         <value lang="en-us">Receiver</value>
         <value lang="nl-nl">Ontvanger</value>
+        <value lang="fr-fr">Destinataire</value>
     </translation>
     <translation key="interactionId">
         <comment>Label: interactionId</comment>
         <value lang="en-us">Interaction ID</value>
         <value lang="nl-nl">Interactie-id</value>
+        <value lang="fr-fr">Id. Interaction</value>
     </translation>
     <translation key="profileId">
         <comment>Label: profileId</comment>
         <value lang="en-us">Profile ID</value>
         <value lang="nl-nl">Profile-id</value>
+        <value lang="fr-fr">Id. profil</value>
     </translation>
     <translation key="transmissionQuantity">
         <comment>Label: transmissionQuantity</comment>
         <value lang="en-us">Batch Message Count</value>
         <value lang="nl-nl">Aantal berichten in de batch</value>
+        <value lang="fr-fr">Nb de messages</value>
     </translation>
     <translation key="resultTotalQuantity">
         <comment>Label: resultTotalQuantity</comment>
         <value lang="en-us">Result Count Total</value>
         <value lang="nl-nl">Aantal resultaten totaal</value>
+        <value lang="fr-fr">Total</value>
     </translation>
     <translation key="resultCurrentQuantity">
         <comment>Label: resultCurrentQuantity</comment>
         <value lang="en-us">Result Count Current</value>
         <value lang="nl-nl">Aantal resultaten huidig</value>
+        <value lang="fr-fr">Nb actuel</value>
     </translation>
     <translation key="resultRemainingQuantity">
         <comment>Label: resultRemainingQuantity</comment>
         <value lang="en-us">Result Count Remaining</value>
         <value lang="nl-nl">Aantal resultaten resterend</value>
+        <value lang="fr-fr">Nb restant</value>
     </translation>
     <translation key="justifiedDetectedIssue">
         <comment>Label: justifiedDetectedIssue</comment>
         <value lang="en-us">Detected Issue</value>
         <value lang="nl-nl">Gedetecteerd probleem</value>
+        <value lang="fr-fr">Problème détecté</value>
     </translation>
     <translation key="queryAck">
         <comment>Label: queryAck</comment>
         <value lang="en-us">Query Ack</value>
+        <value lang="fr-fr">Accusé de réception de la requête</value>
     </translation>
     <translation key="queryByParameter">
         <comment>Label: queryByParameter</comment>
         <value lang="en-us">Query by Parameter</value>
+        <value lang="fr-fr">Requête par paramètre</value>
     </translation>
     <translation key="queryId">
         <comment>Label: queryId</comment>
         <value lang="en-us">Query-ID</value>
         <value lang="nl-nl">Query-id</value>
+        <value lang="fr-fr">Id. de la requête</value>
     </translation>
     <translation key="queryResponseCode">
         <comment>Label: queryResponseCode</comment>
         <value lang="en-us">Query Response Code</value>
         <value lang="nl-nl">Query antwoordcode</value>
+        <value lang="fr-fr">Code de la réponse</value>
     </translation>
     <translation key="responseModalityCode">
         <comment>Label: responseModalityCode</comment>
         <value lang="en-us">Response Modality</value>
         <value lang="nl-nl">Antwoordmodus code</value>
+        <value lang="fr-fr">Modalité de la réponse</value>
     </translation>
     <translation key="responsePriorityCode">
         <comment>Label: responsePriorityCode</comment>
         <value lang="en-us">Response Priority</value>
         <value lang="nl-nl">Antwoordprioriteit</value>
+        <value lang="fr-fr">Priorité de la réponse</value>
     </translation>
     <translation key="initialQuantity">
         <comment>Label: initialQuantity</comment>
         <value lang="en-us">Initial Quantity</value>
         <value lang="nl-nl">Initiële hoeveelheid</value>
+        <value lang="fr-fr">Quantité initiale</value>
     </translation>
     <translation key="initialQuantityCode">
         <comment>Label: initialQuantityCode</comment>
         <value lang="en-us">Initial Quantity Code</value>
         <value lang="nl-nl">Initiële hoeveelheid code</value>
+        <value lang="fr-fr">Code de la quantité initiale</value>
     </translation>
     <translation key="executionAndDeliveryTime">
         <comment>Label: executionAndDeliveryTime</comment>
         <value lang="en-us">Execution and Delivery Time</value>
         <value lang="nl-nl">Antwoord sturen vóór</value>
+        <value lang="fr-fr">Délai d'exécution et de livraison</value>
     </translation>
     <translation key="functionCode">
         <comment>Label: functionCode</comment>
         <value lang="en-us">Function</value>
         <value lang="nl-nl">Functie</value>
+        <value lang="fr-fr">Rôle fonctionnel</value>
     </translation>
     <translation key="copyTime">
         <comment>Label: copyTime</comment>
         <value lang="en-us">Copy Date/time</value>
         <value lang="nl-nl">Kopiedatum/tijd</value>
+        <value lang="fr-fr">Date/Heure de la copie</value>
     </translation>
     <translation key="time">
         <comment>Label: time</comment>
         <value lang="en-us">Time</value>
         <value lang="nl-nl">Tijd</value>
+        <value lang="fr-fr">Heure</value>
     </translation>
     <translation key="confidentialityCode">
         <comment>Label: confidentialityCode</comment>
         <value lang="en-us">Confidentiality</value>
         <value lang="nl-nl">Vertrouwelijkheid</value>
+        <value lang="fr-fr">Confidentialité</value>
     </translation>
     <translation key="languageCode">
         <comment>Label: languageCode</comment>
         <value lang="en-us">Language</value>
         <value lang="nl-nl">Taal</value>
+        <value lang="fr-fr">Langue</value>
     </translation>
     <translation key="signatureCode">
         <comment>Label: signatureCode</comment>
         <value lang="en-us">Signature Code</value>
         <value lang="nl-nl">Handtekeningcode</value>
+        <value lang="fr-fr">Signature</value>
     </translation>
     <translation key="signatureCode-S">
         <comment>Label: signatureCode-S</comment>
         <value lang="en-us">Signed</value>
         <value lang="nl-nl">Getekend</value>
+        <value lang="fr-fr">Signé</value>
     </translation>
     <translation key="signatureCode-I">
         <comment>Label: signatureCode-I</comment>
         <value lang="en-us">Intended</value>
         <value lang="nl-nl">Zal nog tekenen</value>
+        <value lang="fr-fr">Signature prévue</value>
     </translation>
     <translation key="signatureCode-X">
         <comment>Label: signatureCode-X</comment>
         <value lang="en-us">Signature Required</value>
         <value lang="nl-nl">Handtekening vereist</value>
+        <value lang="fr-fr">Signature requise</value>
     </translation>
     <translation key="addr">
         <comment>Label: addr</comment>
         <value lang="en-us">Address</value>
         <value lang="nl-nl">Adres</value>
+        <value lang="fr-fr">Adresse</value>
     </translation>
     <translation key="address not available">
         <comment>Label: address not available</comment>
         <value lang="en-us">address not available</value>
         <value lang="nl-nl">adres niet beschikbaar</value>
+        <value lang="fr-fr">Adresse indisponible</value>
     </translation>
     <translation key="telecom">
         <comment>Label: telecom</comment>
         <value lang="en-us">Telecom</value>
+        <value lang="fr-fr">Telecom</value>
     </translation>
     <translation key="telecom information not available">
         <comment>Label: telecom information not available</comment>
         <value lang="en-us">telecom information not available</value>
         <value lang="nl-nl">telecominformatie niet beschikbaar</value>
+        <value lang="fr-fr">Telecom indisponible</value>
     </translation>
     <translation key="name">
         <comment>Label: name</comment>
         <value lang="en-us">Name</value>
         <value lang="nl-nl">Naam</value>
+        <value lang="fr-fr">Nom</value>
     </translation>
     <translation key="statusCode">
         <comment>Label: statusCode</comment>
         <value lang="en-us">Status</value>
+        <value lang="fr-fr">Statut</value>
     </translation>
     <translation key="text">
         <comment>Label: text</comment>
         <value lang="en-us">Text</value>
         <value lang="nl-nl">Tekst</value>
+        <value lang="fr-fr">Texte</value>
     </translation>
     <translation key="priorityCode">
         <comment>Label: priorityCode</comment>
         <value lang="en-us">Priority</value>
         <value lang="nl-nl">Prioriteit</value>
+        <value lang="fr-fr">Priorité</value>
     </translation>
     <translation key="dischargeDispositionCode">
         <comment>Label: dischargeDispositionCode</comment>
         <value lang="en-us">Discharge Disposition</value>
         <value lang="nl-nl">Ontslagstatus</value>
+        <value lang="fr-fr">Disposition de sortie</value>
     </translation>
     <!-- End: Common Class Attributes -->
     <!-- Start: Body Classes -->
@@ -706,26 +829,31 @@
         <value lang="fr-ch">Contents</value>
         <value lang="it-ch">Contents</value>
         <value lang="nl-nl">Inhoud</value>
+        <value lang="fr-fr">Contenu</value>
     </translation>
     <translation key="section">
         <comment>Label: Section</comment>
         <value lang="en-us">Section</value>
         <value lang="nl-nl">Sectie</value>
+        <value lang="fr-fr">Section</value>
     </translation>
     <translation key="sectionAuthor">
         <comment>Label: Section Author</comment>
         <value lang="en-us">Section Author</value>
         <value lang="nl-nl">Auteur sectie</value>
+        <value lang="fr-fr">Section Auteur</value>
     </translation>
     <translation key="sectionSubject">
         <comment>Label: Section Subject</comment>
         <value lang="en-us">Section Subject</value>
         <value lang="nl-nl">Subject sectie</value>
+        <value lang="fr-fr">Section Sujet</value>
     </translation>
     <translation key="sectionInformant">
         <comment>Label: Section Informant</comment>
         <value lang="en-us">Section Informant</value>
         <value lang="nl-nl">Informant sectie</value>
+        <value lang="fr-fr">Section Informateur</value>
     </translation>
     <!-- End: Body Classes -->
     <!--Start: Miscellaneous -->
@@ -734,16 +862,19 @@
         <value lang="en-us">Supporting Author</value>
         <value lang="de-ch">Mitbehandelnde Heilberufler</value>
         <value lang="nl-nl">Ondersteunend zorgverlener</value>
+        <value lang="fr-fr">Aide</value>
     </translation>
     <translation key="Payer">
         <comment>Label: Payer</comment>
         <value lang="en-us">Payer</value>
         <value lang="nl-nl">Betaler</value>
+        <value lang="fr-fr">Payeur</value>
     </translation>
     <translation key="Policy_Number">
         <comment>Label: Policy Number (for payer)</comment>
         <value lang="en-us">Policy Number</value>
         <value lang="nl-nl">Polisnummer</value>
+        <value lang="fr-fr">Num. d'assurance</value>
     </translation>
     <translation key="Insured">
         <comment>Label: Insured</comment>
@@ -752,6 +883,7 @@
         <value lang="fr-ch">Assuré</value>
         <value lang="it-ch">Assicurati</value>
         <value lang="nl-nl">Verzekerde</value>
+        <value lang="fr-fr">Assuré</value>
     </translation>
     <translation key="Insurance_Company">
         <comment>Label: Insurance Company</comment>
@@ -760,11 +892,13 @@
         <value lang="fr-ch">Assurance</value>
         <value lang="it-ch">Assicurazione</value>
         <value lang="nl-nl">Verzekeraar</value>
+        <value lang="fr-fr">Assurance</value>
     </translation>
     <translation key="Clinical_Document">
         <comment>Title for documents</comment>
         <value lang="en-us">Clinical Document</value>
         <value lang="nl-nl">Klinisch document</value>
+        <value lang="fr-fr">Document de santé</value>
     </translation>
     <translation key="Created_on">
         <comment>Label: Created on</comment>
@@ -773,6 +907,7 @@
         <value lang="fr-ch">Création</value>
         <value lang="it-ch">Generata</value>
         <value lang="nl-nl">Gemaakt op</value>
+        <value lang="fr-fr">Créé le</value>
     </translation>
     <translation key="Created">
         <comment>Label: Created</comment>
@@ -781,36 +916,43 @@
         <value lang="fr-ch">Création</value>
         <value lang="it-ch">Generata</value>
         <value lang="nl-nl">Gemaakt</value>
+        <value lang="fr-fr">Créé</value>
     </translation>
     <translation key="Authored_on">
         <comment>Label: Authored on</comment>
         <value lang="en-us">Authored On</value>
         <value lang="nl-nl">Gemaakt op</value>
+        <value lang="fr-fr">Créé le </value>
     </translation>
     <translation key="Authored">
         <comment>Label: Authored</comment>
         <value lang="en-us">Authored</value>
         <value lang="nl-nl">Gemaakt</value>
+        <value lang="fr-fr">Créé</value>
     </translation>
     <translation key="Exam_Date">
         <comment>Label: Exam Date</comment>
         <value lang="en-us">Exam Date</value>
         <value lang="nl-nl">Datum onderzoek</value>
+        <value lang="fr-fr">Date de l'acte</value>
     </translation>
     <translation key="Exam_Time">
         <comment>Label: Exam Time</comment>
         <value lang="en-us">Exam Time</value>
         <value lang="nl-nl">Tijd onderzoek</value>
+        <value lang="fr-fr">Heure de l'acte</value>
     </translation>
     <translation key="Next_of_Kin">
         <comment>Label: Next of Kin (for recordTarget)</comment>
         <value lang="en-us">Next of Kin</value>
         <value lang="nl-nl">Familie</value>
+        <value lang="fr-fr">Plus proche parent</value>
     </translation>
     <translation key="Table_of_Contents">
         <comment>Title: Table of Contents</comment>
         <value lang="en-us">Table of Contents</value>
         <value lang="nl-nl">Inhoud</value>
+        <value lang="fr-fr">Table des matières</value>
     </translation>
     <translation key="January">
         <comment>Dates: January</comment>
@@ -819,6 +961,7 @@
         <value lang="fr-ch">Janvier</value>
         <value lang="it-ch">Gennaio</value>
         <value lang="nl-nl">januari</value>
+        <value lang="fr-fr">janvier</value>
     </translation>
     <translation key="February">
         <comment>Dates: February</comment>
@@ -827,6 +970,7 @@
         <value lang="fr-ch">Février</value>
         <value lang="it-ch">Febbraio</value>
         <value lang="nl-nl">februari</value>
+        <value lang="fr-fr">février</value>
     </translation>
     <translation key="March">
         <comment>Dates: March</comment>
@@ -835,6 +979,7 @@
         <value lang="fr-ch">Mars</value>
         <value lang="it-ch">März</value>
         <value lang="nl-nl">maart</value>
+        <value lang="fr-fr">mars</value>
     </translation>
     <translation key="April">
         <comment>Dates: April</comment>
@@ -842,6 +987,7 @@
         <value lang="fr-ch">Avril</value>
         <value lang="it-ch">Marzo</value>
         <value lang="nl-nl">april</value>
+        <value lang="fr-fr">avril</value>
     </translation>
     <translation key="May">
         <comment>Dates: May</comment>
@@ -850,6 +996,7 @@
         <value lang="fr-ch">Mai</value>
         <value lang="it-ch">Maggio</value>
         <value lang="nl-nl">mei</value>
+        <value lang="fr-fr">mai</value>
     </translation>
     <translation key="June">
         <comment>Dates: June</comment>
@@ -858,6 +1005,7 @@
         <value lang="fr-ch">Juin</value>
         <value lang="it-ch">Giugno</value>
         <value lang="nl-nl">juni</value>
+        <value lang="fr-fr">juin</value>
     </translation>
     <translation key="July">
         <comment>Dates: July</comment>
@@ -866,6 +1014,7 @@
         <value lang="fr-ch">Juillet</value>
         <value lang="it-ch">Luglio</value>
         <value lang="nl-nl">juli</value>
+        <value lang="fr-fr">juillet</value>
     </translation>
     <translation key="August">
         <comment>Dates: August</comment>
@@ -873,6 +1022,7 @@
         <value lang="fr-ch">Août</value>
         <value lang="it-ch">Agosto</value>
         <value lang="nl-nl">augustus</value>
+        <value lang="fr-fr">août</value>
     </translation>
     <translation key="September">
         <comment>Dates: September</comment>
@@ -880,6 +1030,7 @@
         <value lang="fr-ch">Septembre</value>
         <value lang="it-ch">Settembre</value>
         <value lang="nl-nl">september</value>
+        <value lang="fr-fr">septembre</value>
     </translation>
     <translation key="October">
         <comment>Dates: October</comment>
@@ -888,6 +1039,7 @@
         <value lang="fr-ch">Octobre</value>
         <value lang="it-ch">Ottobre</value>
         <value lang="nl-nl">oktober</value>
+        <value lang="fr-fr">octobre</value>
     </translation>
     <translation key="November">
         <comment>Dates: November</comment>
@@ -895,6 +1047,7 @@
         <value lang="fr-ch">Novembre</value>
         <value lang="it-ch">Novembre</value>
         <value lang="nl-nl">november</value>
+        <value lang="fr-fr">novembre</value>
     </translation>
     <translation key="December">
         <comment>Dates: December</comment>
@@ -903,210 +1056,251 @@
         <value lang="fr-ch">Décembre</value>
         <value lang="it-ch">Dicembre</value>
         <value lang="nl-nl">december</value>
+        <value lang="fr-fr">décembre</value>
     </translation>
     <translation key="Monday">
         <comment>Dates: Monday</comment>
         <value lang="en-us">Monday</value>
         <value lang="nl-nl">maandag</value>
+        <value lang="fr-fr">lundi</value>
     </translation>
     <translation key="Tuesday">
         <comment>Dates: Tuesday</comment>
         <value lang="en-us">Tuesday</value>
         <value lang="nl-nl">dinsdag</value>
+        <value lang="fr-fr">mardi</value>
     </translation>
     <translation key="Wednesday">
         <comment>Dates: Wednesday</comment>
         <value lang="en-us">Wednesday</value>
         <value lang="nl-nl">woensdag</value>
+        <value lang="fr-fr">mercredi</value>
     </translation>
     <translation key="Thursday">
         <comment>Dates: Thursday</comment>
         <value lang="en-us">Thursday</value>
         <value lang="nl-nl">donderdag</value>
+        <value lang="fr-fr">jeudi</value>
     </translation>
     <translation key="Friday">
         <comment>Dates: Friday</comment>
         <value lang="en-us">Friday</value>
         <value lang="nl-nl">vrijdag</value>
+        <value lang="fr-fr">vendredi</value>
     </translation>
     <translation key="Saturday">
         <comment>Dates: Saturday</comment>
         <value lang="en-us">Saturday</value>
         <value lang="nl-nl">zaterdag</value>
+        <value lang="fr-fr">samedi</value>
     </translation>
     <translation key="Sunday">
         <comment>Dates: Sunday</comment>
         <value lang="en-us">Sunday</value>
         <value lang="nl-nl">zondag</value>
+        <value lang="fr-fr">dimanche</value>
     </translation>
     <translation key="dowMon">
         <comment>Dates: Monday (short)</comment>
         <value lang="en-us">Mon</value>
         <value lang="nl-nl">maa</value>
+        <value lang="fr-fr">lun</value>
     </translation>
     <translation key="dowTue">
         <comment>Dates: Tuesday (short)</comment>
         <value lang="en-us">Tue</value>
         <value lang="nl-nl">din</value>
+        <value lang="fr-fr">mar</value>
     </translation>
     <translation key="dowWed">
         <comment>Dates: Wednesday (short)</comment>
         <value lang="en-us">Wed</value>
         <value lang="nl-nl">woe</value>
+        <value lang="fr-fr">mer</value>
     </translation>
     <translation key="dowThu">
         <comment>Dates: Thursday (short)</comment>
         <value lang="en-us">Thu</value>
         <value lang="nl-nl">don</value>
+        <value lang="fr-fr">jeu</value>
     </translation>
     <translation key="Fri">
         <comment>Dates: Friday (short)</comment>
         <value lang="en-us">Fri</value>
         <value lang="nl-nl">vri</value>
+        <value lang="fr-fr">ven</value>
     </translation>
     <translation key="Sat">
         <comment>Dates: Saturday (short)</comment>
         <value lang="en-us">Sat</value>
         <value lang="nl-nl">zat</value>
+        <value lang="fr-fr">sam</value>
     </translation>
     <translation key="Sun">
         <comment>Dates: Sunday (short)</comment>
         <value lang="en-us">Sun</value>
         <value lang="nl-nl">zon</value>
+        <value lang="fr-fr">dim</value>
     </translation>
     <translation key="h">
         <comment>Time: h for hours in 14h in English or 14u in Dutch</comment>
         <value lang="en-us">h</value>
         <value lang="nl-nl">u</value>
+        <value lang="fr-fr">h</value>
     </translation>
     <translation key="Electronically_generated_by">
         <comment>Label: Electronically generated by</comment>
         <value lang="en-us">Electronically generated by</value>
         <value lang="nl-nl">Elektronisch gegenereerd door</value>
+        <value lang="fr-fr">généré électroniquement par</value>
     </translation>
     <translation key="Cannot_display_the_text">
         <comment>Label: Cannot display the text</comment>
         <value lang="en-us">Cannot display the text</value>
         <value lang="nl-nl">Kan tekst niet weergeven</value>
+        <value lang="fr-fr">Impossible d'afficher le texte</value>
     </translation>
     <translation key="Coded_Entries">
         <comment>Label: Coded Entries</comment>
         <value lang="en-us">Coded Entries</value>
         <value lang="nl-nl">Gecodeerde onderdelen</value>
+        <value lang="fr-fr">Entrées codées</value>
     </translation>
     <translation key="displayname">
         <comment>Label: displayname</comment>
         <value lang="en-us">Displayname</value>
         <value lang="nl-nl">Weergavenaam</value>
+        <value lang="fr-fr">Libellé</value>
     </translation>
     <translation key="qualifier">
         <comment>Label: qualifier</comment>
         <value lang="en-us">qualifier</value>
+        <value lang="fr-fr">qualifier</value>
     </translation>
     <translation key="Name">
         <comment>Label: value</comment>
         <value lang="en-us">value</value>
         <value lang="nl-nl">waarde</value>
+        <value lang="fr-fr">valeur</value>
     </translation>
     <translation key="Value">
         <comment>Label: Value</comment>
         <value lang="en-us">Value</value>
         <value lang="nl-nl">Waarde</value>
+        <value lang="fr-fr">valeur</value>
     </translation>
     <translation key="Quantity">
         <comment>Label: Quantity</comment>
         <value lang="en-us">Quantity</value>
         <value lang="nl-nl">Hoeveelheid</value>
+        <value lang="fr-fr">quantité</value>
     </translation>
     <translation key="Unit">
         <comment>Label: Unit</comment>
         <value lang="en-us">Unit</value>
         <value lang="nl-nl">Eenheid</value>
+        <value lang="fr-fr">Unité</value>
     </translation>
     <translation key="Units">
         <comment>Label: Units</comment>
         <value lang="en-us">Units</value>
         <value lang="nl-nl">Eenheden</value>
+        <value lang="fr-fr">Unités</value>
     </translation>
     <translation key="unit">
         <comment>Label: unit</comment>
         <value lang="en-us">unit</value>
         <value lang="nl-nl">eenheid</value>
+        <value lang="fr-fr">unité</value>
     </translation>
     <translation key="units">
         <comment>Label: units</comment>
         <value lang="en-us">units</value>
         <value lang="nl-nl">eenheden</value>
+        <value lang="fr-fr">unités</value>
     </translation>
     <translation key="per">
         <comment>Label: x units per y unit</comment>
         <value lang="en-us">per</value>
         <value lang="nl-nl">per</value>
+        <value lang="fr-fr">par</value>
     </translation>
     <translation key="Reference">
         <comment>Label: Reference</comment>
         <value lang="en-us">Reference</value>
         <value lang="nl-nl">Verwijzing</value>
+        <value lang="fr-fr">Référence</value>
     </translation>
     <translation key="Status">
         <comment>Status</comment>
         <value lang="en-us">Status</value>
+        <value lang="fr-fr">Statut</value>
     </translation>
     <translation key="Time">
         <comment>Dates: Time</comment>
         <value lang="en-us">Time</value>
         <value lang="de-ch">Zeit</value>
         <value lang="nl-nl">Tijd</value>
+        <value lang="fr-fr">Heure</value>
     </translation>
     <translation key="from">
         <comment>Dates: from (as in from/to)</comment>
         <value lang="en-us">from</value>
         <value lang="de-ch">von</value>
         <value lang="nl-nl">van</value>
+        <value lang="fr-fr">du</value>
     </translation>
     <translation key="From">
         <comment>Dates: From (as in from/to)</comment>
         <value lang="en-us">From</value>
         <value lang="de-ch">Von</value>
         <value lang="nl-nl">Van</value>
+        <value lang="fr-fr">Du</value>
     </translation>
     <translation key="FromNoTo">
         <comment>Dates: From (as in from without to)</comment>
         <value lang="en-us">From</value>
         <value lang="de-ch">Von</value>
         <value lang="nl-nl">Vanaf</value>
+        <value lang="fr-fr">Du</value>
     </translation>
     <translation key="to">
         <comment>Dates: to (as in from/to)</comment>
         <value lang="en-us">to</value>
         <value lang="de-ch">zu</value>
         <value lang="nl-nl">tot</value>
+        <value lang="fr-fr">au</value>
     </translation>
     <translation key="To">
         <comment>Dates: To (as in from/to)</comment>
         <value lang="en-us">To</value>
         <value lang="de-ch">Zu</value>
         <value lang="nl-nl">Tot</value>
+        <value lang="fr-fr">au</value>
     </translation>
     <translation key="Up To">
         <comment>Dates: Up To (as in from/to)</comment>
         <value lang="en-us">Up To</value>
         <value lang="nl-nl">tot</value>
+        <value lang="fr-fr">jusqu'à</value>
     </translation>
     <translation key="inclusive">
         <comment>Intervals @inclusive="true"</comment>
         <value lang="en-us">inclusive</value>
         <value lang="nl-nl">inclusief</value>
+        <value lang="fr-fr">compris</value>
     </translation>
     <translation key="for">
         <comment>Interval width: for (for 3 days)</comment>
         <value lang="en-us">for</value>
         <value lang="nl-nl">voor</value>
+        <value lang="fr-fr">pour</value>
     </translation>
     <translation key="every">
         <comment>Interval: every (as every 6 hours)</comment>
         <value lang="en-us">every</value>
         <value lang="nl-nl">elke</value>
+        <value lang="fr-fr">tous les</value>
     </translation>
     <translation key="NHS_Number">
         <comment>Label: NHS Number</comment>
@@ -1117,11 +1311,13 @@
         <comment>Label: Document Created</comment>
         <value lang="en-us">Document Created</value>
         <value lang="nl-nl">Aanmaakdatum</value>
+        <value lang="fr-fr">Document créé</value>
     </translation>
     <translation key="Document_Owner">
         <comment>Label: Document Owner</comment>
         <value lang="en-us">Document Owner</value>
         <value lang="nl-nl">Eigenaar</value>
+        <value lang="fr-fr">Propriétaire du document</value>
     </translation>
     <translation key="on">
         <comment>Dates: on</comment>
@@ -1130,6 +1326,7 @@
         <value lang="fr-ch">le</value>
         <value lang="it-ch">il</value>
         <value lang="nl-nl">op</value>
+        <value lang="fr-fr">sur</value>
     </translation>
     <translation key="On">
         <comment>Dates: On (on August 2)</comment>
@@ -1138,6 +1335,7 @@
         <value lang="fr-ch">Le</value>
         <value lang="it-ch">Il</value>
         <value lang="nl-nl">Op</value>
+        <value lang="fr-fr">le</value>
     </translation>
     <translation key="at">
         <comment>Dates: at</comment>
@@ -1146,6 +1344,7 @@
         <value lang="fr-ch">le</value>
         <value lang="it-ch">il</value>
         <value lang="nl-nl">op</value>
+        <value lang="fr-fr">le</value>
     </translation>
     <translation key="At">
         <comment>Dates: At (as in At 7PM)</comment>
@@ -1154,57 +1353,68 @@
         <value lang="fr-ch">Le</value>
         <value lang="it-ch">Il</value>
         <value lang="nl-nl">Op</value>
+        <value lang="fr-fr">à</value>
     </translation>
     <translation key="Period">
         <comment>Dates: Period (IVL_TS)</comment>
         <value lang="en-us">Period</value>
         <value lang="de-ch">Periode</value>
         <value lang="nl-nl">Periode</value>
+        <value lang="fr-fr">Période</value>
     </translation>
     <translation key="Encounter_Type">
         <comment>Label: Encounter Type</comment>
         <value lang="en-us">Encounter Type</value>
         <value lang="nl-nl">Type contact</value>
+        <value lang="fr-fr">Type de prise en charge</value>
     </translation>
     <translation key="Encounter_Time">
         <comment>Label: Encounter Time</comment>
         <value lang="en-us">Encounter Time</value>
         <value lang="nl-nl">Datum/tijd contact</value>
+        <value lang="fr-fr">Heure de prise en charge</value>
     </translation>
     <translation key="Care_Setting_Type">
         <comment>Label: Care Setting Type</comment>
         <value lang="en-us">Care Setting Type</value>
         <value lang="nl-nl">Type zorginstelling</value>
+        <value lang="fr-fr">Type de structure de soins</value>
     </translation>
     <translation key="Recipient">
         <comment>Label: Recipient</comment>
         <value lang="en-us">Recipient</value>
         <value lang="nl-nl">Ontvanger</value>
+        <value lang="fr-fr">Destinataire</value>
     </translation>
     <translation key="Referrer">
         <comment>Label: Referrer</comment>
         <value lang="en-us">Referrer</value>
         <value lang="nl-nl">Verwijzer</value>
+        <value lang="fr-fr">Référent</value>
     </translation>
     <translation key="Referring Organization">
         <comment>Label: Referring Organization</comment>
         <value lang="en-us">Referring Organization</value>
         <value lang="nl-nl">Verwijzende organisatie</value>
+        <value lang="fr-fr">Organisation référente</value>
     </translation>
     <translation key="Service Provider">
         <comment>Label: Service Provider</comment>
         <value lang="en-us">Service Provider</value>
         <value lang="nl-nl">Zorgaanbieder</value>
+        <value lang="fr-fr">Fournisseur de services</value>
     </translation>
     <translation key="Document_ID">
         <comment>Label: Document ID</comment>
         <value lang="en-us">Document ID</value>
         <value lang="nl-nl">Document-id</value>
+        <value lang="fr-fr">Id du document</value>
     </translation>
     <translation key="Version">
         <comment>Label: Version</comment>
         <value lang="en-us">Version</value>
         <value lang="nl-nl">Versie</value>
+        <value lang="fr-fr">Version</value>
     </translation>
     <translation key="Primary_Recipient">
         <comment>Label: Primary Recipient</comment>
@@ -1213,6 +1423,7 @@
         <value lang="fr-ch">Destinataire</value>
         <value lang="it-ch">Destinatario</value>
         <value lang="nl-nl">Ontvanger</value>
+        <value lang="fr-fr">Destinataire principal</value>
     </translation>
     <translation key="Primary_Recipients">
         <comment>Label: Primary Recipients</comment>
@@ -1221,6 +1432,7 @@
         <value lang="fr-ch">Destinataires</value>
         <value lang="it-ch">Destinatario</value>
         <value lang="nl-nl">Ontvangers</value>
+        <value lang="fr-fr">Destinataires principaux</value>
     </translation>
     <translation key="Copy_Recipient">
         <comment>Label: Copy Recipient</comment>
@@ -1229,6 +1441,7 @@
         <value lang="fr-ch">Copie à</value>
         <value lang="it-ch">In copia a</value>
         <value lang="nl-nl">Kopie naar</value>
+        <value lang="fr-fr">Copie à</value>
     </translation>
     <translation key="Copy_Recipients">
         <comment>Label: Copy Recipients</comment>
@@ -1237,93 +1450,112 @@
         <value lang="fr-ch">Copie à</value>
         <value lang="it-ch">In copia a</value>
         <value lang="nl-nl">Kopie naar</value>
+        <value lang="fr-fr">Copie à</value>
     </translation>
     <translation key="Tel">
         <comment>Label: Tel (telecom type)</comment>
         <value lang="en-us">Tel</value>
+        <value lang="fr-fr">Tel</value>
     </translation>
     <translation key="Fax">
         <comment>Label: Fax (telecom type)</comment>
         <value lang="en-us">Fax</value>
+        <value lang="fr-fr">Fax</value>
     </translation>
     <translation key="Email">
         <comment>Label: Email (telecom type)</comment>
         <value lang="en-us">Email</value>
         <value lang="de-ch">Mail</value>
         <value lang="nl-nl">E-mail</value>
+        <value lang="fr-fr">Courriel</value>
     </translation>
     <translation key="Web">
         <comment>Label: Web (telecom type)</comment>
         <value lang="en-us">Web</value>
+        <value lang="fr-fr">site internet</value>
     </translation>
     <translation key="Contact_details">
         <comment>Label: Contact details</comment>
         <value lang="en-us">Contact Details</value>
         <value lang="nl-nl">Contactgegevens</value>
+        <value lang="fr-fr">Contact</value>
     </translation>
     <translation key="Diagnostic Radiology">
         <comment>Label: Diagnostic Radiology</comment>
         <value lang="en-us">Diagnostic Radiology</value>
         <value lang="nl-nl">Diagnostische radiologie</value>
+        <value lang="fr-fr">Radiologie diagnostique</value>
     </translation>
     <translation key="Consultant">
         <comment>Label: Consultant</comment>
         <value lang="en-us">Consultant</value>
+        <value lang="fr-fr">Consultant</value>
     </translation>
     <translation key="Cannot display the text">
         <comment>Label: Cannot display the text</comment>
         <value lang="en-us">Cannot display the text</value>
         <value lang="nl-nl">Kan de tekst niet weergeven</value>
+        <value lang="fr-fr">Impossible d'afficher le texte</value>
     </translation>
     <translation key="Facility ID">
         <comment>Label: Facility ID</comment>
         <value lang="en-us">Facility ID</value>
         <value lang="nl-nl">Lokatie-id</value>
+        <value lang="fr-fr">Id de l'établissement</value>
     </translation>
     <translation key="Not available">
         <comment>Label: Not available</comment>
         <value lang="en-us">Not available</value>
         <value lang="nl-nl">Niet beschikbaar</value>
+        <value lang="fr-fr">Pas disponible</value>
     </translation>
     <translation key="First day of period reported">
         <comment>Label: First day of period reported</comment>
         <value lang="en-us">First day of period reported</value>
         <value lang="nl-nl">Eerste dag van verslagperiode</value>
+        <value lang="fr-fr">Premier jour de la période déclarée</value>
     </translation>
     <translation key="Last day of period reported">
         <comment>Label: Last day of period reported</comment>
         <value lang="en-us">Last day of period reported</value>
         <value lang="nl-nl">Laatste dag van verslagperiode</value>
+        <value lang="fr-fr">Dernier jour de la période déclarée</value>
     </translation>
     <translation key="Footnote">
         <comment>Label: Footnote</comment>
         <value lang="en-us">Footnote</value>
         <value lang="nl-nl">Voetnoot</value>
+        <value lang="fr-fr">Note de bas de page</value>
     </translation>
     <translation key="Information not available">
         <comment>Label: Information not available</comment>
         <value lang="en-us">Information not available</value>
         <value lang="nl-nl">Informatie niet beschikbaar</value>
+        <value lang="fr-fr">Information non disponible</value>
     </translation>
     <translation key="Race">
         <comment>Label: Race</comment>
         <value lang="en-us">Race</value>
         <value lang="nl-nl">Ras</value>
+        <value lang="fr-fr">Race</value>
     </translation>
     <translation key="doseQuantity">
         <comment>Label: Dose Quantity</comment>
         <value lang="en-us">Dose Quantity</value>
         <value lang="nl-nl">Dosering</value>
+        <value lang="fr-fr">Dose</value>
     </translation>
     <translation key="maxDoseQuantity">
         <comment>Label: Max Dose Quantity</comment>
         <value lang="en-us">Max Dose Quantity</value>
         <value lang="nl-nl">Max dosering</value>
+        <value lang="fr-fr">Dose maximale</value>
     </translation>
     <translation key="rateQuantity">
         <comment>Label: Rate Quantity</comment>
         <value lang="en-us">Rate Quantity</value>
         <value lang="nl-nl">Doseerverhouding</value>
+        <value lang="fr-fr">Dosage</value>
     </translation>
     <!-- End: Miscellaneous -->
     <!-- Start: voc -->
@@ -1334,6 +1566,7 @@
         <value lang="fr-ch">Masculin</value>
         <value lang="it-ch">Maschile</value>
         <value lang="nl-nl">Man</value>
+        <value lang="fr-fr">Masculin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1-F">
         <comment>Label: AdministrativeGender: Female</comment>
@@ -1342,296 +1575,358 @@
         <value lang="fr-ch">Féminin</value>
         <value lang="it-ch">Femminile</value>
         <value lang="nl-nl">Vrouw</value>
+        <value lang="fr-fr">Féminin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1-UN">
         <comment>Label: AdministrativeGender: Undifferentiated</comment>
         <value lang="en-us">Undifferentiated</value>
         <value lang="nl-nl">Ongedifferentieerd</value>
+        <value lang="fr-fr">Sexe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-AMB">
         <comment>Label: ActCode: ActEncounterCode: Ambulatory</comment>
         <value lang="en-us">ambulatory</value>
         <value lang="nl-nl">ambulant</value>
+        <value lang="fr-fr">Ambulatoire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-EMER">
         <comment>Label: ActCode: ActEncounterCode: Emergency</comment>
         <value lang="en-us">emergency</value>
         <value lang="nl-nl">noodgeval</value>
+        <value lang="fr-fr">Urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-FLD">
         <comment>Label: ActCode: ActEncounterCode: Field</comment>
         <value lang="en-us">field</value>
         <value lang="nl-nl">buiten</value>
+        <value lang="fr-fr">Sur le terrain (hors structure de soins et domicile du patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-HH">
         <comment>Label: ActCode: ActEncounterCode: Home Health</comment>
         <value lang="en-us">home health</value>
         <value lang="nl-nl">thuiszorg</value>
+        <value lang="fr-fr">A domicile</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-IMP">
         <comment>Label: ActCode: ActEncounterCode: Inpatient</comment>
         <value lang="en-us">inpatient</value>
         <value lang="nl-nl">klinisch</value>
+        <value lang="fr-fr">Hospitalisation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-ACUTE">
         <comment>Label: ActCode: ActEncounterCode: Acute</comment>
         <value lang="en-us">acute</value>
         <value lang="nl-nl">spoed</value>
+        <value lang="fr-fr">aigu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-NONAC">
         <comment>Label: ActCode: ActEncounterCode: Inpatient non-acute</comment>
         <value lang="en-us">inpatient non-acute</value>
         <value lang="nl-nl">klinisch niet-acuut</value>
+        <value lang="fr-fr">Hospitalisation non aigue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-SS">
         <comment>Label: ActCode: ActEncounterCode: Short stay</comment>
         <value lang="en-us">short stay</value>
         <value lang="nl-nl">dagbehandeling</value>
+        <value lang="fr-fr">Court séjour</value>
     </translation>
     <translation key="2.16.840.1.113883.5.4-VR">
         <comment>Label: ActCode: ActEncounterCode: Virtual</comment>
         <value lang="en-us">virtual</value>
         <value lang="nl-nl">virtueel</value>
+        <value lang="fr-fr">Virtuel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACT">
         <comment>Label: ActClass act</comment>
         <value lang="en-us">act</value>
+        <value lang="fr-fr">acte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACCM">
         <comment>Label: ActClass accommodation</comment>
         <value lang="en-us">accommodation</value>
         <value lang="nl-nl">accommodatie</value>
+        <value lang="fr-fr">hébergement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACCT">
         <comment>Label: ActClass account</comment>
         <value lang="en-us">account</value>
+        <value lang="fr-fr">compte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACSN">
         <comment>Label: ActClass accession</comment>
         <value lang="en-us">accession</value>
         <value lang="nl-nl">accessie</value>
+        <value lang="fr-fr">accès</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ADJUD">
         <comment>Label: ActClass financial adjudication</comment>
         <value lang="en-us">financial adjudication</value>
         <value lang="nl-nl">financiële adjudicatie</value>
+        <value lang="fr-fr">arbitrage financier</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CACT">
         <comment>Label: ActClass control act</comment>
         <value lang="en-us">control act</value>
+        <value lang="fr-fr">acte de contrôle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ACTN">
         <comment>Label: ActClass action</comment>
         <value lang="en-us">action</value>
         <value lang="nl-nl">actie</value>
+        <value lang="fr-fr">action</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-INFO">
         <comment>Label: ActClass information</comment>
         <value lang="en-us">information</value>
         <value lang="nl-nl">informatie</value>
+        <value lang="fr-fr">information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-STC">
         <comment>Label: ActClass state transition control</comment>
         <value lang="en-us">state transition control</value>
         <value lang="nl-nl">statusovergang control</value>
+        <value lang="fr-fr">contrôle de transition d'état</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CNTRCT">
         <comment>Label: ActClass contract</comment>
         <value lang="en-us">contract</value>
+        <value lang="fr-fr">contrat</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-FCNTRCT">
         <comment>Label: ActClass financial contract</comment>
         <value lang="en-us">financial contract</value>
         <value lang="nl-nl">financieel contract</value>
+        <value lang="fr-fr">contrat financier</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-COV">
         <comment>Label: ActClass coverage</comment>
         <value lang="en-us">coverage</value>
         <value lang="nl-nl">verzekeringsdekking</value>
+        <value lang="fr-fr">couverture</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CONS">
         <comment>Label: ActClass consent</comment>
         <value lang="en-us">consent</value>
         <value lang="nl-nl">toestemming</value>
+        <value lang="fr-fr">consentement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CONTREG">
         <comment>Label: ActClass container registration</comment>
         <value lang="en-us">container registration</value>
         <value lang="nl-nl">containerregistratie</value>
+        <value lang="fr-fr">enregistrement des conteneurs</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CTTEVENT">
         <comment>Label: ActClass clinical trial timepoint event</comment>
         <value lang="en-us">clinical trial timepoint event</value>
+        <value lang="fr-fr">événement ponctuel d'essai clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DISPACT">
         <comment>Label: ActClass disciplinary action</comment>
         <value lang="en-us">disciplinary action</value>
         <value lang="nl-nl">disciplinaire maatregel</value>
+        <value lang="fr-fr">mesures disciplinaires</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-EXPOS">
         <comment>Label: ActClass exposure</comment>
         <value lang="en-us">exposure</value>
         <value lang="nl-nl">blootstelling</value>
+        <value lang="fr-fr">exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-AEXPOS">
         <comment>Label: ActClass acquisition exposure</comment>
         <value lang="en-us">acquisition exposure</value>
         <value lang="nl-nl">acquisitie blootstelling</value>
+        <value lang="fr-fr">exposition à l'acquisition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TEXPOS">
         <comment>Label: ActClass transmission exposure</comment>
         <value lang="en-us">transmission exposure</value>
         <value lang="nl-nl">overdracht blootstelling</value>
+        <value lang="fr-fr">transfert d'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-INC">
         <comment>Label: ActClass incident</comment>
         <value lang="en-us">incident</value>
+        <value lang="fr-fr">incident</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-INFRM">
         <comment>Label: ActClass inform</comment>
         <value lang="en-us">inform</value>
         <value lang="nl-nl">informeren</value>
+        <value lang="fr-fr">informer</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-INVE">
         <comment>Label: ActClass invoice element</comment>
         <value lang="en-us">invoice element</value>
+        <value lang="fr-fr">élément de facture</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-LIST">
         <comment>Label: ActClass working list</comment>
         <value lang="en-us">working list</value>
         <value lang="nl-nl">werklijst</value>
+        <value lang="fr-fr">liste de travail</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-MPROT">
         <comment>Label: ActClass monitoring program</comment>
         <value lang="en-us">monitoring program</value>
         <value lang="nl-nl">monitoring programma</value>
+        <value lang="fr-fr">programme de surveillance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-OBS">
         <comment>Label: ActClass observation</comment>
         <value lang="en-us">observation</value>
         <value lang="nl-nl">observatie</value>
+        <value lang="fr-fr">observation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ALRT">
         <comment>Label: ActClass detected issue</comment>
         <value lang="en-us">detected issue</value>
         <value lang="nl-nl">gedetecteerd probleem</value>
+        <value lang="fr-fr">problème détecté</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-BATTERY">
         <comment>Label: ActClass battery</comment>
         <value lang="en-us">battery</value>
         <value lang="nl-nl">batterij</value>
+        <value lang="fr-fr">batterie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CLNTRL">
         <comment>Label: ActClass clinical trial</comment>
         <value lang="en-us">clinical trial</value>
+        <value lang="fr-fr">essai clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CNOD">
         <comment>Label: ActClass Condition Node</comment>
         <value lang="en-us">Condition Node</value>
         <value lang="nl-nl">Conditienode</value>
+        <value lang="fr-fr">Condition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CONC">
         <comment>Label: ActClass concern</comment>
         <value lang="en-us">concern</value>
         <value lang="nl-nl">aandachtspunt</value>
+        <value lang="fr-fr">préoccupation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-COND">
         <comment>Label: ActClass Condition</comment>
         <value lang="en-us">Condition</value>
         <value lang="nl-nl">Conditie</value>
+        <value lang="fr-fr">préoccupation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CASE">
         <comment>Label: ActClass public health case</comment>
         <value lang="en-us">public health case</value>
         <value lang="nl-nl">volksgezondheidsgeval</value>
+        <value lang="fr-fr">cas de santé publique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-OUTB">
         <comment>Label: ActClass outbreak</comment>
         <value lang="en-us">outbreak</value>
         <value lang="nl-nl">uitbraak</value>
+        <value lang="fr-fr">épidémie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DGIMG">
         <comment>Label: ActClass diagnostic image</comment>
         <value lang="en-us">diagnostic image</value>
         <value lang="nl-nl">diagnostiekbeeld</value>
+        <value lang="fr-fr">image diagnostique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-GEN">
         <comment>Label: ActClass genomic observation</comment>
         <value lang="en-us">genomic observation</value>
         <value lang="nl-nl">genetische observatie</value>
+        <value lang="fr-fr">observation génomique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DETPOL">
         <comment>Label: ActClass determinant peptide</comment>
         <value lang="en-us">determinant peptide</value>
+        <value lang="fr-fr">peptide déterminant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-EXP">
         <comment>Label: ActClass expression level</comment>
         <value lang="en-us">expression level</value>
         <value lang="nl-nl">uitdrukkingsniveau</value>
+        <value lang="fr-fr">niveau d'expression</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-LOC">
         <comment>Label: ActClass locus</comment>
         <value lang="en-us">locus</value>
+        <value lang="fr-fr">lieu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PHN">
         <comment>Label: ActClass phenotype</comment>
         <value lang="en-us">phenotype</value>
         <value lang="nl-nl">fenotype</value>
+        <value lang="fr-fr">phénotype</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-POL">
         <comment>Label: ActClass polypeptide</comment>
         <value lang="en-us">polypeptide</value>
+        <value lang="fr-fr">polypeptide</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SEQ">
         <comment>Label: ActClass bio sequence</comment>
         <value lang="en-us">bio sequence</value>
+        <value lang="fr-fr">séquence biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SEQVAR">
         <comment>Label: ActClass bio sequence variation</comment>
         <value lang="en-us">bio sequence variation</value>
         <value lang="nl-nl">bio sequence variatia</value>
+        <value lang="fr-fr">variation de séquence biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-INVSTG">
         <comment>Label: ActClass investigation</comment>
         <value lang="en-us">investigation</value>
         <value lang="nl-nl">onderzoek</value>
+        <value lang="fr-fr">recherche</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-OBSSER">
         <comment>Label: ActClass observation series</comment>
         <value lang="en-us">observation series</value>
         <value lang="nl-nl">observatieserie</value>
+        <value lang="fr-fr">séries d'observations</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-OBSCOR">
         <comment>Label: ActClass correlated observation sequences</comment>
         <value lang="en-us">correlated observation sequences</value>
         <value lang="nl-nl">gecorreleerde observatie sequenties</value>
+        <value lang="fr-fr">séquences d'observation corrélées</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-POS">
         <comment>Label: ActClass position</comment>
         <value lang="en-us">position</value>
         <value lang="nl-nl">positie</value>
+        <value lang="fr-fr">position</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-POSACC">
         <comment>Label: ActClass position accuracy</comment>
         <value lang="en-us">position accuracy</value>
+        <value lang="fr-fr">précision de position</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-POSCOORD">
         <comment>Label: ActClass position coordinate</comment>
         <value lang="en-us">position coordinate</value>
+        <value lang="fr-fr">coordonnée de position</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SPCOBS">
         <comment>Label: ActClass specimen observationActClassSpecObs </comment>
         <value lang="en-us">specimen observationActClassSpecObs </value>
+        <value lang="fr-fr">classe d'acte d'observation d'échantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-VERIF">
         <comment>Label: ActClass Verification</comment>
         <value lang="en-us">Verification</value>
         <value lang="nl-nl">Verificatie</value>
+        <value lang="fr-fr">Vérification</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ROIBND">
         <comment>Label: ActClass bounded ROI</comment>
         <value lang="en-us">bounded ROI</value>
         <value lang="nl-nl">vaste ROI</value>
+        <value lang="fr-fr">retour sur investissement limité</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ROIOVL">
         <comment>Label: ActClass overlay ROI</comment>
@@ -1642,6 +1937,7 @@
         <comment>Label: ActClass left lateral decubitus</comment>
         <value lang="en-us">left lateral decubitus</value>
         <value lang="nl-nl">linker laterale decubitus</value>
+        <value lang="fr-fr">décubitus latéral gauche</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PRN">
         <comment>Label: ActClass prone</comment>
@@ -1651,6 +1947,7 @@
         <comment>Label: ActClass right lateral decubitus</comment>
         <value lang="en-us">right lateral decubitus</value>
         <value lang="nl-nl">rechter laterale decubitus</value>
+        <value lang="fr-fr">décubitus latéral droit</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SFWL">
         <comment>Label: ActClass Semi-Fowler's</comment>
@@ -1660,145 +1957,175 @@
         <comment>Label: ActClass sitting</comment>
         <value lang="en-us">sitting</value>
         <value lang="nl-nl">zittend</value>
+        <value lang="fr-fr">séance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-STN">
         <comment>Label: ActClass standing</comment>
         <value lang="en-us">standing</value>
         <value lang="nl-nl">staand</value>
+        <value lang="fr-fr">debout</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SUP">
         <comment>Label: ActClass supine</comment>
         <value lang="en-us">supine</value>
+        <value lang="fr-fr">couché</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-RTRD">
         <comment>Label: ActClass reverse trendelenburg</comment>
         <value lang="en-us">reverse trendelenburg</value>
         <value lang="nl-nl">omgekeerde trendelenburg</value>
+        <value lang="fr-fr">Trendelenburg inversé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TRD">
         <comment>Label: ActClass trendelenburg</comment>
         <value lang="en-us">trendelenburg</value>
+        <value lang="fr-fr">Trendelenburg</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PCPR">
         <comment>Label: ActClass care provision</comment>
         <value lang="en-us">care provision</value>
+        <value lang="fr-fr">prestation de soins</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ENC">
         <comment>Label: ActClass encounter</comment>
         <value lang="en-us">encounter</value>
         <value lang="nl-nl">bezoek</value>
+        <value lang="fr-fr">prise en charge</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-POLICY">
         <comment>Label: ActClass policy</comment>
         <value lang="en-us">policy</value>
+        <value lang="fr-fr">politique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-JURISPOL">
         <comment>Label: ActClass jurisdictional policy</comment>
         <value lang="en-us">jurisdictional policy</value>
         <value lang="nl-nl">juridische policy</value>
+        <value lang="fr-fr">politique juridictionnelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-ORGPOL">
         <comment>Label: ActClass organizational policy</comment>
         <value lang="en-us">organizational policy</value>
         <value lang="nl-nl">organisatie policy</value>
+        <value lang="fr-fr">politique organisationnelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SCOPOL">
         <comment>Label: ActClass scope of practice policy</comment>
         <value lang="en-us">scope of practice policy</value>
         <value lang="nl-nl">behandelpolicy</value>
+        <value lang="fr-fr">politique d'exercice</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-STDPOL">
         <comment>Label: ActClass standard of practice policy</comment>
         <value lang="en-us">standard of practice policy</value>
         <value lang="nl-nl">standaard behandelpolicy</value>
+        <value lang="fr-fr">politique sur les standards d'exercice</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-PROC">
         <comment>Label: ActClass procedure</comment>
         <value lang="en-us">procedure</value>
         <value lang="nl-nl">verrichting</value>
+        <value lang="fr-fr">opération chirurgicale</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SBADM">
         <comment>Label: ActClass substance administration</comment>
         <value lang="en-us">substance administration</value>
         <value lang="nl-nl">substantie toediening</value>
+        <value lang="fr-fr">administration de produit</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SBEXT">
         <comment>Label: ActClass Substance Extraction</comment>
         <value lang="en-us">Substance Extraction</value>
         <value lang="nl-nl">substantie extractie</value>
+        <value lang="fr-fr">Extraction de substance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SPECCOLLECT">
         <comment>Label: ActClass Specimen Collection</comment>
         <value lang="en-us">Specimen Collection</value>
         <value lang="nl-nl">Monster collectie</value>
+        <value lang="fr-fr">Prélèvement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-REG">
         <comment>Label: ActClass registration</comment>
         <value lang="en-us">registration</value>
         <value lang="nl-nl">registratie</value>
+        <value lang="fr-fr">enregistrement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-REV">
         <comment>Label: ActClass review</comment>
         <value lang="en-us">review</value>
+        <value lang="fr-fr">revue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SPCTRT">
         <comment>Label: ActClass specimen treatment</comment>
         <value lang="en-us">specimen treatment</value>
         <value lang="nl-nl">monmster behandeling</value>
+        <value lang="fr-fr">traitement de l'échantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SPLY">
         <comment>Label: ActClass supply</comment>
         <value lang="en-us">supply</value>
         <value lang="nl-nl">middel</value>
+        <value lang="fr-fr">fourniture</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DIET">
         <comment>Label: ActClass diet</comment>
         <value lang="en-us">diet</value>
         <value lang="nl-nl">dieet</value>
+        <value lang="fr-fr">diète</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-STORE">
         <comment>Label: ActClass storage</comment>
         <value lang="en-us">storage</value>
         <value lang="nl-nl">opslag</value>
+        <value lang="fr-fr">stockage</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-SUBST">
         <comment>Label: ActClass Substitution</comment>
         <value lang="en-us">Substitution</value>
         <value lang="nl-nl">Substitutie</value>
+        <value lang="fr-fr">Substitution</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TRFR">
         <comment>Label: ActClass transfer</comment>
         <value lang="en-us">transfer</value>
         <value lang="nl-nl">overplaatsing</value>
+        <value lang="fr-fr">transfer</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TRNS">
         <comment>Label: ActClass transportation</comment>
         <value lang="en-us">transportation</value>
         <value lang="nl-nl">transport</value>
+        <value lang="fr-fr">transport</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-XACT">
         <comment>Label: ActClass financial transaction</comment>
         <value lang="en-us">financial transaction</value>
         <value lang="nl-nl">financiële transactie</value>
+        <value lang="fr-fr">transaction financière</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-COMPOSITION">
         <comment>Label: ActClass compositionAttestable unit </comment>
         <value lang="en-us">composition</value>
         <value lang="nl-nl">compositie</value>
+        <value lang="fr-fr">composition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DOC">
         <comment>Label: ActClass document</comment>
         <value lang="en-us">document</value>
+        <value lang="fr-fr">document</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DOCCLIN">
         <comment>Label: ActClass clinical document</comment>
         <value lang="en-us">clinical document</value>
         <value lang="nl-nl">klinisch document</value>
+        <value lang="fr-fr">document de santé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CDALVLONE">
         <comment>Label: ActClass CDA Level One clinical document</comment>
         <value lang="en-us">CDA Level One clinical document</value>
         <value lang="nl-nl">CDA Level One klinisch document</value>
+        <value lang="fr-fr">document de santé CDA R2 niveau 1</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CONTAINER">
         <comment>Label: ActClass record container</comment>
@@ -1808,183 +2135,221 @@
         <comment>Label: ActClass category</comment>
         <value lang="en-us">category</value>
         <value lang="nl-nl">categorie</value>
+        <value lang="fr-fr">catégorie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DOCBODY">
         <comment>Label: ActClass document body</comment>
         <value lang="en-us">document body</value>
         <value lang="nl-nl">documentinhoud</value>
+        <value lang="fr-fr">corps du document</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-DOCSECT">
         <comment>Label: ActClass document sectionSection </comment>
         <value lang="en-us">document section</value>
         <value lang="nl-nl">documentsectie</value>
+        <value lang="fr-fr">section du document</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-TOPIC">
         <comment>Label: ActClass topic</comment>
         <value lang="en-us">topic</value>
         <value lang="nl-nl">onderwerp</value>
+        <value lang="fr-fr">sujet</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-EXTRACT">
         <comment>Label: ActClass extract</comment>
         <value lang="en-us">extract</value>
+        <value lang="fr-fr">extrait</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-EHR">
         <comment>Label: ActClass electronic health record</comment>
         <value lang="en-us">electronic health record</value>
         <value lang="nl-nl">electronisch gezondheidsdossier</value>
+        <value lang="fr-fr">dossier patient électronique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-FOLDER">
         <comment>Label: ActClass folder</comment>
         <value lang="en-us">folder</value>
         <value lang="nl-nl">map</value>
+        <value lang="fr-fr">dossier</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-GROUPER">
         <comment>Label: ActClass grouper</comment>
         <value lang="en-us">grouper</value>
         <value lang="nl-nl">groepering</value>
+        <value lang="fr-fr">groupe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-CLUSTER">
         <comment>Label: ActClass Cluster</comment>
         <value lang="en-us">cluster</value>
+        <value lang="fr-fr">regroupement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-CA">
         <comment>Label: OID AcknowledgementType CA</comment>
         <value lang="en-us">Commit Accept</value>
         <value lang="nl-nl">Technische bevestiging</value>
+        <value lang="fr-fr">Acceptation technique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-CE">
         <comment>Label: OID AcknowledgementType CE</comment>
         <value lang="en-us">Commit Error</value>
         <value lang="nl-nl">Technische fout</value>
+        <value lang="fr-fr">Erreur technique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-CR">
         <comment>Label: OID AcknowledgementType CR</comment>
         <value lang="en-us">Commit Reject</value>
         <value lang="nl-nl">Technische weigering</value>
+        <value lang="fr-fr">Rejet technique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-AA">
         <comment>Label: OID AcknowledgementType AA</comment>
         <value lang="en-us">Application Accept</value>
         <value lang="nl-nl">Applicatie bevestiging</value>
+        <value lang="fr-fr">Acceptation applicative</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-AE">
         <comment>Label: OID AcknowledgementType AE</comment>
         <value lang="en-us">Application Error</value>
         <value lang="nl-nl">Applicatie bevestiging</value>
+        <value lang="fr-fr">Erreur applicative</value>
     </translation>
     <translation key="2.16.840.1.113883.5.18-AR">
         <comment>Label: OID AcknowledgementType AR</comment>
         <value lang="en-us">Application Reject</value>
         <value lang="nl-nl">Applicatie weigering</value>
+        <value lang="fr-fr">Rejet applicatif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1082-W">
         <comment>Label: OID AcknowledgementDetail W</comment>
         <value lang="en-us">Warning</value>
         <value lang="en-us">Waarschuwing</value>
+        <value lang="fr-fr">Avertissement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1082-I">
         <comment>Label: OID AcknowledgementDetail I</comment>
         <value lang="en-us">Information</value>
         <value lang="nl-nl">Informatie</value>
+        <value lang="fr-fr">Information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1082-E">
         <comment>Label: OID AcknowledgementDetail E</comment>
         <value lang="en-us">Error</value>
         <value lang="nl-nl">Fout</value>
+        <value lang="fr-fr">Erreur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1067-AE">
         <comment>Label: QueryResponse AE</comment>
         <value lang="en-us">AE (Application error, query aborted)</value>
         <value lang="nl-nl">AE (Applicatie probleem, beantwoording afgebroken)</value>
+        <value lang="fr-fr">AE (Erreur applicative, requête annulée)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1067-NF">
         <comment>Label: QueryResponse NF</comment>
         <value lang="en-us">NF (Nothing found, no errors)</value>
         <value lang="nl-nl">NF (Niets gevonden, geen fouten)</value>
+        <value lang="fr-fr">NF (Rien n'a été trouvé, pas d'erreurs)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1067-OK">
         <comment>Label: QueryResponse OK</comment>
         <value lang="en-us">OK (Data found)</value>
         <value lang="nl-nl">OK (Data gevonden)</value>
+        <value lang="fr-fr">OK (Donnée trouvée)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1067-QE">
         <comment>Label: QueryResponse QE</comment>
         <value lang="en-us">QE (Query Parameter Error, query aborted)</value>
         <value lang="nl-nl">QE (Queryparameter fout, beantwoording afgebroken)</value>
+        <value lang="fr-fr">QE (Erreur de paramètre de requête, requête annulée)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.109-B">
         <comment>Label: OID ResponseModality-B</comment>
         <value lang="en-us">B (Batch)</value>
+        <value lang="fr-fr">B (Batch)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.109-R">
         <comment>Label: OID ResponseModality-R</comment>
         <value lang="en-us">R (Realtime)</value>
+        <value lang="fr-fr">R (Temps réel)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.109-T">
         <comment>Label: OID ResponseModality-T</comment>
         <value lang="en-us">T (Bolus)</value>
         <value lang="nl-nl">T (Bolus, niet gebruiken)</value>
+        <value lang="fr-fr">T (ne pas utiliser)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.102-D">
         <comment>Label: QueryPriority D</comment>
         <value lang="en-us">D (Deferred)</value>
+        <value lang="fr-fr">D (Différé)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.102-I">
         <comment>Label: QueryPriority I</comment>
         <value lang="en-us">I (Immediate)</value>
+        <value lang="fr-fr">I (Immédiat)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1112-RD">
         <comment>Label: QueryRequestLimit RD</comment>
         <value lang="en-us">RD (Records)</value>
+        <value lang="fr-fr">RD (Dossiers)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.25-N">
         <comment>Label: Confidentiality: Normal</comment>
         <value lang="en-us">Normal</value>
         <value lang="nl-nl">Normaal</value>
+        <value lang="fr-fr">Normal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.25-R">
         <comment>Label: Confidentiality: Restricted</comment>
         <value lang="en-us">Restricted</value>
         <value lang="nl-nl">Vertrouwelijk</value>
+        <value lang="fr-fr">Restreint</value>
     </translation>
     <translation key="2.16.840.1.113883.5.25-V">
         <comment>Label: Confidentiality: Very restricted</comment>
         <value lang="en-us">Very restricted</value>
         <value lang="nl-nl">Zeer vertrouwelijk</value>
+        <value lang="fr-fr">Très restreint</value>
     </translation>
     <translation key="nullFlavor_DER">
         <comment>Label: NullFlavor DER</comment>
         <value lang="en-us">derived</value>
         <value lang="nl-nl">afgeleid</value>
+        <value lang="fr-fr">valeur dérivée</value>
     </translation>
     <translation key="nullFlavor_OTH">
         <comment>Label: NullFlavor OTH</comment>
         <value lang="en-us">other</value>
         <value lang="nl-nl">anders</value>
+        <value lang="fr-fr">autre valeur</value>
     </translation>
     <translation key="nullFlavor_ASKU">
         <comment>Label: NullFlavor ASKU</comment>
         <value lang="en-us">asked but unknown</value>
         <value lang="nl-nl">gevraagd maar onbekend</value>
+        <value lang="fr-fr">demandé mais valeur inconnue</value>
     </translation>
     <translation key="nullFlavor_NAV">
         <comment>Label: NullFlavor NAV</comment>
         <value lang="en-us">not available</value>
         <value lang="nl-nl">niet beschikbaar</value>
+        <value lang="fr-fr">valeur temporairement indisponible</value>
     </translation>
     <translation key="nullFlavor_NASK">
         <comment>Label: NullFlavor NASK</comment>
         <value lang="en-us">not asked</value>
         <value lang="nl-nl">niet gevraagd</value>
+        <value lang="fr-fr">non demandé</value>
     </translation>
     <translation key="nullFlavor_QS">
         <comment>Label: NullFlavor QS</comment>
         <value lang="en-us">sufficient quantity</value>
         <value lang="nl-nl">voldoende hoeveelheid</value>
+        <value lang="fr-fr">quantité précise non connue</value>
     </translation>
     <translation key="nullFlavor_TRC">
         <comment>Label: NullFlavor TRC</comment>
         <value lang="en-us">trace</value>
+        <value lang="fr-fr">trace non quantifiable</value>
     </translation>
     <translation key="nullFlavor_NI">
         <comment>Label: NullFlavor NI</comment>
@@ -1993,175 +2358,209 @@
         <value lang="fr-ch">aucune information</value>
         <value lang="it-ch">nessuna informazione</value>
         <value lang="nl-nl">geen informatie</value>
+        <value lang="fr-fr">pas d’information</value>
     </translation>
     <translation key="nullFlavor_INV">
         <comment>Label: NullFlavor INV</comment>
         <value lang="en-us">invalid</value>
         <value lang="de-ch">ungültig</value>
         <value lang="nl-nl">ongeldig</value>
+        <value lang="fr-fr">valeur invalide</value>
     </translation>
     <translation key="nullFlavor_MSK">
         <comment>Label: NullFlavor MSK</comment>
         <value lang="en-us">masked</value>
         <value lang="de-ch">maskiert</value>
         <value lang="nl-nl">afgeschermd</value>
+        <value lang="fr-fr">valeur masquée</value>
     </translation>
     <translation key="nullFlavor_NA">
         <comment>Label: NullFlavor NA</comment>
         <value lang="en-us">not applicable</value>
         <value lang="de-ch">nicht anwendbar</value>
         <value lang="nl-nl">n.v.t.</value>
+        <value lang="fr-fr">pas de valeur applicable</value>
     </translation>
     <translation key="nullFlavor_NINF">
         <comment>Label: NullFlavor NINF</comment>
         <value lang="en-us">negative infinity</value>
         <value lang="nl-nl">negatief oneindig</value>
+        <value lang="fr-fr">borne inférieure infinie</value>
     </translation>
     <translation key="nullFlavor_PINF">
         <comment>Label: NullFlavor PINF</comment>
         <value lang="en-us">positive infinity</value>
         <value lang="nl-nl">positief oneindig</value>
+        <value lang="fr-fr">borne supérieure infinie</value>
     </translation>
     <translation key="nullFlavor_UNC">
         <comment>Label: NullFlavor UNC</comment>
         <value lang="en-us">un-encoded</value>
         <value lang="nl-nl">niet gecodeerd</value>
+        <value lang="fr-fr">valeur non codée</value>
     </translation>
     <translation key="nullFlavor_UNK">
         <comment>Label: NullFlavor UNK</comment>
         <value lang="en-us">unknown</value>
         <value lang="de-ch">unbekannt</value>
         <value lang="nl-nl">onbekend</value>
+        <value lang="fr-fr">valeur inconnue</value>
     </translation>
     <translation key="nullFlavor_NP">
         <comment>Label: NullFlavor NP</comment>
         <value lang="en-us">not present</value>
         <value lang="nl-nl">niet aanwezig</value>
+        <value lang="fr-fr">non présent</value>
     </translation>
     <translation key="statusCode-active">
         <comment>Label: Status active</comment>
         <value lang="en-us">Active</value>
         <value lang="nl-nl">Actief</value>
+        <value lang="fr-fr">Actif</value>
     </translation>
     <translation key="statusCode-completed">
         <comment>Label: Status completed</comment>
         <value lang="en-us">Completed</value>
         <value lang="nl-nl">Afgerond</value>
+        <value lang="fr-fr">Terminé</value>
     </translation>
     <translation key="statusCode-cancelled">
         <comment>Label: Status cancelled</comment>
         <value lang="en-us">Cancelled</value>
         <value lang="nl-nl">Geannuleerd</value>
+        <value lang="fr-fr">Annulé</value>
     </translation>
     <translation key="statusCode-nullified">
         <comment>Label: Status nullified</comment>
         <value lang="en-us">Nullified</value>
         <value lang="nl-nl">Opgeheven</value>
+        <value lang="fr-fr">Annulé</value>
     </translation>
     <translation key="statusCode-aborted">
         <comment>Label: Status aborted</comment>
         <value lang="en-us">Aborted</value>
         <value lang="nl-nl">Afgebroken</value>
+        <value lang="fr-fr">Avorté</value>
     </translation>
     <translation key="statusCode-obsolete">
         <comment>Label: Status obsolete</comment>
         <value lang="en-us">Obsolete</value>
         <value lang="nl-nl">Obsoleet</value>
+        <value lang="fr-fr">Obsolète</value>
     </translation>
     <translation key="statusCode-suspended">
         <comment>Label: Status suspended</comment>
         <value lang="en-us">Suspended</value>
         <value lang="nl-nl">Opgeschort</value>
+        <value lang="fr-fr">Suspendu</value>
     </translation>
     <translation key="statusCode-new">
         <comment>Label: Status new</comment>
         <value lang="en-us">New</value>
         <value lang="nl-nl">Nieuw</value>
+        <value lang="fr-fr">Nouveau</value>
     </translation>
     <translation key="statusCode-normal">
         <comment>Label: Status normal</comment>
         <value lang="en-us">Normal</value>
         <value lang="nl-nl">Normaal</value>
+        <value lang="fr-fr">Normal</value>
     </translation>
     <translation key="statusCode-pending">
         <comment>Label: Status pending</comment>
         <value lang="en-us">Pending</value>
         <value lang="nl-nl">Voorlopig</value>
+        <value lang="fr-fr">En attente</value>
     </translation>
     <translation key="statusCode-terminated">
         <comment>Label: Status terminated</comment>
         <value lang="en-us">Terminated</value>
         <value lang="nl-nl">Beëindigd</value>
+        <value lang="fr-fr">Résilié</value>
     </translation>
     <translation key="statusCode-inactive">
         <comment>Label: Status inactive</comment>
         <value lang="en-us">Inactive</value>
         <value lang="nl-nl">Inactief</value>
+        <value lang="fr-fr">Inactive</value>
     </translation>
     <translation key="statusCode-executing">
         <comment>Label: Status executing</comment>
         <value lang="en-us">Executing</value>
         <value lang="nl-nl">In uitvoering</value>
+        <value lang="fr-fr">En cours</value>
     </translation>
     <translation key="statusCode-waitContinuedQueryResponse">
         <comment>Label: Status waitContinuedQueryResponse</comment>
         <value lang="en-us">Wait continued query response</value>
         <value lang="nl-nl">Wacht op volgende antwoord op vraag</value>
+        <value lang="fr-fr">Attendre la réponse à la requête</value>
     </translation>
     <translation key="statusCode-deliveredResponse">
         <comment>Label: Status deliveredResponse</comment>
         <value lang="en-us">Delivered response</value>
         <value lang="nl-nl">Afgeleverd antwoord</value>
+        <value lang="fr-fr">Réponse délivrée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AUCG">
         <comment>Label: ParticipationFunction caregiver information receiver</comment>
         <value lang="en-us">caregiver information receiver</value>
         <value lang="nl-nl">zorgverlener informatieontvanger</value>
+        <value lang="fr-fr">Destinataire d'informations sur le prestataire de soins</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1002-APND">
         <comment>Label: Act Relationship Type APND</comment>
         <value lang="en-us">appendage</value>
         <value lang="nl-nl">toevoeging</value>
+        <value lang="fr-fr">ajout</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1002-RPLC">
         <comment>Label: Act Relationship Type RPLC</comment>
         <value lang="en-us">replaces</value>
         <value lang="nl-nl">vervangt</value>
+        <value lang="fr-fr">remplacement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1002-XFRM">
         <comment>Label: Act Relationship Type XFRM</comment>
         <value lang="en-us">transformation</value>
         <value lang="nl-nl">transformatie</value>
+        <value lang="fr-fr">transformation</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AULR">
         <comment>Label: ParticipationFunction legitimate relationship information receiver</comment>
         <value lang="en-us">legitimate relationship information receiver</value>
         <value lang="nl-nl">legitieme relatie informatieontvanger</value>
+        <value lang="fr-fr">destinataire légitime d'informations</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AUTM">
         <comment>Label: ParticipationFunction care team information receiver</comment>
         <value lang="en-us">care team information receiver</value>
         <value lang="nl-nl">zorgteam informatieontvanger</value>
+        <value lang="fr-fr">équipe de soins destinataire d'informations</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AUWA">
         <comment>Label: ParticipationFunction work area information receiver</comment>
         <value lang="en-us">work area information receiver</value>
         <value lang="nl-nl">werkomgeving informatieontvanger</value>
+        <value lang="fr-fr">destinataire d'informations sur l'environnement professionnel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-GRDCON">
         <comment>Label: ParticipationFunction legal guardian consent author</comment>
         <value lang="en-us">legal guardian consent author</value>
         <value lang="nl-nl">wettelijke vertegenwoordiger toestemming auteur</value>
+        <value lang="fr-fr">consentement du responsable légal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-POACON">
         <comment>Label: ParticipationFunction healthcare power of attorney consent author</comment>
         <value lang="en-us">healthcare power of attorney consent author</value>
         <value lang="nl-nl">zorgadvocaat toestemming auteur</value>
+        <value lang="fr-fr">consentement du responsable légal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-PRCON">
         <comment>Label: ParticipationFunction personal representative consent author</comment>
         <value lang="en-us">personal representative consent author</value>
         <value lang="nl-nl">persoonlijke vertegenwoordiger toestemming auteur</value>
+        <value lang="fr-fr">consentement du représentant personnel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-PROMSK">
         <comment>Label: ParticipationFunction authorized provider masking author</comment>
@@ -2172,21 +2571,25 @@
         <comment>Label: ParticipationFunction subject of consent author</comment>
         <value lang="en-us">subject of consent author</value>
         <value lang="nl-nl">onderwerp van toestemming auteur</value>
+        <value lang="fr-fr">sujet du consentement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AUCOV">
         <comment>Label: ParticipationFunction consent overrider</comment>
         <value lang="en-us">consent overrider</value>
         <value lang="nl-nl">toestemming verbreker</value>
+        <value lang="fr-fr">dérogation au consentement</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AUEMROV">
         <comment>Label: ParticipationFunction emergency overrider</comment>
         <value lang="en-us">emergency overrider</value>
         <value lang="nl-nl">verbreker in noodgeval</value>
+        <value lang="fr-fr">dérogation en urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-CLMADJ">
         <comment>Label: ParticipationFunction claims adjudication</comment>
         <value lang="en-us">claims adjudication</value>
         <value lang="nl-nl">claim adjudicatie</value>
+        <value lang="fr-fr">règlement des réclamations</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ENROLL">
         <comment>Label: ParticipationFunction enrollment broker</comment>
@@ -2212,6 +2615,7 @@
         <comment>Label: ParticipationFunction fully insured</comment>
         <value lang="en-us">fully insured</value>
         <value lang="nl-nl">volledig verzekerd</value>
+        <value lang="fr-fr">totalement assuré</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-SELFINRD">
         <comment>Label: ParticipationFunction self insured</comment>
@@ -2242,50 +2646,60 @@
         <comment>Label: ParticipationFunction admitting physician</comment>
         <value lang="en-us">admitting physician</value>
         <value lang="nl-nl">opnamearts</value>
+        <value lang="fr-fr">Responsable de l'admission</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ANEST">
         <comment>Label: ParticipationFunction anesthesist</comment>
         <value lang="en-us">anesthesist</value>
+        <value lang="fr-fr">Anesthésiste</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ANRS">
         <comment>Label: ParticipationFunction anesthesia nurse</comment>
         <value lang="en-us">anesthesia nurse</value>
         <value lang="nl-nl">anesthesie-verpleegkundige</value>
+        <value lang="fr-fr">infirmière anesthésiste</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-ATTPHYS">
         <comment>Label: ParticipationFunction attending physician</comment>
         <value lang="en-us">attending physician</value>
         <value lang="nl-nl">behandelend arts</value>
+        <value lang="fr-fr">Référent - Responsable du patient dans la structure de soins</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-DISPHYS">
         <comment>Label: ParticipationFunction discharging physician</comment>
         <value lang="en-us">discharging physician</value>
         <value lang="nl-nl">ontslagarts</value>
+        <value lang="fr-fr">Responsable de la sortie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-FASST">
         <comment>Label: ParticipationFunction first assistant surgeon</comment>
         <value lang="en-us">first assistant surgeon</value>
         <value lang="nl-nl">eerste chirurgisch assistent</value>
+        <value lang="fr-fr">premier chirurgien assistant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-MDWF">
         <comment>Label: ParticipationFunction midwife</comment>
         <value lang="en-us">midwife</value>
         <value lang="nl-nl">verloskundige</value>
+        <value lang="fr-fr">sage-femme</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-NASST">
         <comment>Label: ParticipationFunction nurse assistant</comment>
         <value lang="en-us">nurse assistant</value>
         <value lang="nl-nl">verpleegkundig assistent</value>
+        <value lang="fr-fr">aide-soignante</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-PCP">
         <comment>Label: ParticipationFunction primary care physician</comment>
         <value lang="en-us">primary care physician</value>
         <value lang="nl-nl">eerstelijns arts</value>
+        <value lang="fr-fr">Médecin traitant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-PRISURG">
         <comment>Label: ParticipationFunction primary surgeon</comment>
         <value lang="en-us">primary surgeon</value>
         <value lang="nl-nl">eerste chirurg</value>
+        <value lang="fr-fr">chirurgien</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-RNDPHYS">
         <comment>Label: ParticipationFunction rounding physician</comment>
@@ -2311,304 +2725,367 @@
         <comment>Label: OID ParticipationSignature</comment>
         <value lang="en-us">intended</value>
         <value lang="nl-nl">heeft de intentie</value>
+        <value lang="fr-fr">attendue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.89-S">
         <comment>Label: OID ParticipationSignature</comment>
         <value lang="en-us">signed</value>
         <value lang="nl-nl">heeft getekend</value>
+        <value lang="fr-fr">signé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.89-X">
         <comment>Label: OID ParticipationSignature</comment>
         <value lang="en-us">required</value>
         <value lang="nl-nl">moet tekenen</value>
+        <value lang="fr-fr">requise</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PART">
         <comment>Label: ParticipationType Participation</comment>
         <value lang="en-us">Participation</value>
         <value lang="nl-nl">Participatie</value>
+        <value lang="fr-fr">Participant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ADM">
         <comment>Label: ParticipationType admitter</comment>
         <value lang="en-us">admitter</value>
         <value lang="nl-nl">opgenomen door</value>
+        <value lang="fr-fr">Responsable de l'admission</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ATND">
         <comment>Label: ParticipationType attender</comment>
         <value lang="en-us">attender</value>
         <value lang="nl-nl">behandeld door</value>
+        <value lang="fr-fr">Superviseur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CALLBCK">
         <comment>Label: ParticipationType callback contact</comment>
         <value lang="en-us">callback contact</value>
         <value lang="nl-nl">contactpersoon</value>
+        <value lang="fr-fr">Contact à rappeler</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CON">
         <comment>Label: ParticipationType consultant</comment>
         <value lang="en-us">consultant</value>
+        <value lang="fr-fr">Consultant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIS">
         <comment>Label: ParticipationType discharger</comment>
         <value lang="en-us">discharger</value>
         <value lang="nl-nl">ontslagen door</value>
+        <value lang="fr-fr">Responsable de la sortie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ESC">
         <comment>Label: ParticipationType escort</comment>
         <value lang="en-us">escort</value>
         <value lang="nl-nl">begeleider</value>
+        <value lang="fr-fr">Accompagnateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-REF">
         <comment>Label: ParticipationType referrer</comment>
         <value lang="en-us">referrer</value>
         <value lang="nl-nl">verwijzer</value>
+        <value lang="fr-fr">Référent / Prescripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-AUT">
         <comment>Label: ParticipationType author (originator)</comment>
         <value lang="en-us">author (originator)</value>
         <value lang="nl-nl">auteur (oorspronkelijk)</value>
+        <value lang="fr-fr">Auteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-INF">
         <comment>Label: ParticipationType informant</comment>
         <value lang="en-us">informant</value>
+        <value lang="fr-fr">Informateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-TRANS">
         <comment>Label: ParticipationType Transcriber</comment>
         <value lang="en-us">Transcriber</value>
         <value lang="nl-nl">transscribent</value>
+        <value lang="fr-fr">Transcripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ENT">
         <comment>Label: ParticipationType data entry person</comment>
         <value lang="en-us">data entry person</value>
         <value lang="nl-nl">ingevoerd door</value>
+        <value lang="fr-fr">Opérateur de saisie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-WIT">
         <comment>Label: ParticipationType witness</comment>
         <value lang="en-us">witness</value>
         <value lang="nl-nl">getuige</value>
+        <value lang="fr-fr">Témoin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CST">
         <comment>Label: ParticipationType custodian</comment>
         <value lang="en-us">custodian</value>
         <value lang="nl-nl">beheerder</value>
+        <value lang="fr-fr">Responsable de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIR">
         <comment>Label: ParticipationType direct target</comment>
         <value lang="en-us">direct target</value>
         <value lang="nl-nl">direct doel</value>
+        <value lang="fr-fr">Participant direct</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-BBY">
         <comment>Label: ParticipationType baby</comment>
         <value lang="en-us">baby</value>
+        <value lang="fr-fr">Nouveau né</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CSM">
         <comment>Label: ParticipationType consumable</comment>
         <value lang="en-us">consumable</value>
         <value lang="nl-nl">eet- of drinkbaar</value>
+        <value lang="fr-fr">Consommable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DEV">
         <comment>Label: ParticipationType device</comment>
         <value lang="en-us">device</value>
         <value lang="nl-nl">apparaat</value>
+        <value lang="fr-fr">Dispositif automatique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-NRD">
         <comment>Label: ParticipationType non-reuseable device</comment>
         <value lang="en-us">non-reuseable device</value>
         <value lang="nl-nl">niet-herbruikbaar apparaat</value>
+        <value lang="fr-fr">Dispositif non réutilisable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RDV">
         <comment>Label: ParticipationType reusable device</comment>
         <value lang="en-us">reusable device</value>
         <value lang="nl-nl">herbruikbaar apparaat</value>
+        <value lang="fr-fr">Dispositif réutilisable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DON">
         <comment>Label: ParticipationType donor</comment>
         <value lang="en-us">donor</value>
+        <value lang="fr-fr">Donneur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-EXPAGNT">
         <comment>Label: ParticipationType ExposureAgent</comment>
         <value lang="en-us">ExposureAgent</value>
+        <value lang="fr-fr">Agent de l'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-EXPART">
         <comment>Label: ParticipationType ExposureParticipation</comment>
         <value lang="en-us">ExposureParticipation</value>
+        <value lang="fr-fr">Partie de l'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-EXPTRGT">
         <comment>Label: ParticipationType ExposureTarget</comment>
         <value lang="en-us">ExposureTarget</value>
+        <value lang="fr-fr">Cible de l'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-EXSRC">
         <comment>Label: ParticipationType ExposureSource</comment>
         <value lang="en-us">ExposureSource</value>
+        <value lang="fr-fr">Source de l'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PRD">
         <comment>Label: ParticipationType product</comment>
         <value lang="en-us">product</value>
+        <value lang="fr-fr">Produit</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SBJ">
         <comment>Label: ParticipationType subject</comment>
         <value lang="en-us">subject</value>
+        <value lang="fr-fr">Sujet</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SPC">
         <comment>Label: ParticipationType specimen</comment>
         <value lang="en-us">specimen</value>
         <value lang="nl-nl">monster</value>
+        <value lang="fr-fr">Echantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-IND">
         <comment>Label: ParticipationType indirect target</comment>
         <value lang="en-us">indirect target</value>
         <value lang="nl-nl">indirect doel</value>
+        <value lang="fr-fr">Cible indirecte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-BEN">
         <comment>Label: ParticipationType beneficiary</comment>
         <value lang="en-us">beneficiary</value>
         <value lang="nl-nl">begunstigde</value>
+        <value lang="fr-fr">Bénéficiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-CAGNT">
         <comment>Label: ParticipationType causative agent</comment>
         <value lang="en-us">causative agent</value>
         <value lang="nl-nl">veroorzakende agent</value>
+        <value lang="fr-fr">Agent causal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-COV">
         <comment>Label: ParticipationType coverage target</comment>
         <value lang="en-us">coverage target</value>
         <value lang="nl-nl">verzekerde</value>
+        <value lang="fr-fr">Partie couverte (titulaire ou bénéficiaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-GUAR">
         <comment>Label: ParticipationType guarantor party</comment>
         <value lang="en-us">guarantor party</value>
         <value lang="nl-nl">garantstaande partij</value>
+        <value lang="fr-fr">Garant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-HLD">
         <comment>Label: ParticipationType holder</comment>
         <value lang="en-us">holder</value>
         <value lang="nl-nl">verzekeringshouder</value>
+        <value lang="fr-fr">Souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RCT">
         <comment>Label: ParticipationType record target</comment>
         <value lang="en-us">record target</value>
         <value lang="nl-nl">patiënt</value>
+        <value lang="fr-fr">Patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RCV">
         <comment>Label: ParticipationType receiver</comment>
         <value lang="en-us">receiver</value>
         <value lang="nl-nl">ontvanger</value>
+        <value lang="fr-fr">Récepteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-IRCP">
         <comment>Label: ParticipationType information recipient</comment>
         <value lang="en-us">information recipient</value>
         <value lang="nl-nl">informatieontvanger</value>
+        <value lang="fr-fr">Destinataire de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-NOT">
         <comment>Label: ParticipationType ugent notification contact</comment>
         <value lang="en-us">urgent notification contact</value>
         <value lang="nl-nl">contactpersoon bij nood</value>
+        <value lang="fr-fr">Personne à prévenir en cas d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PRCP">
         <comment>Label: ParticipationType primary information recipient</comment>
         <value lang="en-us">primary information recipient</value>
         <value lang="nl-nl">bedoelde informatieontvanger</value>
+        <value lang="fr-fr">Destinataire principal de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-REFB">
         <comment>Label: ParticipationType Referred By</comment>
         <value lang="en-us">Referred By</value>
         <value lang="nl-nl">Verwezen door</value>
+        <value lang="fr-fr">Personne ayant adressé le patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-REFT">
         <comment>Label: ParticipationType Referred to</comment>
         <value lang="en-us">Referred to</value>
         <value lang="nl-nl">Verwezen naar</value>
+        <value lang="fr-fr">Personne recevant le patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-TRC">
         <comment>Label: ParticipationType tracker</comment>
         <value lang="en-us">tracker</value>
         <value lang="nl-nl">kopie-ontvanger</value>
+        <value lang="fr-fr">Personne recevant une copie de l'information</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-LOC">
         <comment>Label: ParticipationType location</comment>
         <value lang="en-us">location</value>
         <value lang="nl-nl">lokatie</value>
+        <value lang="fr-fr">Emplacement principal</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DST">
         <comment>Label: ParticipationType destination</comment>
         <value lang="en-us">destination</value>
         <value lang="nl-nl">bestemming</value>
+        <value lang="fr-fr">Destination</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ELOC">
         <comment>Label: ParticipationType entry location</comment>
         <value lang="en-us">entry location</value>
         <value lang="nl-nl">invoerlokatie</value>
+        <value lang="fr-fr">Emplacement où les données sont saisies</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-ORG">
         <comment>Label: ParticipationType origin</comment>
         <value lang="en-us">origin</value>
         <value lang="nl-nl">oorsprong</value>
+        <value lang="fr-fr">Lieu d'origine</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RML">
         <comment>Label: ParticipationType remote</comment>
         <value lang="en-us">remote</value>
         <value lang="nl-nl">extern</value>
+        <value lang="fr-fr">Emplacement distant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-VIA">
         <comment>Label: ParticipationType via</comment>
         <value lang="en-us">via</value>
+        <value lang="fr-fr">Emplacement intermédiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PRF">
         <comment>Label: ParticipationType performer</comment>
         <value lang="en-us">performer</value>
         <value lang="nl-nl">uitvoerende</value>
+        <value lang="fr-fr">Exécutant </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-DIST">
         <comment>Label: ParticipationType distributor</comment>
         <value lang="en-us">distributor</value>
         <value lang="nl-nl">distributeur</value>
+        <value lang="fr-fr">Distributeur </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-PPRF">
         <comment>Label: ParticipationType primary performer</comment>
         <value lang="en-us">primary performer</value>
         <value lang="nl-nl">eerste uitvoerende</value>
+        <value lang="fr-fr">Exécutant principal </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-SPRF">
         <comment>Label: ParticipationType secondary performer</comment>
         <value lang="en-us">secondary performer</value>
         <value lang="nl-nl">tweede uitvoerende</value>
+        <value lang="fr-fr">Exécutant secondaire </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-RESP">
         <comment>Label: ParticipationType responsible party</comment>
         <value lang="en-us">responsible party</value>
         <value lang="nl-nl">verantwoordelijke partij</value>
+        <value lang="fr-fr">Responsable de l'acte </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-VRF">
         <comment>Label: ParticipationType verifier</comment>
         <value lang="en-us">verifier</value>
         <value lang="nl-nl">toezichthouder</value>
+        <value lang="fr-fr">Vérificateur </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-AUTHEN">
         <comment>Label: ParticipationType authenticator</comment>
         <value lang="en-us">authenticator</value>
         <value lang="nl-nl">onderetkenaar</value>
+        <value lang="fr-fr">Valideur des résultats </value>
     </translation>
     <translation key="2.16.840.1.113883.5.90-LA">
         <comment>Label: ParticipationType legal authenticator</comment>
         <value lang="en-us">legal authenticator</value>
         <value lang="nl-nl">wettelijke ondertekenaar</value>
+        <value lang="fr-fr">Responsable légal </value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CHILD">
         <comment>Label: RoleClass child</comment>
         <value lang="en-us">child</value>
         <value lang="nl-nl">kind</value>
+        <value lang="fr-fr">Enfant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRED">
         <comment>Label: RoleClass credentialed entity</comment>
         <value lang="en-us">credentialed entity</value>
         <value lang="nl-nl">bevoegde entiteit</value>
+        <value lang="fr-fr">Entité compétente</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NURPRAC">
         <comment>Label: RoleClass nurse practitioner</comment>
         <value lang="en-us">nurse practitioner</value>
+        <value lang="fr-fr">Infirmière praticienne</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NURS">
         <comment>Label: RoleClass nurse</comment>
         <value lang="en-us">nurse</value>
         <value lang="nl-nl">verpleegkundige</value>
+        <value lang="fr-fr">Infirmière</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PA">
         <comment>Label: RoleClass physician assistant</comment>
@@ -2619,11 +3096,13 @@
         <comment>Label: RoleClass physician</comment>
         <value lang="en-us">physician</value>
         <value lang="nl-nl">arts</value>
+        <value lang="fr-fr">Médecin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ROL">
         <comment>Label: RoleClass role</comment>
         <value lang="en-us">role</value>
         <value lang="nl-nl">rol</value>
+        <value lang="fr-fr">Rôle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-AFFL">
         <comment>Label: RoleClass affiliate</comment>
@@ -2633,291 +3112,351 @@
     <translation key="2.16.840.1.113883.5.110-AGNT">
         <comment>Label: RoleClass agent</comment>
         <value lang="en-us">agent</value>
+        <value lang="fr-fr">Agent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ASSIGNED">
         <comment>Label: RoleClass assigned entity</comment>
         <value lang="en-us">assigned entity</value>
         <value lang="nl-nl">benoemde entiteit</value>
+        <value lang="fr-fr">Entité nommée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-COMPAR">
         <comment>Label: RoleClass commissioning party</comment>
         <value lang="en-us">commissioning party</value>
+        <value lang="fr-fr">Commissionnaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SGNOFF">
         <comment>Label: RoleClass signing authority or officer</comment>
         <value lang="en-us">signing authority or officer</value>
         <value lang="nl-nl">ondertekenende autoriteit of functionaris</value>
+        <value lang="fr-fr">Autorité ou officier signataire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CON">
         <comment>Label: RoleClass contact</comment>
         <value lang="en-us">contact</value>
+        <value lang="fr-fr">Contact</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ECON">
         <comment>Label: RoleClass emergency contact</comment>
         <value lang="en-us">emergency contact</value>
         <value lang="nl-nl">noodcontact</value>
+        <value lang="fr-fr">Contact en cas d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NOK">
         <comment>Label: RoleClass next of kin</comment>
         <value lang="en-us">next of kin</value>
         <value lang="nl-nl">familie</value>
+        <value lang="fr-fr">Plus proche parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-GUARD">
         <comment>Label: RoleClass guardian</comment>
         <value lang="en-us">guardian</value>
         <value lang="nl-nl">voogd</value>
+        <value lang="fr-fr">Représentant du patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CIT">
         <comment>Label: RoleClass citizen</comment>
         <value lang="en-us">citizen</value>
         <value lang="nl-nl">burger</value>
+        <value lang="fr-fr">Citoyen</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-COVPTY">
         <comment>Label: RoleClass covered party</comment>
         <value lang="en-us">covered party</value>
         <value lang="nl-nl">verzekerde</value>
+        <value lang="fr-fr">Partie couverte</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CLAIM">
         <comment>Label: RoleClass claimant</comment>
         <value lang="en-us">claimant</value>
+        <value lang="fr-fr">Demandeur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NAMED">
         <comment>Label: RoleClass named insured</comment>
         <value lang="en-us">named insured</value>
         <value lang="nl-nl">benoemde verzekerde</value>
+        <value lang="fr-fr">Assuré désigné</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DEPEN">
         <comment>Label: RoleClass dependent</comment>
         <value lang="en-us">dependent</value>
         <value lang="nl-nl">afhankelijke</value>
+        <value lang="fr-fr">Dépendant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-INDIV">
         <comment>Label: RoleClass individual</comment>
         <value lang="en-us">individual</value>
         <value lang="nl-nl">individu</value>
+        <value lang="fr-fr">Individuel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SUBSCR">
         <comment>Label: RoleClass subscriber</comment>
         <value lang="en-us">subscriber</value>
         <value lang="nl-nl">abonnee</value>
+        <value lang="fr-fr">Souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PROG">
         <comment>Label: RoleClass program eligible</comment>
         <value lang="en-us">program eligible</value>
+        <value lang="fr-fr">Eligible au programme</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRINV">
         <comment>Label: RoleClass clinical research investigator</comment>
         <value lang="en-us">clinical research investigator</value>
         <value lang="nl-nl">klinisch onderzoeker</value>
+        <value lang="fr-fr">Chercheur en recherche clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CRSPNSR">
         <comment>Label: RoleClass clinical research sponsor</comment>
         <value lang="en-us">clinical research sponsor</value>
         <value lang="nl-nl">klinisch onderzoek sponsor</value>
+        <value lang="fr-fr">Sponsor en recherche clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EMP">
         <comment>Label: RoleClass employee</comment>
         <value lang="en-us">employee</value>
         <value lang="nl-nl">werknemer</value>
+        <value lang="fr-fr">Employé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MIL">
         <comment>Label: RoleClass military person</comment>
         <value lang="en-us">military person</value>
         <value lang="nl-nl">militair</value>
+        <value lang="fr-fr">Militaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-INVSBJ">
         <comment>Label: RoleClass Investigation Subject</comment>
         <value lang="en-us">Investigation Subject</value>
         <value lang="nl-nl">Onderzoek subject</value>
+        <value lang="fr-fr">Sujet des investigations</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CASEBJ">
         <comment>Label: RoleClass Case Subject</comment>
         <value lang="en-us">Case Subject</value>
         <value lang="nl-nl">Case subject</value>
+        <value lang="fr-fr">Sujet du cas</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-RESBJ">
         <comment>Label: RoleClass research subject</comment>
         <value lang="en-us">research subject</value>
+        <value lang="fr-fr">Sujet de recherche</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-LIC">
         <comment>Label: RoleClass licensed entity</comment>
         <value lang="en-us">licensed entity</value>
         <value lang="nl-nl">gelicenseerde entiteit</value>
+        <value lang="fr-fr">Entité agréée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-NOT">
         <comment>Label: RoleClass notary public</comment>
         <value lang="en-us">notary public</value>
+        <value lang="fr-fr">Notaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PROV">
         <comment>Label: RoleClass healthcare provider</comment>
         <value lang="en-us">healthcare provider</value>
         <value lang="nl-nl">zorgaanbieder</value>
+        <value lang="fr-fr">Profession </value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAT">
         <comment>Label: RoleClass patient</comment>
         <value lang="en-us">patient</value>
         <value lang="nl-nl">patiënt</value>
+        <value lang="fr-fr">Patient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAYEE">
         <comment>Label: RoleClass payee</comment>
         <value lang="en-us">payee</value>
         <value lang="nl-nl">begunstigde</value>
+        <value lang="fr-fr">Bénéficiaire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PAYOR">
         <comment>Label: RoleClass invoice payor</comment>
         <value lang="en-us">invoice payor</value>
         <value lang="nl-nl">rekening betaler</value>
+        <value lang="fr-fr">Payeur de facture</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-POLHOLD">
         <comment>Label: RoleClass policy holder</comment>
         <value lang="en-us">policy holder</value>
         <value lang="nl-nl">polishouder</value>
+        <value lang="fr-fr">Titulaire de l'assurance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-QUAL">
         <comment>Label: RoleClass qualified entity</comment>
         <value lang="en-us">qualified entity</value>
         <value lang="nl-nl">gekwalificeerde entiteit</value>
+        <value lang="fr-fr">Entité qualifiée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SPNSR">
         <comment>Label: RoleClass coverage sponsor</comment>
         <value lang="en-us">coverage sponsor</value>
         <value lang="nl-nl">verzerkering sponsor</value>
+        <value lang="fr-fr">Promoteur d'assurance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-STD">
         <comment>Label: RoleClass student</comment>
         <value lang="en-us">student</value>
+        <value lang="fr-fr">Etudiant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-UNDWRT">
         <comment>Label: RoleClass underwriter</comment>
         <value lang="en-us">underwriter</value>
+        <value lang="fr-fr">Souscripteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CAREGIVER">
         <comment>Label: RoleClass caregiver</comment>
         <value lang="en-us">caregiver</value>
         <value lang="nl-nl">zorgverlener</value>
+        <value lang="fr-fr">Soignant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PRS">
         <comment>Label: RoleClass personal relationship</comment>
         <value lang="en-us">personal relationship</value>
         <value lang="nl-nl">persoonlijke relatie</value>
+        <value lang="fr-fr">Relation personnelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACCESS">
         <comment>Label: RoleClass access</comment>
         <value lang="en-us">access</value>
         <value lang="nl-nl">toegang</value>
+        <value lang="fr-fr">Accès</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ADMM">
         <comment>Label: RoleClass Administerable Material</comment>
         <value lang="en-us">Administerable Material</value>
         <value lang="nl-nl">Toedienbaar materiaal</value>
+        <value lang="fr-fr">Matériel applicable</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-BIRTHPL">
         <comment>Label: RoleClass birthplace</comment>
         <value lang="en-us">birthplace</value>
         <value lang="nl-nl">geboorteplaats</value>
+        <value lang="fr-fr">Lieu de naissance</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DEATHPLC">
         <comment>Label: RoleClass place of death</comment>
         <value lang="en-us">place of death</value>
         <value lang="nl-nl">plaats overlijden</value>
+        <value lang="fr-fr">Lieu du décès</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DST">
         <comment>Label: RoleClass distributed material</comment>
         <value lang="en-us">distributed material</value>
         <value lang="nl-nl">gedistribueerd materiaal</value>
+        <value lang="fr-fr">Matériel distribué</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-RET">
         <comment>Label: RoleClass retailed material</comment>
         <value lang="en-us">retailed material</value>
         <value lang="nl-nl">verkocht materiaal</value>
+        <value lang="fr-fr">Matériel vendu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EXPR">
         <comment>Label: RoleClass exposed entity</comment>
         <value lang="en-us">exposed entity</value>
         <value lang="nl-nl">blootgestelde entiteit</value>
+        <value lang="fr-fr">Entité exposée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-HLD">
         <comment>Label: RoleClass held entity</comment>
         <value lang="en-us">held entity</value>
+        <value lang="fr-fr">Entité détenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-HLTHCHRT">
         <comment>Label: RoleClass health chart</comment>
         <value lang="en-us">health chart</value>
+        <value lang="fr-fr">Fiche de santé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-IDENT">
         <comment>Label: RoleClass identified entity</comment>
         <value lang="en-us">identified entity</value>
         <value lang="nl-nl">geïdentificeerde entiteit</value>
+        <value lang="fr-fr">Entité identifiée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MANU">
         <comment>Label: RoleClass manufactured product</comment>
         <value lang="en-us">manufactured product</value>
         <value lang="nl-nl">geproduceerd product</value>
+        <value lang="fr-fr">Produit manufacturé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-THER">
         <comment>Label: RoleClass therapeutic agent</comment>
         <value lang="en-us">therapeutic agent</value>
         <value lang="nl-nl">therapeutisch agent</value>
+        <value lang="fr-fr">Agent thérapeutique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MNT">
         <comment>Label: RoleClass maintained entity</comment>
         <value lang="en-us">maintained entity</value>
         <value lang="nl-nl">beheerde entiteit</value>
+        <value lang="fr-fr">Entité maintenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-OWN">
         <comment>Label: RoleClass owned entity</comment>
         <value lang="en-us">owned entity</value>
         <value lang="nl-nl">bezitte entiteit</value>
+        <value lang="fr-fr">Entité détenue</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-RGPR">
         <comment>Label: RoleClass regulated product</comment>
         <value lang="en-us">regulated product</value>
         <value lang="nl-nl">gereguleerd product</value>
+        <value lang="fr-fr">Produit réglementé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SDLOC">
         <comment>Label: RoleClass service delivery location</comment>
         <value lang="en-us">service delivery location</value>
         <value lang="nl-nl">zorgverleningslokatie</value>
+        <value lang="fr-fr">Lieu de prestation de services</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-DSDLOC">
         <comment>Label: RoleClass dedicated service delivery location</comment>
         <value lang="en-us">dedicated service delivery location</value>
         <value lang="nl-nl">lokatie bedoeld voor zorgverlening</value>
+        <value lang="fr-fr">Lieu de prestation de services dédié</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ISDLOC">
         <comment>Label: RoleClass incidental service delivery location</comment>
         <value lang="en-us">incidental service delivery location</value>
         <value lang="nl-nl">toevallige zorgverleningslokatie</value>
+        <value lang="fr-fr">Lieu de prestation de services accessoire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-TERR">
         <comment>Label: RoleClass territory of authority</comment>
         <value lang="en-us">territory of authority</value>
         <value lang="nl-nl">autoriteitsregio</value>
+        <value lang="fr-fr">Territoire d'autorité</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-USED">
         <comment>Label: RoleClass used entity</comment>
         <value lang="en-us">used entity</value>
         <value lang="nl-nl">gebruikte entiteit</value>
+        <value lang="fr-fr">Entité utilisée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-WRTE">
         <comment>Label: RoleClass warranted product</comment>
         <value lang="en-us">warranted product</value>
         <value lang="nl-nl">product onder garantie</value>
+        <value lang="fr-fr">Produit garanti</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EQUIV">
         <comment>Label: RoleClass equivalent entity</comment>
         <value lang="en-us">equivalent entity</value>
         <value lang="nl-nl">equivalente entiteit</value>
+        <value lang="fr-fr">Entité équivalente</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SAME">
         <comment>Label: RoleClass same</comment>
         <value lang="en-us">same</value>
         <value lang="nl-nl">dezelfde</value>
+        <value lang="fr-fr">identique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SUBY">
         <comment>Label: RoleClass subsumed by</comment>
         <value lang="en-us">subsumed by</value>
         <value lang="nl-nl">opgevolgd door</value>
+        <value lang="fr-fr">succédé par</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-GEN">
         <comment>Label: RoleClass has generalization</comment>
@@ -2933,336 +3472,404 @@
         <comment>Label: RoleClass instance</comment>
         <value lang="en-us">instance</value>
         <value lang="nl-nl">instantie</value>
+        <value lang="fr-fr">exemple</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SUBS">
         <comment>Label: RoleClass subsumer</comment>
         <value lang="en-us">subsumer</value>
         <value lang="nl-nl">opvolger van</value>
+        <value lang="fr-fr">successeur de</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-CONT">
         <comment>Label: RoleClass content</comment>
         <value lang="en-us">content</value>
         <value lang="nl-nl">inhoud</value>
+        <value lang="fr-fr">contenu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EXPAGTCAR">
         <comment>Label: RoleClass exposure agent carrier</comment>
         <value lang="en-us">exposure agent carrier</value>
+        <value lang="fr-fr">agent d'exposition porteur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-EXPVECTOR">
         <comment>Label: RoleClass exposure vector</comment>
         <value lang="en-us">exposure vector</value>
+        <value lang="fr-fr">vecteur d'exposition</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-FOMITE">
         <comment>Label: RoleClass fomite</comment>
         <value lang="en-us">fomite</value>
+        <value lang="fr-fr">fomite</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-INGR">
         <comment>Label: RoleClass ingredient</comment>
         <value lang="en-us">ingredient</value>
         <value lang="nl-nl">ingrediënt</value>
+        <value lang="fr-fr">ingredient</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTI">
         <comment>Label: RoleClass active ingredient</comment>
         <value lang="en-us">active ingredient</value>
         <value lang="nl-nl">actief ingrediënt</value>
+        <value lang="fr-fr">ingredient actif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTIB">
         <comment>Label: RoleClass active ingredient - basis of strength</comment>
         <value lang="en-us">active ingredient - basis of strength</value>
         <value lang="nl-nl">actief ingrediënt - op basis van sterkte</value>
+        <value lang="fr-fr">ingredient actif - base de la concentration</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTIM">
         <comment>Label: RoleClass active ingredient - moiety is basis of strength</comment>
         <value lang="en-us">active ingredient - moiety is basis of strength</value>
         <value lang="nl-nl">actief ingrediënt - moiety is basis of strength</value>
+        <value lang="fr-fr">ingredient actif - la moitée est la base de la concentration</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTIR">
         <comment>Label: RoleClass active ingredient - reference substance is basis of strength</comment>
         <value lang="en-us">active ingredient - reference substance is basis of strength</value>
         <value lang="nl-nl">actief ingrediënt - reference substance is basis of strength</value>
+        <value lang="fr-fr">ingredient actif - la substance de référence est la base de la concentration</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ADTV">
         <comment>Label: RoleClass additive</comment>
         <value lang="en-us">additive</value>
         <value lang="nl-nl">additief</value>
+        <value lang="fr-fr">additif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-BASE">
         <comment>Label: RoleClass base</comment>
         <value lang="en-us">base</value>
         <value lang="nl-nl">basis</value>
+        <value lang="fr-fr">base</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-IACT">
         <comment>Label: RoleClass inactive ingredient</comment>
         <value lang="en-us">inactive ingredient</value>
         <value lang="nl-nl">inactief ingrediënt</value>
+        <value lang="fr-fr">ingredient inactif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-COLR">
         <comment>Label: RoleClass color additive</comment>
         <value lang="en-us">color additive</value>
         <value lang="nl-nl">kleuradditief</value>
+        <value lang="fr-fr">additif de couleur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-FLVR">
         <comment>Label: RoleClass flavor additive</comment>
         <value lang="en-us">flavor additive</value>
         <value lang="nl-nl">smaakadditief</value>
+        <value lang="fr-fr">additif aromatique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PRSV">
         <comment>Label: RoleClass preservative</comment>
         <value lang="en-us">preservative</value>
         <value lang="nl-nl">conserveringsmiddel</value>
+        <value lang="fr-fr">conservateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-STBL">
         <comment>Label: RoleClass stabilizer</comment>
         <value lang="en-us">stabilizer</value>
         <value lang="nl-nl">stabilisator</value>
+        <value lang="fr-fr">stabilisateur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-LOCE">
         <comment>Label: RoleClass located entity</comment>
         <value lang="en-us">located entity</value>
         <value lang="nl-nl">gelokaliseerde entiteit</value>
+        <value lang="fr-fr">Entité localisée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-STOR">
         <comment>Label: RoleClass stored entity</comment>
         <value lang="en-us">stored entity</value>
         <value lang="nl-nl">opgeslagen entiteit</value>
+        <value lang="fr-fr">Entité stockée</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-MBR">
         <comment>Label: RoleClass member</comment>
         <value lang="en-us">member</value>
         <value lang="nl-nl">lid</value>
+        <value lang="fr-fr">Membre</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-PART">
         <comment>Label: RoleClass part</comment>
         <value lang="en-us">part</value>
         <value lang="nl-nl">deel</value>
+        <value lang="fr-fr">Partie</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTM">
         <comment>Label: RoleClass active moiety</comment>
         <value lang="en-us">active moiety</value>
+        <value lang="fr-fr">fraction active</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-SPEC">
         <comment>Label: RoleClass specimen</comment>
         <value lang="en-us">specimen</value>
         <value lang="nl-nl">monster</value>
+        <value lang="fr-fr">Echantillon</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ALQT">
         <comment>Label: RoleClass aliquot</comment>
         <value lang="en-us">aliquot</value>
+        <value lang="fr-fr">Aliquote</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ISLT">
         <comment>Label: RoleClass isolate</comment>
         <value lang="en-us">isolate</value>
         <value lang="nl-nl">isolaat</value>
+        <value lang="fr-fr">Isolat</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FAMMEMB">
         <comment>Label: RoleCode Family Member</comment>
         <value lang="en-us">Family Member</value>
         <value lang="nl-nl">Familielid</value>
+        <value lang="fr-fr">Membre de la famille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHILD">
         <comment>Label: RoleCode Child</comment>
         <value lang="en-us">Child</value>
         <value lang="nl-nl">Kind</value>
+        <value lang="fr-fr">Enfant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHLDADOPT">
         <comment>Label: RoleCode adopted child</comment>
         <value lang="en-us">adopted child</value>
         <value lang="nl-nl">geadopteerd kind</value>
+        <value lang="fr-fr">Enfant adopté</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUADOPT">
         <comment>Label: RoleCode adopted daughter</comment>
         <value lang="en-us">adopted daughter</value>
         <value lang="nl-nl">geadopteerde dochter</value>
+        <value lang="fr-fr">Fille adoptive</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONADOPT">
         <comment>Label: RoleCode adopted son</comment>
         <value lang="en-us">adopted son</value>
         <value lang="nl-nl">geadopteerde zoon</value>
+        <value lang="fr-fr">Fils adoptif</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHLDFOST">
         <comment>Label: RoleCode foster child</comment>
         <value lang="en-us">foster child</value>
         <value lang="nl-nl">pleegkind</value>
+        <value lang="fr-fr">Enfant placé en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUFOST">
         <comment>Label: RoleCode foster daughter</comment>
         <value lang="en-us">foster daughter</value>
         <value lang="nl-nl">pleegdochter</value>
+        <value lang="fr-fr">Fille placée en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONFOST">
         <comment>Label: RoleCode foster son</comment>
         <value lang="en-us">foster son</value>
         <value lang="nl-nl">pleegzoon</value>
+        <value lang="fr-fr">Fils placé en famille d'accueil</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-CHLDINLAW">
         <comment>Label: RoleCode child in-law</comment>
         <value lang="en-us">child in-law</value>
         <value lang="nl-nl">aangetrouwd kind</value>
+        <value lang="fr-fr">Gendre ou belle-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUINLAW">
         <comment>Label: RoleCode daughter in-law</comment>
         <value lang="en-us">daughter in-law</value>
         <value lang="nl-nl">schoondochter</value>
+        <value lang="fr-fr">Belle-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONINLAW">
         <comment>Label: RoleCode son in-law</comment>
         <value lang="en-us">son in-law</value>
         <value lang="nl-nl">schoonzoon</value>
+        <value lang="fr-fr">Gendre</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAUC">
         <comment>Label: RoleCode Daughter</comment>
         <value lang="en-us">Daughter</value>
         <value lang="nl-nl">Dochter</value>
+        <value lang="fr-fr">Fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DAU">
         <comment>Label: RoleCode natural daughterDaughter </comment>
         <value lang="en-us">natural daughter</value>
         <value lang="nl-nl">natuurlijke dochter</value>
+        <value lang="fr-fr">Fille biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPDAU">
         <comment>Label: RoleCode stepdaughter</comment>
         <value lang="en-us">stepdaughter</value>
         <value lang="nl-nl">stiefdochter</value>
+        <value lang="fr-fr">Belle-fille - fille du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NCHILD">
         <comment>Label: RoleCode natural child</comment>
         <value lang="en-us">natural child</value>
         <value lang="nl-nl">natuurlijk kind</value>
+        <value lang="fr-fr">Enfant biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SON">
         <comment>Label: RoleCode natural sonSon </comment>
         <value lang="en-us">natural son</value>
         <value lang="nl-nl">naturlijke zoon</value>
+        <value lang="fr-fr">Fils biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SONC">
         <comment>Label: RoleCode son</comment>
         <value lang="en-us">son</value>
         <value lang="nl-nl">zoon</value>
+        <value lang="fr-fr">Fils</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPSON">
         <comment>Label: RoleCode stepson</comment>
         <value lang="en-us">stepson</value>
         <value lang="nl-nl">stiefzoon</value>
+        <value lang="fr-fr">Beau-fils - fils du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPCHLD">
         <comment>Label: RoleCode step child</comment>
         <value lang="en-us">step child</value>
         <value lang="nl-nl">stiefkind</value>
+        <value lang="fr-fr">Enfant du conjoint ou de la conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-EXT">
         <comment>Label: RoleCode extended family member</comment>
         <value lang="en-us">extended family member</value>
         <value lang="nl-nl">ver familielid</value>
+        <value lang="fr-fr">Autre membre de la famille sans lien génétique direct</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-AUNT">
         <comment>Label: RoleCode aunt</comment>
         <value lang="en-us">aunt</value>
         <value lang="nl-nl">tante</value>
+        <value lang="fr-fr">Tante</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MAUNT">
         <comment>Label: RoleCode MaternalAunt</comment>
         <value lang="en-us">Maternal Aunt</value>
         <value lang="nl-nl">Tante via moeder</value>
+        <value lang="fr-fr">Tante maternelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PAUNT">
         <comment>Label: RoleCode PaternalAunt</comment>
         <value lang="en-us">Paternal Aunt</value>
         <value lang="nl-nl">Tante via vader</value>
+        <value lang="fr-fr">Tante paternelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-COUSN">
         <comment>Label: RoleCode cousin</comment>
         <value lang="en-us">cousin</value>
         <value lang="nl-nl">neef/nicht</value>
+        <value lang="fr-fr">Cousin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MCOUSN">
         <comment>Label: RoleCode MaternalCousin</comment>
         <value lang="en-us">Maternal Cousin</value>
         <value lang="nl-nl">Neef/nicht via moeder</value>
+        <value lang="fr-fr">Cousin maternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PCOUSN">
         <comment>Label: RoleCode PaternalCousin</comment>
         <value lang="en-us">Paternal Cousin</value>
         <value lang="nl-nl">Neef/nicht via vader</value>
+        <value lang="fr-fr">Cousin paternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GGRPRN">
         <comment>Label: RoleCode great grandparent</comment>
         <value lang="en-us">great grandparent</value>
         <value lang="nl-nl">overgrootouder</value>
+        <value lang="fr-fr">Arrière-grand-parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GGRFTH">
         <comment>Label: RoleCode great grandfather</comment>
         <value lang="en-us">great grandfather</value>
         <value lang="nl-nl">overgrootvader</value>
+        <value lang="fr-fr">Arrière-grand-père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GGRMTH">
         <comment>Label: RoleCode great grandmother</comment>
         <value lang="en-us">great grandmother</value>
         <value lang="nl-nl">overgrootmoeder</value>
+        <value lang="fr-fr">Arrière-grand-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGGRFTH">
         <comment>Label: RoleCode MaternalGreatgrandfather</comment>
         <value lang="en-us">Maternal Greatgrandfather</value>
         <value lang="nl-nl">overgrootvader via moeder</value>
+        <value lang="fr-fr">Arrière-grand-père maternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGGRMTH">
         <comment>Label: RoleCode MaternalGreatgrandmother</comment>
         <value lang="en-us">Maternal Greatgrandmother</value>
         <value lang="nl-nl">overgrootmoeder via moeder</value>
+        <value lang="fr-fr">Arrière-grand-mère maternelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGGRPRN">
         <comment>Label: RoleCode MaternalGreatgrandparent</comment>
         <value lang="en-us">Maternal Greatgrandparent</value>
         <value lang="nl-nl">overgrootouder via moeder</value>
+        <value lang="fr-fr">Arrière-grand-parents maternels</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGGRFTH">
         <comment>Label: RoleCode PaternalGreatgrandfather</comment>
         <value lang="en-us">Paternal Greatgrandfather</value>
         <value lang="nl-nl">overgrootvader via vader</value>
+        <value lang="fr-fr">Arrière-grand-père paternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGGRMTH">
         <comment>Label: RoleCode PaternalGreatgrandmother</comment>
         <value lang="en-us">Paternal Greatgrandmother</value>
         <value lang="nl-nl">overgrootmoeder via vader</value>
+        <value lang="fr-fr">Arrière-grand-mère paternelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGGRPRN">
         <comment>Label: RoleCode PaternalGreatgrandparent</comment>
         <value lang="en-us">Paternal Greatgrandparent</value>
         <value lang="nl-nl">overgrootouder via vader</value>
+        <value lang="fr-fr">Arrière-grand-parents paternels</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRNDCHILD">
         <comment>Label: RoleCode grandchild</comment>
         <value lang="en-us">grandchild</value>
         <value lang="nl-nl">kleinkind</value>
+        <value lang="fr-fr">Petit-enfant</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRNDDAU">
         <comment>Label: RoleCode granddaughter</comment>
         <value lang="en-us">granddaughter</value>
         <value lang="nl-nl">kleindochter</value>
+        <value lang="fr-fr">Petite-fille</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRNDSON">
         <comment>Label: RoleCode grandson</comment>
         <value lang="en-us">grandson</value>
         <value lang="nl-nl">kleinzoon</value>
+        <value lang="fr-fr">Petit-fils</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRPRN">
         <comment>Label: RoleCode Grandparent</comment>
         <value lang="en-us">Grandparent</value>
         <value lang="nl-nl">grootouder</value>
+        <value lang="fr-fr">Grands-parents</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRFTH">
         <comment>Label: RoleCode Grandfather</comment>
         <value lang="en-us">Grandfather</value>
         <value lang="nl-nl">grootvader</value>
+        <value lang="fr-fr">Grand-père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GRMTH">
         <comment>Label: RoleCode Grandmother</comment>
         <value lang="en-us">Grandmother</value>
         <value lang="nl-nl">grootmoeder</value>
+        <value lang="fr-fr">Grand-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGRFTH">
         <comment>Label: RoleCode MaternalGrandfather</comment>
         <value lang="en-us">MaternalGrandfather</value>
         <value lang="nl-nl">grootvader via moeder</value>
+        <value lang="fr-fr">Grand-père maternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MGRMTH">
         <comment>Label: RoleCode MaternalGrandmother</comment>
@@ -3273,36 +3880,43 @@
         <comment>Label: RoleCode MaternalGrandparent</comment>
         <value lang="en-us">Maternal Grandparent</value>
         <value lang="nl-nl">grootouder via moeder</value>
+        <value lang="fr-fr">Grands-parents maternels</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGRFTH">
         <comment>Label: RoleCode PaternalGrandfather</comment>
         <value lang="en-us">Paternal Grandfather</value>
         <value lang="nl-nl">grootvader via vader</value>
+        <value lang="fr-fr">Grand-père paternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGRMTH">
         <comment>Label: RoleCode PaternalGrandmother</comment>
         <value lang="en-us">Paternal Grandmother</value>
         <value lang="nl-nl">grootmoeder via vader</value>
+        <value lang="fr-fr">Grand-mère paternelle</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PGRPRN">
         <comment>Label: RoleCode PaternalGrandparent</comment>
         <value lang="en-us">Paternal Grandparent</value>
         <value lang="nl-nl">grootouder via vader</value>
+        <value lang="fr-fr">Grands-parents paternels</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NIENEPH">
         <comment>Label: RoleCode niece/nephew</comment>
         <value lang="en-us">niece/nephew</value>
         <value lang="nl-nl">nicht/neef</value>
+        <value lang="fr-fr">Nièce / Neveu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NEPHEW">
         <comment>Label: RoleCode nephew</comment>
         <value lang="en-us">nephew</value>
         <value lang="nl-nl">neef</value>
+        <value lang="fr-fr">Neveu</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NIECE">
         <comment>Label: RoleCode niece</comment>
         <value lang="en-us">niece</value>
         <value lang="nl-nl">nicht</value>
+        <value lang="fr-fr">Nièce</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-UNCLE">
         <comment>Label: RoleCode uncle</comment>
@@ -3313,226 +3927,271 @@
         <comment>Label: RoleCode MaternalUncle</comment>
         <value lang="en-us">Maternal Uncle</value>
         <value lang="nl-nl">oom via moeder</value>
+        <value lang="fr-fr">Oncle maternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PUNCLE">
         <comment>Label: RoleCode PaternalUncle</comment>
         <value lang="en-us">Paternal Uncle</value>
         <value lang="nl-nl">oom via vader</value>
+        <value lang="fr-fr">Oncle paternel</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PRN">
         <comment>Label: RoleCode Parent</comment>
         <value lang="en-us">Parent</value>
         <value lang="nl-nl">ouder</value>
+        <value lang="fr-fr">Parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FTH">
         <comment>Label: RoleCode Father</comment>
         <value lang="en-us">Father</value>
         <value lang="nl-nl">vader</value>
+        <value lang="fr-fr">Père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MTH">
         <comment>Label: RoleCode Mother</comment>
         <value lang="en-us">Mother</value>
         <value lang="nl-nl">moeder</value>
+        <value lang="fr-fr">Mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NPRN">
         <comment>Label: RoleCode natural parent</comment>
         <value lang="en-us">natural parent</value>
         <value lang="nl-nl">natuurlijke ouder</value>
+        <value lang="fr-fr">Parent biologique, au sens père ou mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NFTH">
         <comment>Label: RoleCode natural father</comment>
         <value lang="en-us">natural father</value>
         <value lang="nl-nl">natuurlijke vader</value>
+        <value lang="fr-fr">Père biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NFTHF">
         <comment>Label: RoleCode natural father of fetus</comment>
         <value lang="en-us">natural father of fetus</value>
         <value lang="nl-nl">natuurlijke vader van foetus</value>
+        <value lang="fr-fr">Père biologique du fœtus</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NMTH">
         <comment>Label: RoleCode natural mother</comment>
         <value lang="en-us">natural mother</value>
         <value lang="nl-nl">natuurlijke moeder</value>
+        <value lang="fr-fr">Mère biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-PRNINLAW">
         <comment>Label: RoleCode parent in-law</comment>
         <value lang="en-us">parent in-law</value>
         <value lang="nl-nl">schoonouder</value>
+        <value lang="fr-fr">Beau-père ou belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FTHINLAW">
         <comment>Label: RoleCode father-in-law</comment>
         <value lang="en-us">father-in-law</value>
         <value lang="nl-nl">schoonvader</value>
+        <value lang="fr-fr">Beau-père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-MTHINLAW">
         <comment>Label: RoleCode mother-in-law</comment>
         <value lang="en-us">mother-in-law</value>
         <value lang="nl-nl">schoonmoeder</value>
+        <value lang="fr-fr">Belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPPRN">
         <comment>Label: RoleCode step parent</comment>
         <value lang="en-us">step parent</value>
         <value lang="nl-nl">stiefouder</value>
+        <value lang="fr-fr">Beau-père ou belle-mère - conjoint du père ou de la mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPFTH">
         <comment>Label: RoleCode stepfather</comment>
         <value lang="en-us">stepfather</value>
         <value lang="nl-nl">stiefvader</value>
+        <value lang="fr-fr">Beau-père - époux de la mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPMTH">
         <comment>Label: RoleCode stepmother</comment>
         <value lang="en-us">stepmother</value>
         <value lang="nl-nl">stiefmoeder</value>
+        <value lang="fr-fr">Belle-mère - épouse du père</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIB">
         <comment>Label: RoleCode Sibling</comment>
         <value lang="en-us">Sibling</value>
         <value lang="nl-nl">broer/zus</value>
+        <value lang="fr-fr">Frère ou sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-BRO">
         <comment>Label: RoleCode Brother</comment>
         <value lang="en-us">Brother</value>
         <value lang="nl-nl">broer</value>
+        <value lang="fr-fr">Frère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HSIB">
         <comment>Label: RoleCode half-sibling</comment>
         <value lang="en-us">half-sibling</value>
         <value lang="nl-nl">halfbroer/zus</value>
+        <value lang="fr-fr">Demi-frère ou demi-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HBRO">
         <comment>Label: RoleCode half-brother</comment>
         <value lang="en-us">half-brother</value>
         <value lang="nl-nl">halfbroer</value>
+        <value lang="fr-fr">Demi-frère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HSIS">
         <comment>Label: RoleCode half-sister</comment>
         <value lang="en-us">half-sister</value>
         <value lang="nl-nl">halfzus</value>
+        <value lang="fr-fr">Demi-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NSIB">
         <comment>Label: RoleCode natural sibling</comment>
         <value lang="en-us">natural sibling</value>
         <value lang="nl-nl">natuurlijke broer/zus</value>
+        <value lang="fr-fr">Frère ou soeur biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NBRO">
         <comment>Label: RoleCode natural brother</comment>
         <value lang="en-us">natural brother</value>
         <value lang="nl-nl">natuurlijke broer</value>
+        <value lang="fr-fr">Frère biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NSIS">
         <comment>Label: RoleCode natural sister</comment>
         <value lang="en-us">natural sister</value>
         <value lang="nl-nl">natuurlijke zus</value>
+        <value lang="fr-fr">Soeur biologique</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIBINLAW">
         <comment>Label: RoleCode sibling in-law</comment>
         <value lang="en-us">sibling in-law</value>
         <value lang="nl-nl">schoonbroer/zus</value>
+        <value lang="fr-fr">Beau-frère ou belle-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-BROINLAW">
         <comment>Label: RoleCode brother-in-law</comment>
         <value lang="en-us">brother-in-law</value>
         <value lang="nl-nl">zwager</value>
+        <value lang="fr-fr">Beau-frère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SISINLAW">
         <comment>Label: RoleCode sister-in-law</comment>
         <value lang="en-us">sister-in-law</value>
         <value lang="nl-nl">schoonzus</value>
+        <value lang="fr-fr">Belle-sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIS">
         <comment>Label: RoleCode Sister</comment>
         <value lang="en-us">Sister</value>
         <value lang="nl-nl">zus</value>
+        <value lang="fr-fr">Sœur</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPSIB">
         <comment>Label: RoleCode step sibling</comment>
         <value lang="en-us">step sibling</value>
         <value lang="nl-nl">stiefbroer/zus</value>
+        <value lang="fr-fr">Enfant du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPBRO">
         <comment>Label: RoleCode stepbrother</comment>
         <value lang="en-us">stepbrother</value>
         <value lang="nl-nl">stiefbroer</value>
+        <value lang="fr-fr">Fils du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-STPSIS">
         <comment>Label: RoleCode stepsister</comment>
         <value lang="en-us">stepsister</value>
         <value lang="nl-nl">stiefzus</value>
+        <value lang="fr-fr">Fille du beau-père ou de la belle-mère</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SIGOTHR">
         <comment>Label: RoleCode significant other</comment>
         <value lang="en-us">significant other</value>
         <value lang="nl-nl">significante derde</value>
+        <value lang="fr-fr">Conjoint ou conjointe</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-DOMPART">
         <comment>Label: RoleCode domestic partner</comment>
         <value lang="en-us">domestic partner</value>
         <value lang="nl-nl">huisgenoot</value>
+        <value lang="fr-fr">Concubin(e) ou partenaire PACS</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-SPS">
         <comment>Label: RoleCode spouse</comment>
         <value lang="en-us">spouse</value>
         <value lang="nl-nl">echtgenoot</value>
+        <value lang="fr-fr">Epoux ou épouse</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-HUSB">
         <comment>Label: RoleCode husband</comment>
         <value lang="en-us">husband</value>
         <value lang="nl-nl">echtgenoot</value>
+        <value lang="fr-fr">Epoux</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-WIFE">
         <comment>Label: RoleCode wife</comment>
         <value lang="en-us">wife</value>
         <value lang="nl-nl">echtgenote</value>
+        <value lang="fr-fr">Epouse</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-FRND">
         <comment>Label: RoleCode unrelated friend</comment>
         <value lang="en-us">unrelated friend</value>
         <value lang="nl-nl">niet-gerelateerde vriend</value>
+        <value lang="fr-fr">Ami</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NBOR">
         <comment>Label: RoleCode neighbor</comment>
         <value lang="en-us">neighbor</value>
         <value lang="nl-nl">buur</value>
+        <value lang="fr-fr">Voisin</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-ROOM">
         <comment>Label: RoleCode Roommate</comment>
         <value lang="en-us">Roommate</value>
         <value lang="nl-nl">kamergenoot</value>
+        <value lang="fr-fr">Colocataire</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-NOK">
         <comment>Label: RoleCode Next of Kin</comment>
         <value lang="en-us">Next of Kin</value>
         <value lang="nl-nl">familielid</value>
+        <value lang="fr-fr">Plus proche parent</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-ECON">
         <comment>Label: RoleCode Emergency contact</comment>
         <value lang="en-us">Emergency contact</value>
         <value lang="nl-nl">Contact in nood</value>
+        <value lang="fr-fr">Contact en cas d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.111-GENRL">
         <comment>Label: RoleCode General</comment>
         <value lang="en-us">General</value>
         <value lang="nl-nl">Algemeen</value>
+        <value lang="fr-fr">Général</value>
     </translation>
     <translation key="2.16.840.1.113883.12.443-CP">
         <comment>Label: OID HL7 v2 Table 443 Provider Role code system</comment>
         <value lang="en-us">consulting provider</value>
         <value lang="nl-nl">adviserende zorgverlener</value>
+        <value lang="fr-fr">prestataire de conseil</value>
     </translation>
     <translation key="2.16.840.1.113883.12.443-PP">
         <comment>Label: OID HL7 v2 Table 443 Provider Role code system</comment>
         <value lang="en-us">primary care provider</value>
         <value lang="nl-nl">eerstelijns zorgverlener</value>
+        <value lang="fr-fr">fournisseur de soins primaires</value>
     </translation>
     <translation key="2.16.840.1.113883.12.443-RP">
         <comment>Label: OID HL7 v2 Table 443 Provider Role code system</comment>
         <value lang="en-us">referring provider</value>
         <value lang="nl-nl">verwijzende zorgverlener</value>
+        <value lang="fr-fr">fournisseur référent</value>
     </translation>
     <translation key="2.16.840.1.113883.12.443-MP">
         <comment>Label: OID HL7 v2 Table 443 Provider Role code system</comment>
         <value lang="en-us">medical home provider</value>
         <value lang="nl-nl">verplegende/verzorgende zorgverlener</value>
+        <value lang="fr-fr">prestataire de soins à domicile</value>
     </translation>
     <translation key="typeCode-AUT">
         <comment>Label: ParticipationType Author</comment>
@@ -3541,6 +4200,7 @@
         <value lang="fr-ch">Auteur</value>
         <value lang="it-ch">Autore</value>
         <value lang="nl-nl">Auteur</value>
+        <value lang="fr-fr">Auteur</value>
     </translation>
     <translation key="typeCode-ENT">
         <comment>Label: ParticipationType Entered by</comment>
@@ -3549,16 +4209,19 @@
         <value lang="fr-ch">Saisie par</value>
         <value lang="it-ch">Registrati da</value>
         <value lang="nl-nl">Ingevoerd door</value>
+        <value lang="fr-fr">Opérateur de saisie</value>
     </translation>
     <translation key="typeCode-FLFS">
         <comment>Label: In Fulfillment Of</comment>
         <value lang="en-us">In Fulfillment Of</value>
         <value lang="nl-nl">Op basis van</value>
+        <value lang="fr-fr">Prescription</value>
     </translation>
     <translation key="typeCode-FLFS-rev">
         <comment>Label: Fulfilled By</comment>
         <value lang="en-us">Fulfilled By</value>
         <value lang="nl-nl">Als basis voor</value>
+        <value lang="fr-fr">Délivré par</value>
     </translation>
     <translation key="typeCode-INF">
         <comment>Label: Informant - An informant (or source of information) is a person that provides relevant information</comment>
@@ -3566,6 +4229,7 @@
         <value lang="de-ch">Informiert</value>
         <value lang="fr-ch">Informé</value>
         <value lang="it-ch">Informati</value>
+        <value lang="fr-fr">Informateur</value>
     </translation>
     <translation key="typeCode-AUTHEN">
         <comment>Label: ParticipationType authenticator</comment>
@@ -3573,6 +4237,7 @@
         <value lang="de-ch">Unterzeichnet</value>
         <value lang="fr-ch">Signataires</value>
         <value lang="nl-nl">Ondertekenaar</value>
+        <value lang="fr-fr">Approbateur</value>
     </translation>
     <translation key="typeCode-LA">
         <comment>Label: ParticipationType Legal Authenticator</comment>
@@ -3581,212 +4246,254 @@
         <value lang="fr-ch">Légal signataires</value>
         <value lang="it-ch">Efficace legge firmato</value>
         <value lang="nl-nl">Juridische ondertekenaar</value>
+        <value lang="fr-fr">Signataire légal</value>
     </translation>
     <translation key="typeCode-PRCP">
         <comment>Label: ParticipationType Information Recipient</comment>
         <value lang="en-us">Information Recipient</value>
         <value lang="nl-nl">Ontvanger</value>
+        <value lang="fr-fr">Destinataire prévu</value>
     </translation>
     <translation key="typeCode-PRF">
         <comment>Label: ServiceEventPerformer Performer</comment>
         <value lang="en-us">Performer</value>
         <value lang="nl-nl">Uitvoerende</value>
+        <value lang="fr-fr">Exécutant </value>
     </translation>
     <translation key="typeCode-PPRF">
         <comment>Label: ServiceEventPerformer Primary Performer</comment>
         <value lang="en-us">Primary Performer</value>
         <value lang="nl-nl">Eerste uitvoerende</value>
+        <value lang="fr-fr">Exécutant principal </value>
     </translation>
     <translation key="typeCode-RCT">
         <comment>Label: ParticipationType Record Target</comment>
         <value lang="en-us">Patient</value>
         <value lang="it-ch">Paziente</value>
         <value lang="nl-nl">Patiënt</value>
+        <value lang="fr-fr">Patient </value>
     </translation>
     <translation key="typeCode-RESP">
         <comment>Label: ParticipationType Responsible party</comment>
         <value lang="en-us">Responsible Party</value>
         <value lang="nl-nl">Verantwoordelijke</value>
+        <value lang="fr-fr">Responsable </value>
     </translation>
     <translation key="typeCode-SPRF">
         <comment>Label: ServiceEventPerformer Supporting Performer</comment>
         <value lang="en-us">Supporting Performer</value>
         <value lang="nl-nl">Ondersteunend uitvoerende</value>
+        <value lang="fr-fr">Exécutant secondaire </value>
     </translation>
     <translation key="typeCode-TRC">
         <comment>Label: ParticipationType Tracker</comment>
         <value lang="en-us">Secondary Information Recipient</value>
         <value lang="nl-nl">Kopie-ontvanger</value>
+        <value lang="fr-fr">Destinataire secondaire </value>
     </translation>
     <translation key="typeCode-COMP">
         <comment>Label: ActRelationship Component</comment>
         <value lang="en-us">Component</value>
         <value lang="nl-nl">Component</value>
+        <value lang="fr-fr">Composant</value>
     </translation>
     <translation key="typeCode-COMP-rev">
         <comment>Label: ActRelationship Component</comment>
         <value lang="en-us">Component Of</value>
         <value lang="nl-nl">Component van</value>
+        <value lang="fr-fr">Composant de</value>
     </translation>
     <translation key="typeCode-MFST">
         <comment>Label: ActRelationship Manifestation Of</comment>
         <value lang="en-us">Manifestation Of</value>
         <value lang="nl-nl">Manifestatie van</value>
+        <value lang="fr-fr">Manifestation de</value>
     </translation>
     <translation key="typeCode-MFST-rev">
         <comment>Label: ActRelationship Manifestation Of</comment>
         <value lang="en-us">Manifested By</value>
         <value lang="nl-nl">Gemanifesteerd door</value>
+        <value lang="fr-fr">Manifesté par</value>
     </translation>
     <translation key="typeCode-REFR">
         <comment>Label: ActRelationship Refers To</comment>
         <value lang="en-us">Refers To</value>
         <value lang="nl-nl">Verwijst naar</value>
+        <value lang="fr-fr">Fait référence à</value>
     </translation>
     <translation key="typeCode-REFR-rev">
         <comment>Label: ActRelationship Referred By</comment>
         <value lang="en-us">Referred By</value>
         <value lang="nl-nl">Wordt naar verwezen door</value>
+        <value lang="fr-fr">Référencé par</value>
     </translation>
     <translation key="typeCode-RPLC">
         <comment>Label: ActRelationship Replaces</comment>
         <value lang="en-us">Replaces</value>
         <value lang="nl-nl">Vervangt</value>
+        <value lang="fr-fr">remplace</value>
     </translation>
     <translation key="typeCode-RPLC-rev">
         <comment>Label: ActRelationship Replaced By</comment>
         <value lang="en-us">Replaced By</value>
         <value lang="nl-nl">Vervangen door</value>
+        <value lang="fr-fr">remplacé par</value>
     </translation>
     <translation key="typeCode-RSON">
         <comment>Label: ActRelationship Has Reason</comment>
         <value lang="en-us">Reason</value>
         <value lang="nl-nl">Reden</value>
+        <value lang="fr-fr">Raison</value>
     </translation>
     <translation key="typeCode-RSON-rev">
         <comment>Label: ActRelationship Is Reason For</comment>
         <value lang="en-us">Is Reason For</value>
         <value lang="nl-nl">Is reden voor</value>
+        <value lang="fr-fr">est la raison de</value>
     </translation>
     <translation key="typeCode-SUBJ">
         <comment>Label: ActRelationship Subject</comment>
         <value lang="en-us">Subject</value>
         <value lang="nl-nl">Subject</value>
+        <value lang="fr-fr">sujet</value>
     </translation>
     <translation key="typeCode-SUBJ-rev">
         <comment>Label: ActRelationship Subject Of</comment>
         <value lang="en-us">Subject Of</value>
         <value lang="nl-nl">Subject van</value>
+        <value lang="fr-fr">sujet de</value>
     </translation>
     <translation key="typeCode-SPRT">
         <comment>Label: ActRelationship Supported By</comment>
         <value lang="en-us">Supported By</value>
         <value lang="nl-nl">Ondersteund door</value>
+        <value lang="fr-fr">supporté par</value>
     </translation>
     <translation key="typeCode-SPRT-rev">
         <comment>Label: ActRelationship Supports</comment>
         <value lang="en-us">Supports</value>
         <value lang="nl-nl">Ondersteunt</value>
+        <value lang="fr-fr">supports</value>
     </translation>
     <translation key="moodCode-DEF">
         <comment>Label MoodCode Definition</comment>
         <value lang="en-us">definition</value>
         <value lang="nl-nl">definitie</value>
+        <value lang="fr-fr">définition</value>
     </translation>
     <translation key="moodCode-GOL">
         <comment>Label MoodCode Goal</comment>
         <value lang="en-us">goal</value>
         <value lang="nl-nl">doel</value>
+        <value lang="fr-fr">but</value>
     </translation>
     <translation key="moodCode-INT">
         <comment>Label MoodCode Intent</comment>
         <value lang="en-us">intent</value>
         <value lang="nl-nl">intentie</value>
+        <value lang="fr-fr">intention</value>
     </translation>
     <translation key="moodCode-PRMS">
         <comment>Label MoodCode Promise</comment>
         <value lang="en-us">promise</value>
         <value lang="nl-nl">belofte</value>
+        <value lang="fr-fr">promesse</value>
     </translation>
     <translation key="moodCode-PRP">
         <comment>Label MoodCode Proposal</comment>
         <value lang="en-us">proposal</value>
         <value lang="nl-nl">voorstel</value>
+        <value lang="fr-fr">proposition</value>
     </translation>
     <translation key="moodCode-RQO">
         <comment>Label MoodCode Request</comment>
         <value lang="en-us">request</value>
         <value lang="nl-nl">aanvraag</value>
+        <value lang="fr-fr">demande</value>
     </translation>
     <translation key="nameUse_ABC">
         <comment>Label: Alphabetic transcription of name (Japanese: romaji)</comment>
         <value lang="en-us">Alphabetic</value>
         <value lang="nl-nl">alphabetisch</value>
+        <value lang="fr-fr">alphabetique</value>
     </translation>
     <translation key="nameUse_IDE">
         <comment>Label: Ideographic representation of name (e.g., Japanese kanji, Chinese characters)</comment>
         <value lang="en-us">Ideographic</value>
         <value lang="nl-nl">ideographisch</value>
+        <value lang="fr-fr">idéographique</value>
     </translation>
     <translation key="nameUse_SYL">
         <comment>Label: Syllabic transcription of name (e.g., Japanese kana, Korean hangul)</comment>
         <value lang="en-us">Syllabic</value>
         <value lang="nl-nl">syllabisch</value>
+        <value lang="fr-fr">syllabique</value>
     </translation>
     <translation key="nameUse_ASGN">
         <comment>Label: A name assigned to a person. Reasons some organizations assign alternate names may include not knowing the person's name, or to maintain anonymity. Some, but not necessarily all, of the name types that people call "alias" may fit into this category.</comment>
         <value lang="en-us">assigned</value>
         <value lang="nl-nl">toegekend</value>
+        <value lang="fr-fr">attribué</value>
     </translation>
     <translation key="nameUse_C">
         <comment>Label: As recorded on a license, record, certificate, etc. (only if different from legal name)</comment>
         <value lang="en-us">License</value>
         <value lang="nl-nl">licentie</value>
+        <value lang="fr-fr">officiel</value>
     </translation>
     <translation key="nameUse_I">
         <comment>Label: e.g. Chief Red Cloud</comment>
         <value lang="en-us">Indigenous/Tribal</value>
         <value lang="nl-nl">inheems/tribaal</value>
+        <value lang="fr-fr">indigène/tribal</value>
     </translation>
     <translation key="nameUse_L">
         <comment>Label: Known as/conventional/the one you use</comment>
         <value lang="en-us">Legal</value>
         <value lang="nl-nl">Bekend als</value>
+        <value lang="fr-fr">Nom d'usage</value>
     </translation>
     <translation key="nameUse_OR">
         <comment>Label: The formal name as registered in an official (government) registry, but which name might not be commonly used. Particularly used in countries with a law system based on Napoleonic law.</comment>
         <value lang="en-us">official registry</value>
         <value lang="nl-nl">officieel</value>
+        <value lang="fr-fr">de naissance</value>
     </translation>
     <translation key="nameUse_P">
         <comment>Label: A self asserted name that the person is using or has used.</comment>
         <value lang="en-us">pseudonym</value>
         <value lang="nl-nl">pseudoniem</value>
+        <value lang="fr-fr">pseudonyme</value>
     </translation>
     <translation key="nameUse_A">
         <comment>Label: Includes writer's pseudonym, stage name, etc</comment>
         <value lang="en-us">Artist/Stage</value>
         <value lang="nl-nl">artiest/stage</value>
+        <value lang="fr-fr">pseudonyme</value>
     </translation>
     <translation key="nameUse_R">
         <comment>Label: e.g. Sister Mary Francis, Brother John</comment>
         <value lang="en-us">Religious</value>
         <value lang="nl-nl">religieus</value>
+        <value lang="fr-fr">religieux</value>
     </translation>
     <translation key="nameUse_SRCH">
         <comment>Label: A name intended for use in searching or matching.</comment>
         <value lang="en-us">search</value>
         <value lang="nl-nl">zoek</value>
+        <value lang="fr-fr">recherche</value>
     </translation>
     <translation key="nameUse_PHON">
         <comment>Label: A name spelled phonetically.</comment>
         <value lang="en-us">phonetic</value>
         <value lang="nl-nl">fonetisch</value>
+        <value lang="fr-fr">phonétique</value>
     </translation>
     <translation key="nameUse_SNDX">
         <comment>Label: A name spelled according to the SoundEx algorithm.</comment>
         <value lang="en-us">Soundex</value>
         <value lang="nl-nl">soundex</value>
+        <value lang="fr-fr">Soundex</value>
     </translation>
     <translation key="addressUse_H">
         <comment>Label: Home (e.g. address, or telecom type)</comment>
@@ -3795,6 +4502,7 @@
         <value lang="fr-ch">p</value>
         <value lang="it-ch">C</value>
         <value lang="nl-nl">Privé</value>
+        <value lang="fr-fr">Domicile</value>
     </translation>
     <translation key="addressUse_HV">
         <comment>Label: Vacation Home (e.g. address, or telecom type)</comment>
@@ -3803,6 +4511,7 @@
         <value lang="fr-ch">p</value>
         <value lang="it-ch">C</value>
         <value lang="nl-nl">Vakantieadres</value>
+        <value lang="fr-fr">Vacances</value>
     </translation>
     <translation key="addressUse_HP">
         <comment>Label: Home Primary (e.g. address, or telecom type)</comment>
@@ -3811,6 +4520,7 @@
         <value lang="fr-ch">p</value>
         <value lang="it-ch">C</value>
         <value lang="nl-nl">Privé (hoofd)</value>
+        <value lang="fr-fr">Domicile principal</value>
     </translation>
     <translation key="addressUse_WP">
         <comment>Label: Workplace (e.g. address, telecom type)</comment>
@@ -3819,6 +4529,7 @@
         <value lang="fr-ch">g</value>
         <value lang="it-ch">U</value>
         <value lang="nl-nl">Werk</value>
+        <value lang="fr-fr">Travail</value>
     </translation>
     <translation key="addressUse_PUB">
         <comment>Label: Workplace Public (e.g. address, telecom type)</comment>
@@ -3827,49 +4538,59 @@
         <value lang="fr-ch">g</value>
         <value lang="it-ch">U</value>
         <value lang="nl-nl">Werk algemeen</value>
+        <value lang="fr-fr">Public</value>
     </translation>
     <translation key="addressUse_EC">
         <comment>Label: Emergency Contact (e.g. address, or telecom type)</comment>
         <value lang="en-us">Emergency</value>
         <value lang="nl-nl">Noodgevallen</value>
+        <value lang="fr-fr">Urgence</value>
     </translation>
     <translation key="addressUse_MC">
         <comment>Label: Mobile Contact (e.g. telecom type)</comment>
         <value lang="en-us">Mobile</value>
         <value lang="nl-nl">Mobiel</value>
+        <value lang="fr-fr">Mobile</value>
     </translation>
     <translation key="addressUse_PG">
         <comment>Label: Pager (e.g. telecom type)</comment>
         <value lang="en-us">Pager</value>
+        <value lang="fr-fr">Pager</value>
     </translation>
     <translation key="addressUse_PST">
         <comment>Label: Postal (e.g. address type)</comment>
         <value lang="en-us">Postal</value>
         <value lang="nl-nl">Post</value>
+        <value lang="fr-fr">Adresse postale</value>
     </translation>
     <translation key="addressUse_TMP">
         <comment>Label: Temporary (e.g. address type)</comment>
         <value lang="en-us">Temporary</value>
         <value lang="nl-nl">Tijdelijk</value>
+        <value lang="fr-fr">temporaire</value>
     </translation>
     <translation key="addressUse_CONF">
         <comment>Label: Confidential (e.g. address type)</comment>
         <value lang="en-us">Confidential</value>
         <value lang="nl-nl">Geheim</value>
+        <value lang="fr-fr">confidentiel</value>
     </translation>
     <translation key="addressUse_PHYS">
         <comment>Label: Physical (e.g. address type)</comment>
         <value lang="en-us">Physical</value>
         <value lang="nl-nl">Bezoek</value>
+        <value lang="fr-fr">physique</value>
     </translation>
     <translation key="addressUse_DIR">
         <comment>Label: Direct (e.g. address type)</comment>
         <value lang="en-us">Direct</value>
+        <value lang="fr-fr">directe</value>
     </translation>
     <translation key="addressUse_BAD">
         <comment>Label: BAD (e.g. address type)</comment>
         <value lang="en-us">Bad address</value>
         <value lang="nl-nl">Verkeerd adres</value>
+        <value lang="fr-fr">Mauvaise adresse</value>
     </translation>
     <!-- End: voc -->
     <!-- Start: LOINC where SCALE is Doc -->
@@ -3877,11 +4598,14 @@
         <comment>Label: LOINC DOC code 11534-5</comment>
         <value lang="en-us">Temperature charts</value>
         <value lang="nl-nl">Temperatuuroverzicht</value>
+        <value lang="fr-fr">Courbes des température</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC codes -->
     <translation key="2.16.840.1.113883.6.1-11536-0">
         <comment>Label: LOINC DOC code 11536-0</comment>
         <value lang="en-us">Notes (Nursing)</value>
         <value lang="nl-nl">Verslag (verpleging)</value>
+        <value lang="fr-fr">Note (infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11538-6">
         <comment>Label: LOINC DOC code 11538-6</comment>
@@ -3907,37 +4631,46 @@
         <comment>Label: LOINC DOC code 11542-8</comment>
         <value lang="en-us">Subsequent visit evaluation note ({Provider})</value>
         <value lang="nl-nl">Vervolgbezoek evaluatieaantekeningen ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC codes -->
     <translation key="2.16.840.1.113883.6.1-11543-6">
         <comment>Label: LOINC DOC code 11543-6</comment>
         <value lang="en-us">Nursery records</value>
         <value lang="nl-nl">Verpleegkundig dossier</value>
+        <value lang="fr-fr">Dossier infirmier</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11485-0">
         <comment>Label: LOINC DOC code 11485-0</comment>
         <value lang="en-us">Anesthesia records</value>
         <value lang="nl-nl">Anesthesiedossier</value>
+        <value lang="fr-fr">Dossier d'anesthésie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11486-8">
         <comment>Label: LOINC DOC code 11486-8</comment>
         <value lang="en-us">Chemotherapy records</value>
         <value lang="nl-nl">Chemotherapiedossier</value>
+        <value lang="fr-fr">Dossier de chimiothérapie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11488-4">
         <comment>Label: LOINC DOC code 11488-4</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">CR ou fiche de consultation ou de visite ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11490-0">
         <comment>Label: LOINC DOC code 11490-0</comment>
         <value lang="en-us">Discharge summarization note (Physician)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief ({Arts})</value>
+        <value lang="fr-fr">Lettre de sortie (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11492-6">
         <comment>Label: LOINC DOC code 11492-6</comment>
         <value lang="en-us">History and physical note ({Provider})</value>
         <value lang="nl-nl">Geschiedenis en lichamelijk onderzoeksverslag ({Instelling})</value>
+        <value lang="fr-fr">Synthèse ({Fournisseur})</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC codes -->
     <translation key="2.16.840.1.113883.6.1-11494-2">
         <comment>Label: LOINC DOC code 11494-2</comment>
         <value lang="en-us">Initial assessment note (Physician)</value>
@@ -3947,7 +4680,7 @@
         <comment>Label: LOINC DOC code 11495-9</comment>
         <value lang="en-us">Initial assessment note (Physical therapy)</value>
         <value lang="nl-nl">Verslag eerste anamnese (Lichamelijke oefening)</value>
-    </translation>
+    </translation>    
     <translation key="2.16.840.1.113883.6.1-11496-7">
         <comment>Label: LOINC DOC code 11496-7</comment>
         <value lang="en-us">Initial assessment note (Podiatry)</value>
@@ -3973,146 +4706,178 @@
         <value lang="en-us">Initial assessment note (Occupational therapy)</value>
         <value lang="nl-nl">Verslag eerste anamnese (Bezigheidstherapie)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC codes -->
     <translation key="2.16.840.1.113883.6.1-11502-2">
         <comment>Label: LOINC DOC code 11502-2</comment>
         <value lang="en-us">Laboratory report.total</value>
         <value lang="nl-nl">Laboratoriumrapport.volledig</value>
+        <value lang="fr-fr">CR d'examens biologiques</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11503-0">
         <comment>Label: LOINC DOC code 11503-0</comment>
         <value lang="en-us">Medical records</value>
         <value lang="nl-nl">Medisch dossier</value>
+        <value lang="fr-fr">Dossier médical</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11504-8">
         <comment>Label: LOINC DOC code 11504-8</comment>
         <value lang="en-us">Surgical operation note ({Provider})</value>
         <value lang="nl-nl">Verslag chirurgische operatie ({Instelling})</value>
+        <value lang="fr-fr">CR opératoire ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11505-5">
         <comment>Label: LOINC DOC code 11505-5</comment>
         <value lang="en-us">Procedure note (Physician)</value>
         <value lang="nl-nl">Verslag procedure ({Arts})</value>
+        <value lang="fr-fr">CR d'acte thérapeutique (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11506-3">
         <comment>Label: LOINC DOC code 11506-3</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11507-1">
         <comment>Label: LOINC DOC code 11507-1</comment>
         <value lang="en-us">Subsequent evaluation note (Occupational therapy)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note d'évaluation (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11508-9">
         <comment>Label: LOINC DOC code 11508-9</comment>
         <value lang="en-us">Subsequent evaluation note (Physical therapy)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note d'évaluation (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11509-7">
         <comment>Label: LOINC DOC code 11509-7</comment>
         <value lang="en-us">Subsequent evaluation note (Podiatry)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Podologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11510-5">
         <comment>Label: LOINC DOC code 11510-5</comment>
         <value lang="en-us">Subsequent evaluation note (Psychology)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Psychologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11512-1">
-        <comment>Label: LOINC DOC code 11512-1</comment>
+         <comment>Label: LOINC DOC code 11512-1</comment>
         <value lang="en-us">Subsequent evaluation note (Speech therapy)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Spraaktherapie)</value>
+        <value lang="fr-fr">Note d'évaluation (Orthophonie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11514-7">
         <comment>Label: LOINC DOC code 11514-7</comment>
         <value lang="en-us">Records.total (Chiropractic)</value>
         <value lang="nl-nl">Dossier.volledig (Chiropractie)</value>
+        <value lang="fr-fr">Note ou CR (Chiropratique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11515-4">
         <comment>Label: LOINC DOC code 11515-4</comment>
         <value lang="en-us">Records.total (Physical therapy)</value>
         <value lang="nl-nl">Dossier.volledig (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note ou CR (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11516-2">
         <comment>Label: LOINC DOC code 11516-2</comment>
         <value lang="en-us">Records.total (Physician)</value>
         <value lang="nl-nl">Dossier.volledig ({Arts})</value>
+        <value lang="fr-fr">Note ou CR (Médical)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11517-0">
         <comment>Label: LOINC DOC code 11517-0</comment>
         <value lang="en-us">Records.total (Podiatry)</value>
         <value lang="nl-nl">Dossier.volledig (Podologie)</value>
+        <value lang="fr-fr">Note ou CR (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11518-8">
         <comment>Label: LOINC DOC code 11518-8</comment>
         <value lang="en-us">Records.total (Psychology)</value>
         <value lang="nl-nl">Dossier.volledig (Psychologie)</value>
+        <value lang="fr-fr">Note ou CR (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11519-6">
         <comment>Label: LOINC DOC code 11519-6</comment>
         <value lang="en-us">Records.total (Social service)</value>
         <value lang="nl-nl">Dossier.volledig (Sociale dienst)</value>
+        <value lang="fr-fr">Note ou CR (Service social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11520-4">
         <comment>Label: LOINC DOC code 11520-4</comment>
         <value lang="en-us">Records.total (Speech therapy)</value>
         <value lang="nl-nl">Dossier.volledig (Spraaktherapie)</value>
+        <value lang="fr-fr">Note ou CR (Orthophonie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11521-2">
         <comment>Label: LOINC DOC code 11521-2</comment>
         <value lang="en-us">Records.total (Occupational therapy)</value>
         <value lang="nl-nl">Dossier.volledig (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note ou CR (Ergothérapie)</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-11522-0">
         <comment>Label: LOINC DOC code 11522-0</comment>
         <value lang="en-us">Study report (Cardiac echo)</value>
         <value lang="nl-nl">Onderzoeksverslag (Cardiac echo)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-11523-8">
         <comment>Label: LOINC DOC code 11523-8</comment>
         <value lang="en-us">Study report (EEG)</value>
         <value lang="nl-nl">Onderzoeksverslag (EEG)</value>
+        <value lang="fr-fr">Compte-rendu (EEG)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11524-6">
         <comment>Label: LOINC DOC code 11524-6</comment>
         <value lang="en-us">Study report (EKG)</value>
         <value lang="nl-nl">Onderzoeksverslag (EKG)</value>
+        <value lang="fr-fr">Compte-rendu (ECG)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11525-3">
         <comment>Label: LOINC DOC code 11525-3</comment>
         <value lang="en-us">Study report (OB US)</value>
         <value lang="nl-nl">Onderzoeksverslag (OB US)</value>
+        <value lang="fr-fr">Compte-rendu (échographie de grossesse)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11526-1">
         <comment>Label: LOINC DOC code 11526-1</comment>
         <value lang="en-us">Study report (Pathology)</value>
         <value lang="nl-nl">Onderzoeksverslag (Pathologie)</value>
+        <value lang="fr-fr">Compte-rendu (Pathologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11527-9">
         <comment>Label: LOINC DOC code 11527-9</comment>
         <value lang="en-us">Study report (Psychiatry)</value>
         <value lang="nl-nl">Onderzoeksverslag (Psychiatrie)</value>
+        <value lang="fr-fr">Compte-rendu (Psychiatrie)</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-11528-7">
         <comment>Label: LOINC DOC code 11528-7</comment>
         <value lang="en-us">Study.total (Radiology.XXX)</value>
         <value lang="nl-nl">Onderzoek.volledig (Radiology.XXX)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-11529-5">
         <comment>Label: LOINC DOC code 11529-5</comment>
         <value lang="en-us">Study report (Surgical pathology)</value>
         <value lang="nl-nl">Onderzoeksverslag (Surgical pathology)</value>
+        <value lang="fr-fr">Note d'évaluation (Pathologie chirurgicale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-15507-7">
         <comment>Label: LOINC DOC code 15507-7</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-15508-5">
         <comment>Label: LOINC DOC code 15508-5</comment>
         <value lang="en-us">Labor and delivery records</value>
         <value lang="nl-nl">Dossier zwangerschap en bevalling</value>
+        <value lang="fr-fr">CR d'accouchement</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-17787-3">
         <comment>Label: LOINC DOC code 17787-3</comment>
         <value lang="en-us">Study report (Radnuc)</value>
@@ -4122,122 +4887,148 @@
         <comment>Label: LOINC DOC code 18765-8</comment>
         <value lang="en-us">Subsequent visit evaluation note (Podiatry)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Podologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18766-6">
         <comment>Label: LOINC DOC code 18766-6</comment>
         <value lang="en-us">Subsequent visit evaluation note (Psychology)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Psychologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Psychologie)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18733-6">
         <comment>Label: LOINC DOC code 18733-6</comment>
         <value lang="en-us">Subsequent evaluation note (Attending physician)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Behandelend arts)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin traitant)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18734-4">
         <comment>Label: LOINC DOC code 18734-4</comment>
         <value lang="en-us">Initial evaluation note (Occupational therapy)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18735-1">
         <comment>Label: LOINC DOC code 18735-1</comment>
         <value lang="en-us">Initial evaluation note (Physical therapy)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18736-9">
         <comment>Label: LOINC DOC code 18736-9</comment>
         <value lang="en-us">Initial evaluation note (Physician)</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Arts})</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Médical)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18737-7">
         <comment>Label: LOINC DOC code 18737-7</comment>
         <value lang="en-us">Initial evaluation note (Podiatry)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Podologie)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18738-5">
         <comment>Label: LOINC DOC code 18738-5</comment>
         <value lang="en-us">Initial evaluation note (Psychology)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Psychologie)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18739-3">
         <comment>Label: LOINC DOC code 18739-3</comment>
         <value lang="en-us">Initial evaluation note (Social service)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Sociale dienst)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Service social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18740-1">
         <comment>Label: LOINC DOC code 18740-1</comment>
         <value lang="en-us">Initial evaluation note (Speech therapy)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Spraaktherapie)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Orthophonie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18741-9">
         <comment>Label: LOINC DOC code 18741-9</comment>
         <value lang="en-us">Subsequent visit evaluation note (Attending physician)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Behandelend arts)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin traitant)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18742-7">
         <comment>Label: LOINC DOC code 18742-7</comment>
         <value lang="en-us">Study report (Arthroscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Arthroscopy)</value>
+        <value lang="fr-fr">Compte-rendu (Arthroscopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18743-5">
         <comment>Label: LOINC DOC code 18743-5</comment>
         <value lang="en-us">Autopsy report ({Provider})</value>
         <value lang="nl-nl">Autopsy report ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu d'autopsie ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18744-3">
         <comment>Label: LOINC DOC code 18744-3</comment>
         <value lang="en-us">Study report (Bronchoscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Bronchoscopy)</value>
+        <value lang="fr-fr">Compte-rendu (Bronchoscopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18745-0">
         <comment>Label: LOINC DOC code 18745-0</comment>
         <value lang="en-us">Study report (Cardiac catheterization)</value>
         <value lang="nl-nl">Onderzoeksverslag (Cardiac catheterization)</value>
+        <value lang="fr-fr">Compte-rendu (Cathétérisme cardiaque)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18746-8">
         <comment>Label: LOINC DOC code 18746-8</comment>
         <value lang="en-us">Study report (Colonoscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Colonoscopy)</value>
+        <value lang="fr-fr">Compte-rendu (Coloscopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18747-6">
         <comment>Label: LOINC DOC code 18747-6</comment>
         <value lang="en-us">Study (CT)</value>
         <value lang="nl-nl">Onderzoek (CT)</value>
+        <value lang="fr-fr">Compte-rendu (Scanner)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18748-4">
         <comment>Label: LOINC DOC code 18748-4</comment>
         <value lang="en-us">Study report (Diagnostic imaging)</value>
         <value lang="nl-nl">Onderzoeksverslag (Diagnostic imaging)</value>
+        <value lang="fr-fr">Compte-rendu (Imagerie diagnostique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18749-2">
         <comment>Label: LOINC DOC code 18749-2</comment>
         <value lang="en-us">Study report (Electromyogram)</value>
         <value lang="nl-nl">Onderzoeksverslag (Electromyogram)</value>
+        <value lang="fr-fr">Compte-rendu (Électromyogramme)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18750-0">
         <comment>Label: LOINC DOC code 18750-0</comment>
         <value lang="en-us">Study report (Electrophysiology)</value>
         <value lang="nl-nl">Onderzoeksverslag (Electrophysiology)</value>
+        <value lang="fr-fr">Compte-rendu (Électrophysiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18751-8">
         <comment>Label: LOINC DOC code 18751-8</comment>
         <value lang="en-us">Study report (Endoscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Endoscopy)</value>
+        <value lang="fr-fr">Compte-rendu (Endoscopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18752-6">
         <comment>Label: LOINC DOC code 18752-6</comment>
         <value lang="en-us">Study report (Exercise stress test)</value>
         <value lang="nl-nl">Onderzoeksverslag (Exercise stress test)</value>
+        <value lang="fr-fr">Compte-rendu (Test d'effort)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18753-4">
         <comment>Label: LOINC DOC code 18753-4</comment>
         <value lang="en-us">Study report (Flexible sigmoidoscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Flexible sigmoidoscopy)</value>
+        <value lang="fr-fr">Compte-rendu (sigmoïdoscopie flexible)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18754-2">
         <comment>Label: LOINC DOC code 18754-2</comment>
         <value lang="en-us">Study report (Holter monitor)</value>
         <value lang="nl-nl">Onderzoeksverslag (Holter monitor)</value>
-    </translation>
+        <value lang="fr-fr">Compte-rendu (moniteur Holter)</value>
+    </translation>    
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18755-9">
         <comment>Label: LOINC DOC code 18755-9</comment>
         <value lang="en-us">Study report (MRI)</value>
@@ -4258,1301 +5049,1575 @@
         <value lang="en-us">Study (PET scan)</value>
         <value lang="nl-nl">Onderzoek (PET scan)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18759-1">
         <comment>Label: LOINC DOC code 18759-1</comment>
         <value lang="en-us">Study report (Spirometry)</value>
         <value lang="nl-nl">Onderzoeksverslag (Spirometry)</value>
+        <value lang="fr-fr">Compte-rendu (Spirométrie)</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18760-9">
         <comment>Label: LOINC DOC code 18760-9</comment>
         <value lang="en-us">Study (US)</value>
         <value lang="nl-nl">Onderzoek (US)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18761-7">
         <comment>Label: LOINC DOC code 18761-7</comment>
         <value lang="en-us">Transfer summarization note ({Provider})</value>
         <value lang="nl-nl">Samenvattend verslag overplaatsing ({Instelling})</value>
+        <value lang="fr-fr">Note de transfert ({Fournisseur})</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18762-5">
         <comment>Label: LOINC DOC code 18762-5</comment>
         <value lang="en-us">Subsequent evaluation note (Chiropractor)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Chiropractor)</value>
+        <value lang="fr-fr">Note d'évaluation (Chiropratique)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18763-3">
         <comment>Label: LOINC DOC code 18763-3</comment>
         <value lang="en-us">Initial evaluation note (Consulting physician)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Behandelend arts)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin)</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18764-1">
         <comment>Label: LOINC DOC code 18764-1</comment>
         <value lang="en-us">Subsequent evaluation note (Nurse practitioner)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Nurse practitioner)</value>
-    </translation>
+        <value lang="fr-fr">Note d'évaluation (Infirmière)</value>
+    </translation>    
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18836-7">
         <comment>Label: LOINC DOC code 18836-7</comment>
         <value lang="en-us">Procedure (*)</value>
         <value lang="nl-nl">Ingreep (*)</value>
+        <value lang="fr-fr">Compte-rendu d'échocardiographie de stress</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18841-7">
         <comment>Label: LOINC DOC code 18841-7</comment>
         <value lang="en-us">Hospital consultations</value>
         <value lang="nl-nl">Ziekenhuisbezoeken</value>
+        <value lang="fr-fr">Compte-rendu de consultation hospitalière</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18842-5">
         <comment>Label: LOINC DOC code 18842-5</comment>
         <value lang="en-us">Discharge summarization note ({Provider})</value>
         <value lang="nl-nl">Samenvattende ontslagbrief ({Instelling})</value>
+        <value lang="fr-fr">Lettre de sortie ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-24611-6">
         <comment>Label: LOINC DOC code 24611-6</comment>
         <value lang="en-us">Confirmatory consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ter bevestiging ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu de consultation ambulatoire - 2ème avis ({Fournisseur})</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28032-1">
         <comment>Label: LOINC DOC code 28032-1</comment>
         <value lang="en-us">Report.total (Cardiac echo)</value>
         <value lang="nl-nl">Verslag.volledig (Hart echo)</value>
+        <value lang="fr-fr">Compte-rendu (Echographie cardiaque)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28570-0">
         <comment>Label: LOINC DOC code 28570-0</comment>
         <value lang="en-us">Procedure note ({Provider})</value>
         <value lang="nl-nl">Procedure note ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu d'acte ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28571-8">
         <comment>Label: LOINC DOC code 28571-8</comment>
         <value lang="en-us">Visit note (Speech therapy)</value>
         <value lang="nl-nl">Bezoekverslag (Spraaktherapie)</value>
+        <value lang="fr-fr">Note (Orthophonie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28572-6">
         <comment>Label: LOINC DOC code 28572-6</comment>
         <value lang="en-us">Initial evaluation note (Dentistry)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Tandheelkunde)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28573-4">
         <comment>Label: LOINC DOC code 28573-4</comment>
         <value lang="en-us">Surgical operation note (Physician)</value>
         <value lang="nl-nl">Verslag chirurgische operatie ({Arts})</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Médecin)</value>
     </translation>
+    <!-- [ANS] Star: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28574-2">
         <comment>Label: LOINC DOC code 28574-2</comment>
         <value lang="en-us">Discharge note ({Provider})</value>
         <value lang="nl-nl">Ontslagbrief ({Instelling})</value>
+        <value lang="fr-fr">Lettre de sortie ({Fournisseur})</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28575-9">
         <comment>Label: LOINC DOC code 28575-9</comment>
         <value lang="en-us">Progress note (Nurse practitioner)</value>
         <value lang="nl-nl">Voortgangsrapport (Nurse practitioner)</value>
+        <value lang="fr-fr">Note d'évolution (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28577-5">
         <comment>Label: LOINC DOC code 28577-5</comment>
         <value lang="en-us">Procedure note (Dentistry)</value>
         <value lang="nl-nl">Procedure note (Tandheelkunde)</value>
+        <value lang="fr-fr">Compte-rendu d'acte (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28578-3">
         <comment>Label: LOINC DOC code 28578-3</comment>
         <value lang="en-us">Visit note (Occupational therapy)</value>
         <value lang="nl-nl">Bezoekverslag (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note de consultation (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28579-1">
         <comment>Label: LOINC DOC code 28579-1</comment>
         <value lang="en-us">Visit note (Physical therapy)</value>
         <value lang="nl-nl">Bezoekverslag (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note de consultation (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28580-9">
         <comment>Label: LOINC DOC code 28580-9</comment>
         <value lang="en-us">Progress note (Chiropractor)</value>
         <value lang="nl-nl">Voortgangsrapport (Chiropractor)</value>
+        <value lang="fr-fr">Note d'évolution (Chiropratique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28581-7">
         <comment>Label: LOINC DOC code 28581-7</comment>
         <value lang="en-us">Initial evaluation note (Chiropractor)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Chiropractor)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Chiropratique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28583-3">
         <comment>Label: LOINC DOC code 28583-3</comment>
         <value lang="en-us">Surgical operation note (Dentistry)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Tandheelkunde)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28651-8">
         <comment>Label: LOINC DOC code 28651-8</comment>
         <value lang="en-us">Transfer summarization note (Nursing)</value>
         <value lang="nl-nl">Samenvattend verslag overplaatsing (Verpleging)</value>
+        <value lang="fr-fr">Note de transfert (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28653-4">
         <comment>Label: LOINC DOC code 28653-4</comment>
         <value lang="en-us">Visit note (Social service)</value>
         <value lang="nl-nl">Bezoekverslag (Sociale dienst)</value>
+        <value lang="fr-fr">Note de consultation (Service social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28568-4">
         <comment>Label: LOINC DOC code 28568-4</comment>
         <value lang="en-us">Visit note (Physician)</value>
         <value lang="nl-nl">Bezoekverslag ({Arts})</value>
+        <value lang="fr-fr">Note de consultation (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28569-2">
         <comment>Label: LOINC DOC code 28569-2</comment>
         <value lang="en-us">Subsequent evaluation note (Consulting physician)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Behandelend arts)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28615-3">
         <comment>Label: LOINC DOC code 28615-3</comment>
         <value lang="en-us">Audiology study</value>
         <value lang="nl-nl">Audiologisch onderzoek</value>
+        <value lang="fr-fr">Compte-rendu d'audiologie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28616-1">
         <comment>Label: LOINC DOC code 28616-1</comment>
         <value lang="en-us">Transfer summarization note (Physician)</value>
         <value lang="nl-nl">Samenvattend overplaatsingsverslag ({Arts})</value>
+        <value lang="fr-fr">Note de transfert (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28617-9">
         <comment>Label: LOINC DOC code 28617-9</comment>
         <value lang="en-us">Subsequent evaluation note (Dentistry)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Tandheelkunde)</value>
+        <value lang="fr-fr">Note d'évolution (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28618-7">
         <comment>Label: LOINC DOC code 28618-7</comment>
         <value lang="en-us">Visit note (Dentistry)</value>
         <value lang="nl-nl">Bezoekverslag (Tandheelkunde)</value>
+        <value lang="fr-fr">Note de consultation (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28621-1">
         <comment>Label: LOINC DOC code 28621-1</comment>
         <value lang="en-us">Initial evaluation note (Nurse practitioner)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Nurse practitioner)</value>
-    </translation>
+        <value lang="fr-fr">Note d'évaluation initiale (Infirmière)</value>
+    </translation>    
+    <!-- [ANS] Star: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28622-9">
         <comment>Label: LOINC DOC code 28622-9</comment>
         <value lang="en-us">Discharge assessment note (Nursing)</value>
         <value lang="nl-nl">Discharge assessment note (Verpleging)</value>
+        <value lang="fr-fr">Lettre de sortie (Infirmière)</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28623-7">
         <comment>Label: LOINC DOC code 28623-7</comment>
         <value lang="en-us">Subsequent evaluation note (Nursing)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Verpleging)</value>
+        <value lang="fr-fr">Note d'évaluation (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28624-5">
         <comment>Label: LOINC DOC code 28624-5</comment>
         <value lang="en-us">Surgical operation note (Podiatry)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Podologie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28625-2">
         <comment>Label: LOINC DOC code 28625-2</comment>
         <value lang="en-us">Procedure note (Podiatry)</value>
         <value lang="nl-nl">Procedure note (Podologie)</value>
+        <value lang="fr-fr">Note d'acte (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28626-0">
         <comment>Label: LOINC DOC code 28626-0</comment>
         <value lang="en-us">History and physical note (Physician)</value>
         <value lang="nl-nl">Verslag voorschiedenis en lichaam ({Arts})</value>
+        <value lang="fr-fr">Synthèse (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28627-8">
         <comment>Label: LOINC DOC code 28627-8</comment>
         <value lang="en-us">Subsequent evaluation note (Psychiatry)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Psychiatrie)</value>
+        <value lang="fr-fr">Note d'évaluation (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28628-6">
         <comment>Label: LOINC DOC code 28628-6</comment>
         <value lang="en-us">Visit note (Psychiatry)</value>
         <value lang="nl-nl">Bezoekverslag (Psychiatrie)</value>
+        <value lang="fr-fr">Note de consultation (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28633-6">
         <comment>Label: LOINC DOC code 28633-6</comment>
         <value lang="en-us">Study report (Polysomnography)</value>
         <value lang="nl-nl">Onderzoeksverslag (Polysomnography)</value>
+        <value lang="fr-fr">Compte-rendu (Polysomnographie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28635-1">
         <comment>Label: LOINC DOC code 28635-1</comment>
         <value lang="en-us">Initial evaluation note (Psychiatry)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Psychiatrie)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28636-9">
         <comment>Label: LOINC DOC code 28636-9</comment>
         <value lang="en-us">Initial evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation initiale ({fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28654-2">
         <comment>Label: LOINC DOC code 28654-2</comment>
         <value lang="en-us">Initial evaluation note (Attending physician)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Behandelend arts)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Médecin traitant)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28655-9">
         <comment>Label: LOINC DOC code 28655-9</comment>
         <value lang="en-us">Discharge summarization note (Attending physician)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief (Behandelend arts)</value>
+        <value lang="fr-fr">Lettre de sortie (Médecin traitant)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-28656-7">
         <comment>Label: LOINC DOC code 28656-7</comment>
         <value lang="en-us">Subsequent evaluation note (Social service)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Sociale dienst)</value>
+        <value lang="fr-fr">Note d'évaluation (Service social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29749-9">
         <comment>Label: LOINC DOC code 29749-9</comment>
         <value lang="en-us">Dialysis records</value>
         <value lang="nl-nl">Dialysedossier</value>
+        <value lang="fr-fr">Compte-rendu de dialyse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29750-7">
         <comment>Label: LOINC DOC code 29750-7</comment>
         <value lang="en-us">Neonatal intensive care records</value>
         <value lang="nl-nl">Neonataal intensieve zorg-dossier</value>
+        <value lang="fr-fr">Compte-rendu de soins intensifs néonataux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29751-5">
         <comment>Label: LOINC DOC code 29751-5</comment>
         <value lang="en-us">Critical care records</value>
         <value lang="nl-nl">IC-dossier</value>
+        <value lang="fr-fr">Compte-rendu de soins critiques</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29752-3">
         <comment>Label: LOINC DOC code 29752-3</comment>
         <value lang="en-us">Perioperative records</value>
         <value lang="nl-nl">Peri-operatief dossier</value>
+        <value lang="fr-fr">Compte-rendu périopératoire</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29753-1">
         <comment>Label: LOINC DOC code 29753-1</comment>
         <value lang="en-us">Initial evaluation note (Nursing)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Verpleging)</value>
+        <value lang="fr-fr">Note d'évaluation initiale (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29754-9">
         <comment>Label: LOINC DOC code 29754-9</comment>
         <value lang="en-us">Study report (Nystagmogram)</value>
         <value lang="nl-nl">Onderzoeksverslag (Nystagmogram)</value>
+        <value lang="fr-fr">Compte-rendu (Nystagmogramme)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29755-6">
         <comment>Label: LOINC DOC code 29755-6</comment>
         <value lang="en-us">Study report (Nerve conduction)</value>
         <value lang="nl-nl">Onderzoeksverslag (Zenuwconductie)</value>
+        <value lang="fr-fr">Compte-rendu (Conduction nerveuse)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29756-4">
         <comment>Label: LOINC DOC code 29756-4</comment>
         <value lang="en-us">Study report (Peritoneoscopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Peritoneoscopie)</value>
+        <value lang="fr-fr">Compte-rendu (Péritonéoscopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29757-2">
         <comment>Label: LOINC DOC code 29757-2</comment>
         <value lang="en-us">Study report (Colposcopy)</value>
         <value lang="nl-nl">Onderzoeksverslag (Colposcopie)</value>
+        <value lang="fr-fr">Compte-rendu (Colposcopie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29761-4">
         <comment>Label: LOINC DOC code 29761-4</comment>
         <value lang="en-us">Discharge summarization note (Dentistry)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief (Tandheelkunde)</value>
+        <value lang="fr-fr">Lettre de sortie (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34134-7">
         <comment>Label: LOINC DOC code 34134-7</comment>
         <value lang="en-us">Supervisory note (Attending physician)</value>
         <value lang="nl-nl">Supervisory note (Behandelend arts)</value>
+        <value lang="fr-fr">Note de surveillance (Médecin traitant)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34135-4">
         <comment>Label: LOINC DOC code 34135-4</comment>
         <value lang="en-us">Supervisory note (Attending physician.cardiology)</value>
         <value lang="nl-nl">Verslag van toezicht (Behandelend arts.cardiologie)</value>
+        <value lang="fr-fr">Note de surveillance (Médecin.Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34136-2">
         <comment>Label: LOINC DOC code 34136-2</comment>
         <value lang="en-us">Supervisory note (Attending physician.gastroenterology)</value>
         <value lang="nl-nl">Verslag van toezicht (Behandelend arts.gastro-enterologie)</value>
+        <value lang="fr-fr">Note de surveillance (Médecin.gastro-entérologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34137-0">
         <comment>Label: LOINC DOC code 34137-0</comment>
         <value lang="en-us">Surgical operation note ({Provider})</value>
         <value lang="nl-nl">Verslag chirurgische operatie ({Instelling})</value>
+        <value lang="fr-fr">Note d'opération chirurgicale ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34138-8">
         <comment>Label: LOINC DOC code 34138-8</comment>
         <value lang="en-us">Targeted history and physical note ({Provider})</value>
         <value lang="nl-nl">Targeted history and physical note ({Instelling})</value>
+        <value lang="fr-fr">Synthèse ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34125-5">
         <comment>Label: LOINC DOC code 34125-5</comment>
         <value lang="en-us">Subsequent evaluation note (Case manager)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Case manager)</value>
+        <value lang="fr-fr">Note d'évaluation (Chargé du dossier)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34126-3">
         <comment>Label: LOINC DOC code 34126-3</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34127-1">
         <comment>Label: LOINC DOC code 34127-1</comment>
         <value lang="en-us">Subsequent evaluation note (Dental hygienist)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Dental hygienist)</value>
+        <value lang="fr-fr">Note d'évaluation (Hygiéniste dentaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34128-9">
         <comment>Label: LOINC DOC code 34128-9</comment>
         <value lang="en-us">Subsequent evaluation note (Dentistry)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Tandheelkunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34129-7">
         <comment>Label: LOINC DOC code 34129-7</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34130-5">
         <comment>Label: LOINC DOC code 34130-5</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34131-3">
         <comment>Label: LOINC DOC code 34131-3</comment>
         <value lang="en-us">Subsequent evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag vervolgonderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34132-1">
         <comment>Label: LOINC DOC code 34132-1</comment>
         <value lang="en-us">Subsequent evaluation note (Pharmacy)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Apotheek)</value>
+        <value lang="fr-fr">Note d'évaluation (Pharmacie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34133-9">
         <comment>Label: LOINC DOC code 34133-9</comment>
         <value lang="en-us">Summarization of episode note ({Provider})</value>
         <value lang="nl-nl">Summarization of episode note ({Instelling})</value>
+        <value lang="fr-fr">Synthèse d'épisode de soins ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34798-9">
         <comment>Label: LOINC DOC code 34798-9</comment>
         <value lang="en-us">Consultation note (Neurosurgery)</value>
         <value lang="nl-nl">Consultverslag (Neurosurgery)</value>
+        <value lang="fr-fr">Note de consultation (Neurochirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34799-7">
         <comment>Label: LOINC DOC code 34799-7</comment>
         <value lang="en-us">Evaluation and management note (Neurosurgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Neurosurgery)</value>
+        <value lang="fr-fr">Note d'évaluation (Neurochirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34800-3">
         <comment>Label: LOINC DOC code 34800-3</comment>
         <value lang="en-us">Consultation note (Nutrition+Dietetics)</value>
         <value lang="nl-nl">Consultverslag (Nutrition+Dietetics)</value>
+        <value lang="fr-fr">Note de consultation (Nutrition+Diététique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34801-1">
         <comment>Label: LOINC DOC code 34801-1</comment>
         <value lang="en-us">Evaluation and management note (Nutrition+Dietetics)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Nutrition+Dietetics)</value>
+        <value lang="fr-fr">Note d'évaluation (Nutrition+Diététique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34802-9">
         <comment>Label: LOINC DOC code 34802-9</comment>
         <value lang="en-us">Evaluation and management note (Occupational health)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Occupational health)</value>
+        <value lang="fr-fr">Note d'évaluation (Santé au travail)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34803-7">
         <comment>Label: LOINC DOC code 34803-7</comment>
         <value lang="en-us">Consultation note (Occupational health)</value>
         <value lang="nl-nl">Consultverslag (Occupational health)</value>
+        <value lang="fr-fr">Note de consultation (Santé au travail)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34804-5">
         <comment>Label: LOINC DOC code 34804-5</comment>
         <value lang="en-us">Evaluation and management note (Occupational therapy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note d'évaluation (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34805-2">
         <comment>Label: LOINC DOC code 34805-2</comment>
         <value lang="en-us">Consultation note (Oncology)</value>
         <value lang="nl-nl">Consultverslag (Oncology)</value>
+        <value lang="fr-fr">Note de consultation (Oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33716-2">
         <comment>Label: LOINC DOC code 33716-2</comment>
         <value lang="en-us">Study report (Cytology.non-gyn)</value>
         <value lang="nl-nl">Onderzoeksverslag (Cytology.non-gyn)</value>
+        <value lang="fr-fr">Compte-rendu (Cytologie non gynécologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33717-0">
         <comment>Label: LOINC DOC code 33717-0</comment>
         <value lang="en-us">Study report (Cytology)</value>
         <value lang="nl-nl">Onderzoeksverslag (Cytology)</value>
+        <value lang="fr-fr">Compte-rendu (Cytologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33718-8">
         <comment>Label: LOINC DOC code 33718-8</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33719-6">
         <comment>Label: LOINC DOC code 33719-6</comment>
         <value lang="en-us">Study report (Flow cytometry)</value>
         <value lang="nl-nl">Onderzoeksverslag (Flow cytometry)</value>
+        <value lang="fr-fr">Compte-rendu (Cytométrie en flux)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33720-4">
         <comment>Label: LOINC DOC code 33720-4</comment>
         <value lang="en-us">Blood bank consult</value>
         <value lang="nl-nl">Bloedbank bezoek</value>
+        <value lang="fr-fr">Consultation banque de sang</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-33721-2">
         <comment>Label: LOINC DOC code 33721-2</comment>
         <value lang="en-us">Bone marrow biopsy report</value>
         <value lang="nl-nl">Verslag beenmergbioptie</value>
+        <value lang="fr-fr">Compte-rendu de biopsie de pathologie de la moelle osseuse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34094-3">
         <comment>Label: LOINC DOC code 34094-3</comment>
         <value lang="en-us">Admission history and physical note (Cardiology)</value>
         <value lang="nl-nl">Admission history and physical note (Cardiologie)</value>
+        <value lang="fr-fr">Synthèse d'admission (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34095-0">
         <comment>Label: LOINC DOC code 34095-0</comment>
         <value lang="en-us">Comprehensive history and physical note ({Provider})</value>
         <value lang="nl-nl">Comprehensive history and physical note ({Instelling})</value>
+        <value lang="fr-fr">Synthèse ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34096-8">
         <comment>Label: LOINC DOC code 34096-8</comment>
         <value lang="en-us">Comprehensive history and physical note</value>
         <value lang="nl-nl">Uitgebreid verslag voorgeschiedenis en lichaam</value>
+        <value lang="fr-fr">Synthèse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34097-6">
         <comment>Label: LOINC DOC code 34097-6</comment>
         <value lang="en-us">Conference evaluation note ({Provider})</value>
         <value lang="nl-nl">Vergadering evaluatieverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34098-4">
         <comment>Label: LOINC DOC code 34098-4</comment>
         <value lang="en-us">Conference evaluation note ({Provider})</value>
         <value lang="nl-nl">Vergadering evaluatieverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34099-2">
         <comment>Label: LOINC DOC code 34099-2</comment>
         <value lang="en-us">Consultation note (Cardiology)</value>
         <value lang="nl-nl">Consultverslag (Cardiologie)</value>
+        <value lang="fr-fr">Note de consultation (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34100-8">
         <comment>Label: LOINC DOC code 34100-8</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34101-6">
         <comment>Label: LOINC DOC code 34101-6</comment>
         <value lang="en-us">Consultation note (General medicine)</value>
         <value lang="nl-nl">Consultverslag (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note de consultation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34102-4">
         <comment>Label: LOINC DOC code 34102-4</comment>
         <value lang="en-us">Consultation note (Psychiatry)</value>
         <value lang="nl-nl">Consultverslag (Psychiatrie)</value>
+        <value lang="fr-fr">Note de consultation (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34103-2">
         <comment>Label: LOINC DOC code 34103-2</comment>
         <value lang="en-us">Consultation note (Pulmonary)</value>
         <value lang="nl-nl">Consultverslag (Pulmonary)</value>
+        <value lang="fr-fr">Note de consultation (Pulmonaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34104-0">
         <comment>Label: LOINC DOC code 34104-0</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34105-7">
         <comment>Label: LOINC DOC code 34105-7</comment>
         <value lang="en-us">Discharge summarization note ({Provider})</value>
         <value lang="nl-nl">Samenvattende ontslagbrief ({Instelling})</value>
+        <value lang="fr-fr">Lettre de sortie ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34106-5">
         <comment>Label: LOINC DOC code 34106-5</comment>
         <value lang="en-us">Discharge summarization note (Physician)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief ({Arts})</value>
+        <value lang="fr-fr">Lettre de sortie (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34107-3">
         <comment>Label: LOINC DOC code 34107-3</comment>
         <value lang="en-us">Education procedure note ({Provider})</value>
         <value lang="nl-nl">Education procedure note ({Instelling})</value>
+        <value lang="fr-fr">Note d'éducation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34108-1">
         <comment>Label: LOINC DOC code 34108-1</comment>
         <value lang="en-us">Evaluation and management note ({Provider})</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34109-9">
         <comment>Label: LOINC DOC code 34109-9</comment>
         <value lang="en-us">Evaluation and management note ({Provider})</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34110-7">
         <comment>Label: LOINC DOC code 34110-7</comment>
         <value lang="en-us">Evaluation and management note (Diabetology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Diabetologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Diabétologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34111-5">
         <comment>Label: LOINC DOC code 34111-5</comment>
         <value lang="en-us">Evaluation and management note ({Provider})</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34112-3">
         <comment>Label: LOINC DOC code 34112-3</comment>
         <value lang="en-us">Evaluation and management note ({Provider})</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34113-1">
         <comment>Label: LOINC DOC code 34113-1</comment>
         <value lang="en-us">Evaluation and management note ({Provider})</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34114-9">
         <comment>Label: LOINC DOC code 34114-9</comment>
         <value lang="en-us">Group counseling note ({Provider})</value>
         <value lang="nl-nl">Verslag groepstherapie ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation de groupe ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34115-6">
         <comment>Label: LOINC DOC code 34115-6</comment>
         <value lang="en-us">History and physical note (Medical student)</value>
         <value lang="nl-nl">Verslag voorschiedenis en lichaam (Medisch student)</value>
+        <value lang="fr-fr">Synthèse (Etudiant en médecine)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34116-4">
         <comment>Label: LOINC DOC code 34116-4</comment>
         <value lang="en-us">History and physical note (Physician)</value>
         <value lang="nl-nl">Verslag voorschiedenis en lichaam ({Arts})</value>
+        <value lang="fr-fr">Synthèse (Médecin)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34117-2">
         <comment>Label: LOINC DOC code 34117-2</comment>
         <value lang="en-us">History and physical note ({Provider})</value>
         <value lang="nl-nl">Verslag voorschiedenis en lichaam ({Instelling})</value>
+        <value lang="fr-fr">Synthèse ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34118-0">
         <comment>Label: LOINC DOC code 34118-0</comment>
         <value lang="en-us">Initial evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation initiale ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34119-8">
         <comment>Label: LOINC DOC code 34119-8</comment>
         <value lang="en-us">Initial evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation initiale ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34120-6">
         <comment>Label: LOINC DOC code 34120-6</comment>
         <value lang="en-us">Initial evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation initiale ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34121-4">
         <comment>Label: LOINC DOC code 34121-4</comment>
         <value lang="en-us">Interventional procedure note</value>
         <value lang="nl-nl">Verslag interventieprocedure</value>
+        <value lang="fr-fr">Note de procédure interventionnelle</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34122-2">
         <comment>Label: LOINC DOC code 34122-2</comment>
         <value lang="en-us">Pathology procedure note (Pathology)</value>
         <value lang="nl-nl">Verslag pathologische procedure (Pathologie)</value>
+        <value lang="fr-fr">Note de procédure (Pathologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34123-0">
         <comment>Label: LOINC DOC code 34123-0</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Anesthesia)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Anesthesie)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Anesthésie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34124-8">
         <comment>Label: LOINC DOC code 34124-8</comment>
         <value lang="en-us">Subsequent evaluation note (Cardiology)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Cardiologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34139-6">
         <comment>Label: LOINC DOC code 34139-6</comment>
         <value lang="en-us">Telephone encounter note (Nursing)</value>
         <value lang="nl-nl">Telephone encounter note (Verpleging)</value>
+        <value lang="fr-fr">Note d'entretien téléphonique (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34140-4">
         <comment>Label: LOINC DOC code 34140-4</comment>
         <value lang="en-us">Transfer of care referral note ({Provider})</value>
         <value lang="nl-nl">Transfer of care referral note ({Instelling})</value>
+        <value lang="fr-fr">Note de transfert de soins ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34876-3">
         <comment>Label: LOINC DOC code 34876-3</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Surgery)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34877-1">
         <comment>Label: LOINC DOC code 34877-1</comment>
         <value lang="en-us">Surgical operation note (Urology)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Urologie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Urologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34878-9">
         <comment>Label: LOINC DOC code 34878-9</comment>
         <value lang="en-us">Evaluation and management note (Emergency medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Emergency medicine)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine d'urgence)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34879-7">
         <comment>Label: LOINC DOC code 34879-7</comment>
         <value lang="en-us">Consultation note (Endocrinology)</value>
         <value lang="nl-nl">Consultverslag (Endocrinologie)</value>
+        <value lang="fr-fr">Note de consultation (Endocrinologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34880-5">
         <comment>Label: LOINC DOC code 34880-5</comment>
         <value lang="en-us">Post-operative evaluation and management note (Nurse.surgery)</value>
         <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Operatieverpleegkundige)</value>
+        <value lang="fr-fr">Note d'évaluation post-opératoire (Infirmière.chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34881-3">
         <comment>Label: LOINC DOC code 34881-3</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Nurse.surgery)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Operatieverpleegkundige)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Infirmière.chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34861-5">
         <comment>Label: LOINC DOC code 34861-5</comment>
         <value lang="en-us">Evaluation and management note (Diabetology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Diabetologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Diabétologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34862-3">
         <comment>Label: LOINC DOC code 34862-3</comment>
         <value lang="en-us">Admission evaluation note (Attending physician.general medicine)</value>
         <value lang="nl-nl">Voortgangsverslag opname (Behandelend arts.algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation d'admission (Médecin.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34863-1">
         <comment>Label: LOINC DOC code 34863-1</comment>
         <value lang="en-us">Post-operative evaluation and management note (General surgery)</value>
         <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Algemene chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation post-opératoire (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34864-9">
         <comment>Label: LOINC DOC code 34864-9</comment>
         <value lang="en-us">Counseling note (Mental health)</value>
         <value lang="nl-nl">Counseling note (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note de conseils (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34865-6">
         <comment>Label: LOINC DOC code 34865-6</comment>
         <value lang="en-us">Counseling note (Psychiatry)</value>
         <value lang="nl-nl">Counseling note (Psychiatrie)</value>
+        <value lang="fr-fr">Note de conseils (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34866-4">
         <comment>Label: LOINC DOC code 34866-4</comment>
         <value lang="en-us">Counseling note (Psychology)</value>
         <value lang="nl-nl">Counseling note (Psychologie)</value>
+        <value lang="fr-fr">Note de conseils (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34867-2">
         <comment>Label: LOINC DOC code 34867-2</comment>
         <value lang="en-us">Post-operative evaluation and management note (Ophthalmology)</value>
         <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Ophthalmologie)</value>
+        <value lang="fr-fr">Note d'évaluation post-opératoire (Ophthalmologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34868-0">
         <comment>Label: LOINC DOC code 34868-0</comment>
         <value lang="en-us">Surgical operation note (Orthopedics)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Orthopedie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Orthopédie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34869-8">
         <comment>Label: LOINC DOC code 34869-8</comment>
         <value lang="en-us">Counseling note (Pharmacy)</value>
         <value lang="nl-nl">Verslag advies (Apotheek)</value>
+        <value lang="fr-fr">Note de conseils (Pharmacie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34870-6">
         <comment>Label: LOINC DOC code 34870-6</comment>
         <value lang="en-us">Surgical operation note (Plastic surgery)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Plastic surgery)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Chirurgie plastique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34871-4">
         <comment>Label: LOINC DOC code 34871-4</comment>
         <value lang="en-us">Surgical operation note (Podiatry)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Podologie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34872-2">
         <comment>Label: LOINC DOC code 34872-2</comment>
         <value lang="en-us">Counseling note (Social work)</value>
         <value lang="nl-nl">Counseling note (Sociaal werk)</value>
+        <value lang="fr-fr">Note de conseils (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34873-0">
         <comment>Label: LOINC DOC code 34873-0</comment>
         <value lang="en-us">Admission evaluation note (Surgery)</value>
         <value lang="nl-nl">Admission evaluation note (Chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation d'admission (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34874-8">
         <comment>Label: LOINC DOC code 34874-8</comment>
         <value lang="en-us">Surgical operation note (Surgery)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Chirurgie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34875-5">
         <comment>Label: LOINC DOC code 34875-5</comment>
         <value lang="en-us">Post-operative evaluation and management note (Surgery)</value>
         <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation post-opératoire (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34744-3">
         <comment>Label: LOINC DOC code 34744-3</comment>
         <value lang="en-us">Admission evaluation note (Nursing)</value>
         <value lang="nl-nl">Admission evaluation note (Verpleging)</value>
+        <value lang="fr-fr">Note d'évaluation d'admission (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34745-0">
         <comment>Label: LOINC DOC code 34745-0</comment>
         <value lang="en-us">Discharge summarization note (Nursing)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief (Verpleging)</value>
+        <value lang="fr-fr">Lettre de sortie (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34746-8">
         <comment>Label: LOINC DOC code 34746-8</comment>
         <value lang="en-us">Evaluation and management note (Nursing)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Verpleging)</value>
+        <value lang="fr-fr">Note d'évaluation (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34747-6">
         <comment>Label: LOINC DOC code 34747-6</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Nursing)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Verpleging)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34748-4">
         <comment>Label: LOINC DOC code 34748-4</comment>
         <value lang="en-us">Telephone encounter note ({Provider})</value>
         <value lang="nl-nl">Telephone encounter note ({Instelling})</value>
+        <value lang="fr-fr">Note d'entretien téléphonique ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34749-2">
         <comment>Label: LOINC DOC code 34749-2</comment>
         <value lang="en-us">Consultation note (Anesthesia)</value>
         <value lang="nl-nl">Consultverslag (Anasthesie)</value>
+        <value lang="fr-fr">Note de consultation (Anesthésie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34750-0">
         <comment>Label: LOINC DOC code 34750-0</comment>
         <value lang="en-us">Evaluation and management note (Anesthesia)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Anesthesie)</value>
+        <value lang="fr-fr">Note d'évaluation (Anesthésie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34751-8">
         <comment>Label: LOINC DOC code 34751-8</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Anesthesia)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Anesthesie)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Anesthésie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34752-6">
         <comment>Label: LOINC DOC code 34752-6</comment>
         <value lang="en-us">Evaluation and management note (Cardiology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Cardiologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34753-4">
         <comment>Label: LOINC DOC code 34753-4</comment>
         <value lang="en-us">Evaluation and management note (Cardiology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Cardiologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34754-2">
         <comment>Label: LOINC DOC code 34754-2</comment>
         <value lang="en-us">Evaluation and management note (Critical care)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Spoedeisende hulp)</value>
+        <value lang="fr-fr">Note d'évaluation (Soins critiques)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34755-9">
         <comment>Label: LOINC DOC code 34755-9</comment>
         <value lang="en-us">Transfer summarization note (Critical care)</value>
         <value lang="nl-nl">Samenvattend verslag overplaatsing (Spoedeisende hulp)</value>
+        <value lang="fr-fr">Note de transfert (Soins critiques)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34756-7">
         <comment>Label: LOINC DOC code 34756-7</comment>
         <value lang="en-us">Consultation note (Dentistry)</value>
         <value lang="nl-nl">Consultverslag (Tandheelkunde)</value>
+        <value lang="fr-fr">Note de consultation (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34757-5">
         <comment>Label: LOINC DOC code 34757-5</comment>
         <value lang="en-us">Evaluation and management note (Dentistry)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Tandheelkunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34758-3">
         <comment>Label: LOINC DOC code 34758-3</comment>
         <value lang="en-us">Consultation note (Dermatology)</value>
         <value lang="nl-nl">Consultverslag (Dermatologie)</value>
+        <value lang="fr-fr">Note de consultation (Dermatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34759-1">
         <comment>Label: LOINC DOC code 34759-1</comment>
         <value lang="en-us">Evaluation and management note (Dermatology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Dermatologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Dermatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34760-9">
         <comment>Label: LOINC DOC code 34760-9</comment>
         <value lang="en-us">Consultation note (Diabetology)</value>
         <value lang="nl-nl">Consultverslag (Diabetologie)</value>
+        <value lang="fr-fr">Note de consultation (Diabétologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34761-7">
         <comment>Label: LOINC DOC code 34761-7</comment>
         <value lang="en-us">Consultation note (Gastroenterology)</value>
         <value lang="nl-nl">Consultverslag (Gastro-enterologie)</value>
+        <value lang="fr-fr">Note de consultation (Gastro-entérologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34762-5">
         <comment>Label: LOINC DOC code 34762-5</comment>
         <value lang="en-us">Evaluation and management note (Gastroenterology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Gastro-enterologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Gastro-entérologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34763-3">
         <comment>Label: LOINC DOC code 34763-3</comment>
         <value lang="en-us">Admission history and physical note (General medicine)</value>
         <value lang="nl-nl">Admission history and physical note (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Synthèse d'admission (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34764-1">
         <comment>Label: LOINC DOC code 34764-1</comment>
         <value lang="en-us">Consultation note (General medicine)</value>
         <value lang="nl-nl">Consultverslag (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note de consultation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34765-8">
         <comment>Label: LOINC DOC code 34765-8</comment>
         <value lang="en-us">Evaluation and management note (General medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34766-6">
         <comment>Label: LOINC DOC code 34766-6</comment>
         <value lang="en-us">Evaluation and management note (General medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34767-4">
         <comment>Label: LOINC DOC code 34767-4</comment>
         <value lang="en-us">Evaluation and management note (Medical student.general medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Medisch student.algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Etudiant en médecine.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34768-2">
         <comment>Label: LOINC DOC code 34768-2</comment>
         <value lang="en-us">Evaluation and management note (Nurse.general medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Verpleegkundige.algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Infirmière.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34769-0">
         <comment>Label: LOINC DOC code 34769-0</comment>
         <value lang="en-us">Evaluation and management note (Attending physician.general medicine)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Behandelend arts.algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34770-8">
         <comment>Label: LOINC DOC code 34770-8</comment>
         <value lang="en-us">Transfer summarization note (General medicine)</value>
         <value lang="nl-nl">Samenvattend verslag overplaatsing (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note de transfert (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34771-6">
         <comment>Label: LOINC DOC code 34771-6</comment>
         <value lang="en-us">Consultation note (General surgery)</value>
         <value lang="nl-nl">Consultverslag (Algemene chirurgie)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34772-4">
         <comment>Label: LOINC DOC code 34772-4</comment>
         <value lang="en-us">Evaluation and management note (General surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Algemene chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34773-2">
         <comment>Label: LOINC DOC code 34773-2</comment>
         <value lang="en-us">Evaluation and management note (Attending physician.general surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Attending physician.general surgery)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecin.Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34774-0">
         <comment>Label: LOINC DOC code 34774-0</comment>
         <value lang="en-us">History and physical note (General surgery)</value>
         <value lang="nl-nl">Verslag voorschiedenis en lichaam (Algemene chirurgie)</value>
+        <value lang="fr-fr">Synthèse (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34775-7">
         <comment>Label: LOINC DOC code 34775-7</comment>
         <value lang="en-us">Pre-operative evaluation and management note (General surgery)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Algemene chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34776-5">
         <comment>Label: LOINC DOC code 34776-5</comment>
         <value lang="en-us">Consultation note (Gerontology)</value>
         <value lang="nl-nl">Consultverslag (Gerontologie)</value>
+        <value lang="fr-fr">Note de consultation (Gérontologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34777-3">
         <comment>Label: LOINC DOC code 34777-3</comment>
         <value lang="en-us">Consultation note (Gynecology)</value>
         <value lang="nl-nl">Consultverslag (Gynecology)</value>
+        <value lang="fr-fr">Note de consultation (Gynécologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34778-1">
         <comment>Label: LOINC DOC code 34778-1</comment>
         <value lang="en-us">Evaluation and management note (Gynecology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Gynecology)</value>
+        <value lang="fr-fr">Note d'évaluation (Gynécologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34779-9">
         <comment>Label: LOINC DOC code 34779-9</comment>
         <value lang="en-us">Consultation note (Hematology+Oncology)</value>
         <value lang="nl-nl">Consultverslag (Hematology+Oncology)</value>
+        <value lang="fr-fr">Note de consultation (Hématologie+Oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34780-7">
         <comment>Label: LOINC DOC code 34780-7</comment>
         <value lang="en-us">Evaluation and management note (Hematology+Oncology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Hematology+Oncology)</value>
+        <value lang="fr-fr">Note d'évaluation (Hématologie+Oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34781-5">
         <comment>Label: LOINC DOC code 34781-5</comment>
         <value lang="en-us">Consultation note (Infectious disease)</value>
         <value lang="nl-nl">Consultverslag (Infectious disease)</value>
+        <value lang="fr-fr">Note de consultation (Maladies infectieuses)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34782-3">
         <comment>Label: LOINC DOC code 34782-3</comment>
         <value lang="en-us">Evaluation and management note (Infectious disease)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Infectious disease)</value>
+        <value lang="fr-fr">Note d'évaluation (Maladies infectieuses)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34783-1">
         <comment>Label: LOINC DOC code 34783-1</comment>
         <value lang="en-us">Consultation note (Kinesiotherapy)</value>
         <value lang="nl-nl">Consultverslag (Kinesiotherapy)</value>
+        <value lang="fr-fr">Note de consultation (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34784-9">
         <comment>Label: LOINC DOC code 34784-9</comment>
         <value lang="en-us">Evaluation and management note (Kinesiotherapy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Kinesiotherapy)</value>
+        <value lang="fr-fr">Note d'évaluation (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34785-6">
         <comment>Label: LOINC DOC code 34785-6</comment>
         <value lang="en-us">Consultation note (Mental health)</value>
         <value lang="nl-nl">Consultverslag (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note de consultation (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34786-4">
         <comment>Label: LOINC DOC code 34786-4</comment>
         <value lang="en-us">Evaluation and management note (Mental health)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note d'évaluation (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34787-2">
         <comment>Label: LOINC DOC code 34787-2</comment>
         <value lang="en-us">Group counseling note (Mental health)</value>
         <value lang="nl-nl">Group counseling note (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note de consultation de groupe (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34788-0">
         <comment>Label: LOINC DOC code 34788-0</comment>
         <value lang="en-us">Consultation note (Psychiatry)</value>
         <value lang="nl-nl">Consultverslag (Psychiatrie)</value>
+        <value lang="fr-fr">Note de consultation (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34789-8">
         <comment>Label: LOINC DOC code 34789-8</comment>
         <value lang="en-us">Evaluation and management note (Psychiatry)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Psychiatrie)</value>
+        <value lang="fr-fr">Note d'évaluation (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34790-6">
         <comment>Label: LOINC DOC code 34790-6</comment>
         <value lang="en-us">Group counseling note (Psychiatry)</value>
         <value lang="nl-nl">Group counseling note (Psychiatrie)</value>
+        <value lang="fr-fr">Note de consultation de groupe (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34791-4">
         <comment>Label: LOINC DOC code 34791-4</comment>
         <value lang="en-us">Consultation note (Psychology)</value>
         <value lang="nl-nl">Consultverslag (Psychologie)</value>
+        <value lang="fr-fr">Note de consultation (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34792-2">
         <comment>Label: LOINC DOC code 34792-2</comment>
         <value lang="en-us">Evaluation and management note (Psychology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Psychologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34793-0">
         <comment>Label: LOINC DOC code 34793-0</comment>
         <value lang="en-us">Group counseling note (Psychology)</value>
         <value lang="nl-nl">Group counseling note (Psychologie)</value>
+        <value lang="fr-fr">Note de consultation de groupe (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34794-8">
         <comment>Label: LOINC DOC code 34794-8</comment>
         <value lang="en-us">Evaluation and management note (Multidisciplinary)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Multidisciplinary)</value>
+        <value lang="fr-fr">Note d'évaluation (Pluridisciplinaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34795-5">
         <comment>Label: LOINC DOC code 34795-5</comment>
         <value lang="en-us">Consultation note (Nephrology)</value>
         <value lang="nl-nl">Consultverslag (Nephrology)</value>
+        <value lang="fr-fr">Note de consultation (Néphrologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34796-3">
         <comment>Label: LOINC DOC code 34796-3</comment>
         <value lang="en-us">Evaluation and management note (Nephrology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Nephrology)</value>
+        <value lang="fr-fr">Note d'évaluation (Néphrologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34797-1">
         <comment>Label: LOINC DOC code 34797-1</comment>
         <value lang="en-us">Consultation note (Neurology)</value>
         <value lang="nl-nl">Consultverslag (Neurologie)</value>
+        <value lang="fr-fr">Note de consultation (Neurologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34806-0">
         <comment>Label: LOINC DOC code 34806-0</comment>
         <value lang="en-us">Evaluation and management note (Oncology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Oncology)</value>
+        <value lang="fr-fr">Note d'évaluation (Oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34807-8">
         <comment>Label: LOINC DOC code 34807-8</comment>
         <value lang="en-us">Consultation note (Ophthalmology)</value>
         <value lang="nl-nl">Consultverslag (Oogheelkunde)</value>
+        <value lang="fr-fr">Note de consultation (Ophthalmologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34808-6">
         <comment>Label: LOINC DOC code 34808-6</comment>
         <value lang="en-us">Evaluation and management note (Ophthalmology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Oogheelkunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Ophthalmologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34809-4">
         <comment>Label: LOINC DOC code 34809-4</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Ophthalmology)</value>
         <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Oogheelkunde)</value>
+        <value lang="fr-fr">Note d'évaluation pré-opératoire (Ophthalmologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34810-2">
         <comment>Label: LOINC DOC code 34810-2</comment>
         <value lang="en-us">Consultation note (Optometry)</value>
         <value lang="nl-nl">Consultverslag (Optometrie)</value>
+        <value lang="fr-fr">Note de consultation (Optométrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34811-0">
         <comment>Label: LOINC DOC code 34811-0</comment>
         <value lang="en-us">Evaluation and management note (Optometry)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Optometrie)</value>
+        <value lang="fr-fr">Note d'évaluation (Optométrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34812-8">
         <comment>Label: LOINC DOC code 34812-8</comment>
         <value lang="en-us">Consultation note (Oromaxillofacial surgery)</value>
         <value lang="nl-nl">Consultverslag (Oromaxillofaciale chirurgie)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie oro-maxillo-faciale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34813-6">
         <comment>Label: LOINC DOC code 34813-6</comment>
         <value lang="en-us">Evaluation and management note (Oromaxillofacial surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Oromaxillofaciale chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie oro-maxillo-faciale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34814-4">
         <comment>Label: LOINC DOC code 34814-4</comment>
         <value lang="en-us">Consultation note (Orthopedics)</value>
         <value lang="nl-nl">Consultverslag (Orthopedie)</value>
+        <value lang="fr-fr">Note de consultation (Orthopédie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34815-1">
         <comment>Label: LOINC DOC code 34815-1</comment>
         <value lang="en-us">Evaluation and management note (Orthopedics)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Orthopedie)</value>
+        <value lang="fr-fr">Note d'évaluation (Orthopédie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34816-9">
         <comment>Label: LOINC DOC code 34816-9</comment>
         <value lang="en-us">Consultation note (Otorhinolaryngology)</value>
         <value lang="nl-nl">Consultverslag (Otorhinolaryngologie)</value>
+        <value lang="fr-fr">Note de consultation (Oto-rhino-laryngologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34817-7">
         <comment>Label: LOINC DOC code 34817-7</comment>
         <value lang="en-us">Evaluation and management note (Otorhinolaryngology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Otorhinolaryngologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Oto-rhino-laryngologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34818-5">
         <comment>Label: LOINC DOC code 34818-5</comment>
         <value lang="en-us">Surgical operation note (Otorhinolaryngology)</value>
         <value lang="nl-nl">Verslag chirurgische operatie (Otorhinolaryngologie)</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Oto-rhino-laryngologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34819-3">
         <comment>Label: LOINC DOC code 34819-3</comment>
         <value lang="en-us">Evaluation and management note (Pathology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Pathologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Pathologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34820-1">
         <comment>Label: LOINC DOC code 34820-1</comment>
         <value lang="en-us">Consultation note (Pharmacy)</value>
         <value lang="nl-nl">Consultverslag (Apotheek)</value>
+        <value lang="fr-fr">Note de consultation (Pharmacie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34821-9">
         <comment>Label: LOINC DOC code 34821-9</comment>
         <value lang="en-us">Evaluation and management note (Pharmacy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Apotheek)</value>
+        <value lang="fr-fr">Note d'évaluation (Pharmacie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34822-7">
         <comment>Label: LOINC DOC code 34822-7</comment>
         <value lang="en-us">Consultation note (Physical medicine and rehabilitation)</value>
         <value lang="nl-nl">Consultverslag (Physical medicine and rehabilitation)</value>
+        <value lang="fr-fr">Note de consultation (Médecine physique et réadaptation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34823-5">
         <comment>Label: LOINC DOC code 34823-5</comment>
         <value lang="en-us">Evaluation and management note (Physical medicine and rehabilitation)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Physical medicine and rehabilitation)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine physique et réadaptation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34824-3">
         <comment>Label: LOINC DOC code 34824-3</comment>
         <value lang="en-us">Consultation note (Physical therapy)</value>
         <value lang="nl-nl">Consultverslag (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note de consultation (Thérapie physique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34825-0">
         <comment>Label: LOINC DOC code 34825-0</comment>
         <value lang="en-us">Evaluation and management note (Physical therapy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note d'évaluation (Thérapie physique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34826-8">
         <comment>Label: LOINC DOC code 34826-8</comment>
         <value lang="en-us">Consultation note (Plastic surgery)</value>
         <value lang="nl-nl">Consultverslag (Plastic surgery)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie plastique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34827-6">
         <comment>Label: LOINC DOC code 34827-6</comment>
         <value lang="en-us">Evaluation and management note (Plastic surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Plastic surgery)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie plastique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34828-4">
         <comment>Label: LOINC DOC code 34828-4</comment>
         <value lang="en-us">Consultation note (Podiatry)</value>
         <value lang="nl-nl">Consultverslag (Podologie)</value>
+        <value lang="fr-fr">Note de consultation (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34829-2">
         <comment>Label: LOINC DOC code 34829-2</comment>
         <value lang="en-us">Evaluation and management note (Podiatry)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Podologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34830-0">
         <comment>Label: LOINC DOC code 34830-0</comment>
         <value lang="en-us">Evaluation and management note (Pulmonary)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Pulmonary)</value>
+        <value lang="fr-fr">Note d'évaluation (Pulmonaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34831-8">
         <comment>Label: LOINC DOC code 34831-8</comment>
         <value lang="en-us">Consultation note (Radiation oncology)</value>
         <value lang="nl-nl">Consultverslag (Radiation oncology)</value>
+        <value lang="fr-fr">Note de consultation (Radio-oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34832-6">
         <comment>Label: LOINC DOC code 34832-6</comment>
         <value lang="en-us">Evaluation and management note (Radiation oncology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Radiation oncology)</value>
+        <value lang="fr-fr">Note d'évaluation (Radio-oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34833-4">
         <comment>Label: LOINC DOC code 34833-4</comment>
         <value lang="en-us">Consultation note (Recreational therapy)</value>
         <value lang="nl-nl">Consultverslag (Recreational therapy)</value>
+        <value lang="fr-fr">Note de consultation (Thérapie récréative)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34834-2">
         <comment>Label: LOINC DOC code 34834-2</comment>
         <value lang="en-us">Evaluation and management note (Recreational therapy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Recreational therapy)</value>
+        <value lang="fr-fr">Note d'évaluation (Thérapie récréative)</value>
     </translation>
+    <!-- Deprecated LOINC Code: Start -->
     <translation key="2.16.840.1.113883.6.1-34835-9">
         <comment>Label: LOINC DOC code 34835-9</comment>
         <value lang="en-us">Consultation note (Rehabilitation)</value>
         <value lang="nl-nl">Consultverslag (Rehabilitation)</value>
+        <value lang="fr-fr">Note de consultation (Réhabilitation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34836-7">
         <comment>Label: LOINC DOC code 34836-7</comment>
         <value lang="en-us">Evaluation and management note (Rehabilitation)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Rehabilitation)</value>
-    </translation>
+        <value lang="fr-fr">Note d'évaluation (Réhabilitation)</value>
+    </translation>    
+    <!-- Deprecated LOINC Code: End -->
     <translation key="2.16.840.1.113883.6.1-34837-5">
         <comment>Label: LOINC DOC code 34837-5</comment>
         <value lang="en-us">Consultation note (Respiratory therapy)</value>
         <value lang="nl-nl">Consultverslag (Respiratory therapy)</value>
+        <value lang="fr-fr">Note de consultation (Thérapie respiratoire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34838-3">
         <comment>Label: LOINC DOC code 34838-3</comment>
         <value lang="en-us">Evaluation and management note (Respiratory therapy)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Respiratory therapy)</value>
+        <value lang="fr-fr">Note d'évaluation (Thérapie respiratoire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34839-1">
         <comment>Label: LOINC DOC code 34839-1</comment>
         <value lang="en-us">Consultation note (Rheumatology)</value>
         <value lang="nl-nl">Consultverslag (Rheumatology)</value>
+        <value lang="fr-fr">Note de consultation (Rhumatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34840-9">
         <comment>Label: LOINC DOC code 34840-9</comment>
         <value lang="en-us">Evaluation and management note (Rheumatology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Rheumatology)</value>
+        <value lang="fr-fr">Note d'évaluation (Rhumatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34841-7">
         <comment>Label: LOINC DOC code 34841-7</comment>
         <value lang="en-us">Consultation note (Social work)</value>
         <value lang="nl-nl">Consultverslag (Sociaal werk)</value>
+        <value lang="fr-fr">Note de consultation (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34842-5">
         <comment>Label: LOINC DOC code 34842-5</comment>
         <value lang="en-us">Evaluation and management note (Social work)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Sociaal werk)</value>
+        <value lang="fr-fr">Note d'évaluation (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34843-3">
         <comment>Label: LOINC DOC code 34843-3</comment>
         <value lang="en-us">Group counseling note (Social work)</value>
         <value lang="nl-nl">Group counseling note (Sociaal werk)</value>
+        <value lang="fr-fr">Note de consultation de groupe (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34844-1">
         <comment>Label: LOINC DOC code 34844-1</comment>
         <value lang="en-us">Telephone encounter note (Social work)</value>
         <value lang="nl-nl">Telephone encounter note (Sociaal werk)</value>
+        <value lang="fr-fr">Note d'entretien téléphonique (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34845-8">
         <comment>Label: LOINC DOC code 34845-8</comment>
         <value lang="en-us">Consultation note (Speech therapy+Audiology)</value>
         <value lang="nl-nl">Consultverslag (Spraaktherapie+Audiologie)</value>
+        <value lang="fr-fr">Note de consultation (Orthophonie+Audiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34846-6">
         <comment>Label: LOINC DOC code 34846-6</comment>
         <value lang="en-us">Evaluation and management note (Speech therapy+Audiology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Spraaktherapie+Audiologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Orthophonie+Audiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34847-4">
         <comment>Label: LOINC DOC code 34847-4</comment>
         <value lang="en-us">Consultation note (Surgery)</value>
         <value lang="nl-nl">Consultverslag (Chirurgie)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34848-2">
         <comment>Label: LOINC DOC code 34848-2</comment>
         <value lang="en-us">Evaluation and management note (Surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34849-0">
         <comment>Label: LOINC DOC code 34849-0</comment>
         <value lang="en-us">Consultation note (Thoracic surgery)</value>
         <value lang="nl-nl">Consultverslag (Thorax chirurgie)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie thoracique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34850-8">
         <comment>Label: LOINC DOC code 34850-8</comment>
         <value lang="en-us">Evaluation and management note (Thoracic surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Thorax chirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie thoracique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34851-6">
         <comment>Label: LOINC DOC code 34851-6</comment>
         <value lang="en-us">Consultation note (Urology)</value>
         <value lang="nl-nl">Consultverslag (Urologie)</value>
+        <value lang="fr-fr">Note de consultation (Urologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34852-4">
         <comment>Label: LOINC DOC code 34852-4</comment>
         <value lang="en-us">Evaluation and management note (Urology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Urologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Urologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34853-2">
         <comment>Label: LOINC DOC code 34853-2</comment>
         <value lang="en-us">Consultation note (Vascular surgery)</value>
         <value lang="nl-nl">Consultverslag (Vaatchirurgie)</value>
+        <value lang="fr-fr">Note de consultation (Chirurgie vasculaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34854-0">
         <comment>Label: LOINC DOC code 34854-0</comment>
         <value lang="en-us">Evaluation and management note (Vascular surgery)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Vaatchirurgie)</value>
+        <value lang="fr-fr">Note d'évaluation (Chirurgie vasculaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34855-7">
         <comment>Label: LOINC DOC code 34855-7</comment>
         <value lang="en-us">Consultation note (Occupational therapy)</value>
         <value lang="nl-nl">Consultverslag (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note de consultation (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34856-5">
         <comment>Label: LOINC DOC code 34856-5</comment>
         <value lang="en-us">Evaluation and management note (Anticoagulation)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Anticoagulatie)</value>
+        <value lang="fr-fr">Note d'évaluation (Anticoagulation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34857-3">
         <comment>Label: LOINC DOC code 34857-3</comment>
         <value lang="en-us">Evaluation and management note (Substance abuse)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Misbruik van substanties)</value>
+        <value lang="fr-fr">Note d'évaluation (Abus de substance)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34858-1">
         <comment>Label: LOINC DOC code 34858-1</comment>
         <value lang="en-us">Evaluation and management note (Pain management)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Pijnbestrijding)</value>
+        <value lang="fr-fr">Note d'évaluation (Gestion de la douleur)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34859-9">
         <comment>Label: LOINC DOC code 34859-9</comment>
         <value lang="en-us">Evaluation and management note (Hyperlipidemia)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Hyperlipidemia)</value>
+        <value lang="fr-fr">Note d'évaluation (Hyperlipidémie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34860-7">
         <comment>Label: LOINC DOC code 34860-7</comment>
         <value lang="en-us">Evaluation and management note (Hypertension)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Hypertensie)</value>
+        <value lang="fr-fr">Note d'évaluation (Hypertension)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34895-3">
         <comment>Label: LOINC DOC code 34895-3</comment>
         <value lang="en-us">Education note ({Provider})</value>
         <value lang="nl-nl">Opleidingsverslag ({Instelling})</value>
+        <value lang="fr-fr">Note d'éducation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34896-1">
         <comment>Label: LOINC DOC code 34896-1</comment>
         <value lang="en-us">Interventional procedure note (Cardiology)</value>
         <value lang="nl-nl">Interventional procedure note (Cardiologie)</value>
+        <value lang="fr-fr">Note d'acte interventionnel (Cardiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34897-9">
         <comment>Label: LOINC DOC code 34897-9</comment>
         <value lang="en-us">Education note (Diabetology)</value>
         <value lang="nl-nl">Opleidingsverslag (Diabetologie)</value>
+        <value lang="fr-fr">Note d'éducation (Diabétologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34898-7">
         <comment>Label: LOINC DOC code 34898-7</comment>
         <value lang="en-us">Evaluation and management note (Endocrinology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Endocrinologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Endocrinologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34899-5">
         <comment>Label: LOINC DOC code 34899-5</comment>
         <value lang="en-us">Interventional procedure note (Gastroenterology)</value>
         <value lang="nl-nl">Interventional procedure note (Gastro-enterologie)</value>
+        <value lang="fr-fr">Note d'acte interventionnel (Gastro-entérologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34900-1">
         <comment>Label: LOINC DOC code 34900-1</comment>
         <value lang="en-us">Subsequent evaluation note (General medicine)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34901-9">
         <comment>Label: LOINC DOC code 34901-9</comment>
         <value lang="en-us">Subsequent evaluation note (General medicine)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note d'évaluation (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34902-7">
         <comment>Label: LOINC DOC code 34902-7</comment>
         <value lang="en-us">Education note (Gerontology)</value>
         <value lang="nl-nl">Opleidingsverslag (Gerontologie)</value>
+        <value lang="fr-fr">Note d'éducation (Gérontologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34903-5">
         <comment>Label: LOINC DOC code 34903-5</comment>
         <value lang="en-us">Note (Mental health)</value>
         <value lang="nl-nl">Verslag (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34904-3">
         <comment>Label: LOINC DOC code 34904-3</comment>
         <value lang="en-us">Subsequent evaluation note (Mental health)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note d'évaluation (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34905-0">
         <comment>Label: LOINC DOC code 34905-0</comment>
         <value lang="en-us">Evaluation and management note (Neurology)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Neurologie)</value>
+        <value lang="fr-fr">Note d'évaluation (Neurologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34906-8">
         <comment>Label: LOINC DOC code 34906-8</comment>
         <value lang="en-us">Note (Pastoral care)</value>
         <value lang="nl-nl">Verslag (Pastoral care)</value>
+        <value lang="fr-fr">Note (Cure.religion)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38269-7">
         <comment>Label: LOINC DOC code 38269-7</comment>
         <value lang="en-us">Study report (XR.DEXA)</value>
         <value lang="nl-nl">Onderzoeksverslag (XR.DEXA)</value>
+        <value lang="fr-fr">Compte-rendu (Densitométrie osseuse)</value>
     </translation>
+    <!-- US VA (Veterans Affairs) documents: Start -->
     <translation key="2.16.840.1.113883.6.1-38932-0">
         <comment>Label: LOINC DOC code 38932-0</comment>
         <value lang="en-us">VA C&amp;P exam.acromegaly ({Provider})</value>
@@ -5837,443 +6902,544 @@
         <comment>Label: LOINC DOC code 38984-1</comment>
         <value lang="en-us">VA C&amp;P exam.skin diseases other than scars ({Provider})</value>
         <value lang="nl-nl">VA C&amp;P exam.skin diseases other than scars ({Instelling})</value>
-    </translation>
+    </translation>    
+    <!-- US VA (Veterans Affairs) documents: End -->
+    
     <translation key="2.16.840.1.113883.6.1-46208-5">
         <comment>Label: LOINC DOC code 46208-5</comment>
         <value lang="en-us">Nursing notes</value>
         <value lang="nl-nl">Verpleegkundig verslag</value>
+        <value lang="fr-fr">Note d'infirmière</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46209-3">
         <comment>Label: LOINC DOC code 46209-3</comment>
         <value lang="en-us">Provider orders</value>
+        <value lang="fr-fr">Commande fournisseur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46210-1">
         <comment>Label: LOINC DOC code 46210-1</comment>
         <value lang="en-us">Note (Case manager)</value>
         <value lang="nl-nl">Verslag (Case manager)</value>
+        <value lang="fr-fr">Note (Chargé du dossier)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46213-5">
         <comment>Label: LOINC DOC code 46213-5</comment>
         <value lang="en-us">Tilt table study</value>
+        <value lang="fr-fr">Test d'inclinaison</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46214-3">
         <comment>Label: LOINC DOC code 46214-3</comment>
         <value lang="en-us">Intracardiac ablation study</value>
+        <value lang="fr-fr">Examen d'ablation cardiaque intracardiaque</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46215-0">
         <comment>Label: LOINC DOC code 46215-0</comment>
         <value lang="en-us">Note (Wound care management)</value>
         <value lang="nl-nl">Verslag (Wound care management)</value>
+        <value lang="fr-fr">Note (Soins des plaies)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46242-4">
         <comment>Label: LOINC DOC code 46242-4</comment>
         <value lang="en-us">Vital signs measurements</value>
+        <value lang="fr-fr">Mesures de signes vitaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46264-8">
         <comment>Label: LOINC DOC code 46264-8</comment>
         <value lang="en-us">History of medical device use ({Provider})</value>
         <value lang="nl-nl">History of medical device use ({Instelling})</value>
+        <value lang="fr-fr">Antécédents d'utilisation de dispositifs médicaux ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47039-3">
         <comment>Label: LOINC DOC code 47039-3</comment>
         <value lang="en-us">Admission history and physical note ({Provider})</value>
         <value lang="nl-nl">Admission history and physical note ({Instelling})</value>
+        <value lang="fr-fr">Synthèse d'admission ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47040-1">
         <comment>Label: LOINC DOC code 47040-1</comment>
         <value lang="en-us">Confirmatory consultation note ({Provider})</value>
         <value lang="nl-nl">Confirmatory consultation note ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation 2ème avis ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47041-9">
         <comment>Label: LOINC DOC code 47041-9</comment>
         <value lang="en-us">Confirmatory consultation note ({Provider})</value>
         <value lang="nl-nl">Confirmatory consultation note ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation 2ème avis ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47042-7">
         <comment>Label: LOINC DOC code 47042-7</comment>
         <value lang="en-us">Counseling note ({Provider})</value>
         <value lang="nl-nl">Counseling note ({Instelling})</value>
+        <value lang="fr-fr">Note de conseils ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47043-5">
         <comment>Label: LOINC DOC code 47043-5</comment>
         <value lang="en-us">Group counseling note ({Provider})</value>
         <value lang="nl-nl">Group counseling note ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation de groupe ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47044-3">
         <comment>Label: LOINC DOC code 47044-3</comment>
         <value lang="en-us">Initial evaluation note ({Provider})</value>
         <value lang="nl-nl">Verslag eerste onderzoek ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation initiale ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47045-0">
         <comment>Label: LOINC DOC code 47045-0</comment>
         <value lang="en-us">Study report ({Provider})</value>
         <value lang="nl-nl">Onderzoeksverslag ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47046-8">
         <comment>Label: LOINC DOC code 47046-8</comment>
         <value lang="en-us">Summary of death ({Provider})</value>
         <value lang="nl-nl">Summary of death ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu de décès ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47047-6">
         <comment>Label: LOINC DOC code 47047-6</comment>
         <value lang="en-us">Supervisory note ({Provider})</value>
         <value lang="nl-nl">Supervisory note ({Instelling})</value>
+        <value lang="fr-fr">Note de surveillance ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47048-4">
         <comment>Label: LOINC DOC code 47048-4</comment>
         <value lang="en-us">Diagnostic interventional study report (Interventional radiology)</value>
+        <value lang="fr-fr">Compte-rendu (Radiologie interventionnelle)</value>
     </translation>
+    <!-- Deprecated LOINC Code: Start -->
     <translation key="2.16.840.1.113883.6.1-47049-2">
         <comment>Label: LOINC DOC code 47049-2</comment>
         <value lang="en-us">Communication ({Non-patient})</value>
     </translation>
+    <!-- Deprecated LOINC Code: End -->
     <translation key="2.16.840.1.113883.6.1-47245-6">
         <comment>Label: LOINC DOC code 47245-6</comment>
         <value lang="en-us">HIV Rx Form</value>
         <value lang="nl-nl">HIV Rx formulier</value>
+        <value lang="fr-fr">Formulaire de traitement du VIH</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47420-5">
         <comment>Label: LOINC DOC code 47420-5</comment>
         <value lang="en-us">Functional status assessment ({Provider})</value>
         <value lang="nl-nl">Functional status assessment ({Instelling})</value>
+        <value lang="fr-fr">Évaluation du statut fonctionnel ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47519-4">
         <comment>Label: LOINC DOC code 47519-4</comment>
         <value lang="en-us">History of Procedures ({Provider})</value>
         <value lang="nl-nl">History of Procedures ({Instelling})</value>
+        <value lang="fr-fr">Historique des actes ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47520-2">
         <comment>Label: LOINC DOC code 47520-2</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Expectorations (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47521-0">
         <comment>Label: LOINC DOC code 47521-0</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Ponction mammaire (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47522-8">
         <comment>Label: LOINC DOC code 47522-8</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Écoulement du mamelon (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47523-6">
         <comment>Label: LOINC DOC code 47523-6</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Fluide corporel (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47524-4">
         <comment>Label: LOINC DOC code 47524-4</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Ponction de la thyroïde (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47525-1">
         <comment>Label: LOINC DOC code 47525-1</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Urine (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47526-9">
         <comment>Label: LOINC DOC code 47526-9</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Echantillon (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47527-7">
         <comment>Label: LOINC DOC code 47527-7</comment>
         <value lang="en-us">Cytology report (Cyto stain.thin prep)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain.thin prep)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47528-5">
         <comment>Label: LOINC DOC code 47528-5</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47529-3">
         <comment>Label: LOINC DOC code 47529-3</comment>
         <value lang="en-us">Cytology report (XXX stain)</value>
         <value lang="nl-nl">Cytologieverslag (XXX stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Tissu</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47530-1">
         <comment>Label: LOINC DOC code 47530-1</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Lavage canalaire mammaire (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-48768-6">
         <comment>Label: LOINC DOC code 48768-6</comment>
         <value lang="en-us">Payment sources</value>
+        <value lang="fr-fr">Informations sur le payeur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-48764-5">
         <comment>Label: LOINC DOC code 48764-5</comment>
         <value lang="en-us">Summary purpose</value>
         <value lang="nl-nl">Samenvatting doel</value>
+        <value lang="fr-fr">Raison de la synthèse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-48765-2">
         <comment>Label: LOINC DOC code 48765-2</comment>
         <value lang="en-us">Allergies, adverse reactions, alerts</value>
         <value lang="nl-nl">Allergieën, allergische reacties, waarschuwingen</value>
+        <value lang="fr-fr">Allergies et hypersensibilités</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-48807-2">
         <comment>Label: LOINC DOC code 48807-2</comment>
         <value lang="en-us">Bone marrow aspiration report</value>
+        <value lang="fr-fr">Compte-rendu de ponction de moelle osseuse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-50007-4">
         <comment>Label: LOINC DOC code 50007-4</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51969-4">
         <comment>Label: LOINC DOC code 51969-4</comment>
         <value lang="en-us">Genetic analysis summary report (Molgen)</value>
+        <value lang="fr-fr">Compte-rendu de génétique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52030-4">
         <comment>Label: LOINC DOC code 52030-4</comment>
         <value lang="en-us">Explanation of benefits attachment</value>
+        <value lang="fr-fr">Informations sur les paiements</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52031-2">
         <comment>Label: LOINC DOC code 52031-2</comment>
         <value lang="en-us">Explanation of benefits to subscriber attachment</value>
+        <value lang="fr-fr">Informations au souscripteur sur les paiements</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52032-0">
         <comment>Label: LOINC DOC code 52032-0</comment>
         <value lang="en-us">Appeal denial letter attachment</value>
+        <value lang="fr-fr">Informations sur les réclamations</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52033-8">
         <comment>Label: LOINC DOC code 52033-8</comment>
         <value lang="en-us">General correspondence attachment</value>
+        <value lang="fr-fr">Correspondance générale</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52034-6">
         <comment>Label: LOINC DOC code 52034-6</comment>
         <value lang="en-us">Payer letter attachment</value>
+        <value lang="fr-fr">Lettre du payeur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52035-3">
         <comment>Label: LOINC DOC code 52035-3</comment>
         <value lang="en-us">Home health claims attachment</value>
+        <value lang="fr-fr">Réclamation sur les soins à domicile</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52036-1">
         <comment>Label: LOINC DOC code 52036-1</comment>
         <value lang="en-us">Home health prior authorization attachment</value>
+        <value lang="fr-fr">Autorisation préalable aux soins à domicile</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52037-9">
         <comment>Label: LOINC DOC code 52037-9</comment>
         <value lang="en-us">Member ID card copy attachment</value>
+        <value lang="fr-fr">Copie de la carte de membre</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52038-7">
         <comment>Label: LOINC DOC code 52038-7</comment>
         <value lang="en-us">Subscriber Information including retroactive and presumptive eligibility attachment</value>
+        <value lang="fr-fr">Informations sur l'abonné pour l'éligibilité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52039-5">
         <comment>Label: LOINC DOC code 52039-5</comment>
         <value lang="en-us">Skilled Nursing Facility record attachment</value>
+        <value lang="fr-fr">Informations sur l'établissement de soins infirmiers qualifiés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52040-3">
         <comment>Label: LOINC DOC code 52040-3</comment>
         <value lang="en-us">Dental X-rays and other images (not DICOM) attachment</value>
+        <value lang="fr-fr">Radiographies dentaires et autres images (non DICOM)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52041-1">
         <comment>Label: LOINC DOC code 52041-1</comment>
         <value lang="en-us">Blood glucose monitors attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un lecteur de glycémie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-50971-1">
         <comment>Label: LOINC DOC code 50971-1</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
+        <value lang="fr-fr">Compte-rendu cytologique (Coloration cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51897-7">
         <comment>Label: LOINC DOC code 51897-7</comment>
         <value lang="en-us">Healthcare Associated Infection report ({Provider})</value>
         <value lang="nl-nl">Healthcare Associated Infection report ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu sur les infections associées aux soins ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51898-5">
         <comment>Label: LOINC DOC code 51898-5</comment>
         <value lang="en-us">Risk factors ({Provider})</value>
         <value lang="nl-nl">Risk factors ({Instelling})</value>
+        <value lang="fr-fr">Facteurs de risques ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51899-3">
         <comment>Label: LOINC DOC code 51899-3</comment>
         <value lang="en-us">Details ({Provider})</value>
         <value lang="nl-nl">Details ({Instelling})</value>
+        <value lang="fr-fr">Détails ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51900-9">
         <comment>Label: LOINC DOC code 51900-9</comment>
         <value lang="en-us">Summary ({Provider})</value>
         <value lang="nl-nl">Samenvatting ({Instelling})</value>
+        <value lang="fr-fr">Résumé ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51845-6">
         <comment>Label: LOINC DOC code 51845-6</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51846-4">
         <comment>Label: LOINC DOC code 51846-4</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51847-2">
         <comment>Label: LOINC DOC code 51847-2</comment>
         <value lang="en-us">Assessment+Plan note ({Provider})</value>
         <value lang="nl-nl">Assessment+Plan note ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation et plan ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51848-0">
         <comment>Label: LOINC DOC code 51848-0</comment>
         <value lang="en-us">Assessment note ({Provider})</value>
         <value lang="nl-nl">Assessment note ({Instelling})</value>
+        <value lang="fr-fr">Note d'évaluation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51849-8">
         <comment>Label: LOINC DOC code 51849-8</comment>
         <value lang="en-us">Admission history and physical note ({Provider})</value>
         <value lang="nl-nl">Admission history and physical note ({Instelling})</value>
+        <value lang="fr-fr">Synthèse ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51850-6">
         <comment>Label: LOINC DOC code 51850-6</comment>
         <value lang="en-us">Physical findings (Observed)</value>
+        <value lang="fr-fr">Constatations physiques (Observées)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51851-4">
         <comment>Label: LOINC DOC code 51851-4</comment>
         <value lang="en-us">Administrative note ({Provider})</value>
         <value lang="nl-nl">Administratief verslag ({Instelling})</value>
+        <value lang="fr-fr">Note administrative ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51852-2">
         <comment>Label: LOINC DOC code 51852-2</comment>
         <value lang="en-us">Letter ({Provider})</value>
         <value lang="nl-nl">Brief ({Instelling})</value>
+        <value lang="fr-fr">Lettre ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51853-0">
         <comment>Label: LOINC DOC code 51853-0</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51854-8">
         <comment>Label: LOINC DOC code 51854-8</comment>
         <value lang="en-us">Consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ({Instelling})</value>
+        <value lang="fr-fr">Note de consultation ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51855-5">
         <comment>Label: LOINC DOC code 51855-5</comment>
         <value lang="en-us">Note (Patient)</value>
         <value lang="nl-nl">Verslag (Patiënt)</value>
+        <value lang="fr-fr">Note (Patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51965-2">
         <comment>Label: LOINC DOC code 51965-2</comment>
         <value lang="en-us">Pharmacogenetic analysis report (Molgen)</value>
+        <value lang="fr-fr">Compte-rendu d'analyse pharmacogénétique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52027-0">
         <comment>Label: LOINC DOC code 52027-0</comment>
         <value lang="en-us">Abortion consent attachment</value>
+        <value lang="fr-fr">Consentement à l'avortement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52028-8">
         <comment>Label: LOINC DOC code 52028-8</comment>
         <value lang="en-us">Hysterectomy consent attachment</value>
+        <value lang="fr-fr">Consentement à l'hystérectomie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52029-6">
         <comment>Label: LOINC DOC code 52029-6</comment>
         <value lang="en-us">Sterilization consent attachment</value>
+        <value lang="fr-fr">Consentement à la stérilisation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52042-9">
         <comment>Label: LOINC DOC code 52042-9</comment>
         <value lang="en-us">Continuous positive airway pressure attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la ventilation en pression positive continue (PPC)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52043-7">
         <comment>Label: LOINC DOC code 52043-7</comment>
         <value lang="en-us">Enteral nutrition attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la nutrition entérale</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52044-5">
         <comment>Label: LOINC DOC code 52044-5</comment>
         <value lang="en-us">External infusion pump attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la pompe à perfusion externe</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52045-2">
         <comment>Label: LOINC DOC code 52045-2</comment>
         <value lang="en-us">Gait trainers attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un support de marche</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52046-0">
         <comment>Label: LOINC DOC code 52046-0</comment>
         <value lang="en-us">Hospital beds attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un lit médicalisé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52047-8">
         <comment>Label: LOINC DOC code 52047-8</comment>
         <value lang="en-us">Immunosuppressive drugs attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'immunodépresseurs</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52048-6">
         <comment>Label: LOINC DOC code 52048-6</comment>
         <value lang="en-us">Lymphedema pumps attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'une pompe à lymphoedème</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52049-4">
         <comment>Label: LOINC DOC code 52049-4</comment>
         <value lang="en-us">Manual wheelchair attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant manuel</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52050-2">
         <comment>Label: LOINC DOC code 52050-2</comment>
         <value lang="en-us">Motorized wheelchair attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant motorisé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52051-0">
         <comment>Label: LOINC DOC code 52051-0</comment>
         <value lang="en-us">Orthotics + prosthetics attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'orthèses + prothèses</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52052-8">
         <comment>Label: LOINC DOC code 52052-8</comment>
         <value lang="en-us">Osteogenesis stimulators attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un stimulateur de croissance osseuse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52053-6">
         <comment>Label: LOINC DOC code 52053-6</comment>
         <value lang="en-us">Oxygen attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'oxygène</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52054-4">
         <comment>Label: LOINC DOC code 52054-4</comment>
         <value lang="en-us">Parenteral attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la nutrition parentérale</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52055-1">
         <comment>Label: LOINC DOC code 52055-1</comment>
         <value lang="en-us">Power operated vehicles attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un véhicule à moteur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52056-9">
         <comment>Label: LOINC DOC code 52056-9</comment>
         <value lang="en-us">Repair of durable medical equipment attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'une réparation de matériel médical durable</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52057-7">
         <comment>Label: LOINC DOC code 52057-7</comment>
         <value lang="en-us">Seat lift mechanism attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un mécanisme de levage du siège</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52058-5">
         <comment>Label: LOINC DOC code 52058-5</comment>
         <value lang="en-us">Seating systems attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un siège</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52059-3">
         <comment>Label: LOINC DOC code 52059-3</comment>
         <value lang="en-us">Speech generating device attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un générateur de parole</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52060-1">
         <comment>Label: LOINC DOC code 52060-1</comment>
         <value lang="en-us">Standers + standing frames attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un dispositif de stabilisation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52061-9">
         <comment>Label: LOINC DOC code 52061-9</comment>
         <value lang="en-us">Support surfaces attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de dispositifs de soutien</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52062-7">
         <comment>Label: LOINC DOC code 52062-7</comment>
         <value lang="en-us">Transcutaneous electrical neural stimulation attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de neurostimulation électrique transcutanée</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52063-5">
         <comment>Label: LOINC DOC code 52063-5</comment>
         <value lang="en-us">Prescription for durable medical equipment attachment</value>
+        <value lang="fr-fr">Prescription de matériel médical durable</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52064-3">
         <comment>Label: LOINC DOC code 52064-3</comment>
         <value lang="en-us">First report of injury attachment</value>
+        <value lang="fr-fr">Premier rapport de blessure</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52065-0">
         <comment>Label: LOINC DOC code 52065-0</comment>
         <value lang="en-us">Automobile liability attachment</value>
+        <value lang="fr-fr">Informations sur la responsabilité civile automobile</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52066-8">
         <comment>Label: LOINC DOC code 52066-8</comment>
         <value lang="en-us">Notice of Discharge Medicare Appeal Rights Form attachment</value>
+        <value lang="fr-fr">lettre de renonciation de droit d'appel d'assurance maladie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52067-6">
         <comment>Label: LOINC DOC code 52067-6</comment>
         <value lang="en-us">Past filing limit justification attachment</value>
+        <value lang="fr-fr">Justification pour dépassement de date limite de paiement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52068-4">
         <comment>Label: LOINC DOC code 52068-4</comment>
         <value lang="en-us">Property and casualty state mandated forms attachment</value>
+        <value lang="fr-fr">Formulaires obligatoires de l'État pour les biens et les accidents</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52069-2">
         <comment>Label: LOINC DOC code 52069-2</comment>
@@ -6282,624 +7448,756 @@
     <translation key="2.16.840.1.113883.6.1-52070-0">
         <comment>Label: LOINC DOC code 52070-0</comment>
         <value lang="en-us">Workers compensation attachment</value>
+        <value lang="fr-fr">Informations sur les demandes d'indemnisation des travailleurs</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52071-8">
         <comment>Label: LOINC DOC code 52071-8</comment>
         <value lang="en-us">Employee assistance program attachment</value>
+        <value lang="fr-fr">Informations sur le programme d'aide aux employés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52072-6">
         <comment>Label: LOINC DOC code 52072-6</comment>
         <value lang="en-us">Non-emergency transportation attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de transport non urgent</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52073-4">
         <comment>Label: LOINC DOC code 52073-4</comment>
         <value lang="en-us">Vision attachment</value>
+        <value lang="fr-fr">Informations pour la prise en charge de services de vision</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52075-9">
         <comment>Label: LOINC DOC code 52075-9</comment>
         <value lang="en-us">Purchase invoice attachment</value>
+        <value lang="fr-fr">Informations sur la facture</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53242-4">
         <comment>Label: LOINC DOC code 53242-4</comment>
         <value lang="en-us">Charge ticket or encounter form attachment</value>
+        <value lang="fr-fr">Copie de ticket</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53243-2">
         <comment>Label: LOINC DOC code 53243-2</comment>
         <value lang="en-us">Advance beneficiary notice attachment</value>
+        <value lang="fr-fr">Copie de l'information de non prise en charge financière</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53244-0">
         <comment>Label: LOINC DOC code 53244-0</comment>
         <value lang="en-us">Notice of privacy practices receipt attachment</value>
+        <value lang="fr-fr">Accusé de réception d'information sur la politique de confidentialité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53245-7">
         <comment>Label: LOINC DOC code 53245-7</comment>
         <value lang="en-us">Driver license image attachment</value>
         <value lang="nl-nl">Bijlage afbeelding rijbewijs</value>
+        <value lang="fr-fr">Copie du permis de conduire</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53246-5">
         <comment>Label: LOINC DOC code 53246-5</comment>
         <value lang="en-us">Non-medical services attachment</value>
+        <value lang="fr-fr">Informations sur les demandes de services non médicaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53247-3">
         <comment>Label: LOINC DOC code 53247-3</comment>
         <value lang="en-us">Eligibility acknowledgement attachment</value>
+        <value lang="fr-fr">Informations sur l'éligibilité à la prise en charge</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53576-5">
         <comment>Label: LOINC DOC code 53576-5</comment>
         <value lang="en-us">Personal health monitoring report ({Provider})</value>
         <value lang="nl-nl">Personal health monitoring report ({Instelling})</value>
+        <value lang="fr-fr">Compte-rendu de suivi personnel de santé ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-54094-8">
         <comment>Label: LOINC DOC code 54094-8</comment>
         <value lang="en-us">Triage note</value>
         <value lang="nl-nl">Triageverslag</value>
+        <value lang="fr-fr">Note de triage</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-54095-5">
         <comment>Label: LOINC DOC code 54095-5</comment>
         <value lang="en-us">Chemotherapy effectiveness panel</value>
         <value lang="nl-nl">Chemotherapie effectiviteitspanel</value>
+        <value lang="fr-fr">Chimiothérapie efficacité panel</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-54096-3">
         <comment>Label: LOINC DOC code 54096-3</comment>
         <value lang="en-us">Identity testing (Molgen)</value>
         <value lang="nl-nl">Identiteitstesten (Molgen)</value>
+        <value lang="fr-fr">Test d'identité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55107-7">
         <comment>Label: LOINC DOC code 55107-7</comment>
         <value lang="en-us">Addendum</value>
+        <value lang="fr-fr">Addendum</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55108-5">
         <comment>Label: LOINC DOC code 55108-5</comment>
         <value lang="en-us">Clinical presentation</value>
         <value lang="nl-nl">Klinische presentatie</value>
+        <value lang="fr-fr">Présentation clinique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55109-3">
         <comment>Label: LOINC DOC code 55109-3</comment>
         <value lang="en-us">Complications</value>
         <value lang="nl-nl">Complicaties</value>
+        <value lang="fr-fr">Complications</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55110-1">
         <comment>Label: LOINC DOC code 55110-1</comment>
         <value lang="en-us">Conclusions</value>
         <value lang="nl-nl">Conclusies</value>
+        <value lang="fr-fr">Conclusions</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55111-9">
         <comment>Label: LOINC DOC code 55111-9</comment>
         <value lang="en-us">Current imaging procedure descriptions</value>
+        <value lang="fr-fr">Actes d'imagerie en cours</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55112-7">
         <comment>Label: LOINC DOC code 55112-7</comment>
         <value lang="en-us">Document summary</value>
         <value lang="nl-nl">Documentsamenvatting</value>
+        <value lang="fr-fr">Résumé de document</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55113-5">
         <comment>Label: LOINC DOC code 55113-5</comment>
         <value lang="en-us">Key images (Radiology)</value>
         <value lang="nl-nl">Sleutelbeelden (Radiologie)</value>
+        <value lang="fr-fr">Images clés (Radiologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55114-3">
         <comment>Label: LOINC DOC code 55114-3</comment>
         <value lang="en-us">Prior imaging procedure descriptions</value>
+        <value lang="fr-fr">Actes d'imagerie antérieurs</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55115-0">
         <comment>Label: LOINC DOC code 55115-0</comment>
         <value lang="en-us">Requested imaging studies information</value>
+        <value lang="fr-fr">Informations sur les actes d'imagerie demandés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55182-0">
         <comment>Label: LOINC DOC code 55182-0</comment>
         <value lang="en-us">Quality Reporting Document Architecture incidence report</value>
+        <value lang="fr-fr">Rapport de mesures de la qualité pour un patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55183-8">
         <comment>Label: LOINC DOC code 55183-8</comment>
         <value lang="en-us">Quality Reporting Document Architecture patient list report</value>
+        <value lang="fr-fr">Rapport de mesures de la qualité pour un groupe de patients</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55184-6">
         <comment>Label: LOINC DOC code 55184-6</comment>
         <value lang="en-us">Quality Reporting Document Architecture calculated summary report</value>
+        <value lang="fr-fr">Résumé des rapports de mesures de la qualité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55185-3">
         <comment>Label: LOINC DOC code 55185-3</comment>
         <value lang="en-us">Measure set</value>
         <value lang="nl-nl">Metingenset</value>
+        <value lang="fr-fr">Groupe de mesures</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55186-1">
         <comment>Label: LOINC DOC code 55186-1</comment>
         <value lang="en-us">Measure</value>
         <value lang="nl-nl">Metingen</value>
+        <value lang="fr-fr">Mesure</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55187-9">
         <comment>Label: LOINC DOC code 55187-9</comment>
         <value lang="en-us">Reporting parameters</value>
+        <value lang="fr-fr">Paramètres des rapports</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55188-7">
         <comment>Label: LOINC DOC code 55188-7</comment>
         <value lang="en-us">Patient data</value>
         <value lang="nl-nl">Patiëntgegevens</value>
+        <value lang="fr-fr">Données patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55228-1">
         <comment>Label: LOINC DOC code 55228-1</comment>
         <value lang="en-us">Study report (Cytogenetics)</value>
         <value lang="nl-nl">Onderzoeksverslag (Cytogenetics)</value>
+        <value lang="fr-fr">Compte-rendu (Cytogénétique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55229-9">
         <comment>Label: LOINC DOC code 55229-9</comment>
         <value lang="en-us">Study report (Immune stain)</value>
         <value lang="nl-nl">Onderzoeksverslag (Immune stain)</value>
+        <value lang="fr-fr">Compte-rendu (immunocoloration)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55230-7">
         <comment>Label: LOINC DOC code 55230-7</comment>
         <value lang="en-us">Study report (Immunophenotyping)</value>
         <value lang="nl-nl">Onderzoeksverslag (Immunophenotyping)</value>
+        <value lang="fr-fr">Compte-rendu (Immunophénotypage)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55750-4">
         <comment>Label: LOINC DOC code 55750-4</comment>
         <value lang="en-us">Patient safety report</value>
         <value lang="nl-nl">Verslag patiëntveiligheid</value>
+        <value lang="fr-fr">Rapport sur la sécurité du patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55751-2">
         <comment>Label: LOINC DOC code 55751-2</comment>
         <value lang="en-us">Public health case report</value>
         <value lang="nl-nl">Volksgezondheid incidentverslag</value>
+        <value lang="fr-fr">Rapport de cas de santé publique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57056-4">
         <comment>Label: LOINC DOC code 57056-4</comment>
         <value lang="en-us">Labor and delivery admission history and physical ({Provider})</value>
         <value lang="nl-nl">Voorgeschiedenis en lichamelijke conditie bij opname zwangerschap en geboorte ({Instelling})</value>
+        <value lang="fr-fr">Synthèse d'admission pour l'accouchement ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57057-2">
         <comment>Label: LOINC DOC code 57057-2</comment>
         <value lang="en-us">Labor and delivery summary ({Provider})</value>
         <value lang="nl-nl">Samenvatting zwangerschap en geboorte ({Instelling})</value>
+        <value lang="fr-fr">Synthèse du travail et de l'accouchement ({Fournisseur})</value>
     </translation>
+    <!-- Deprecated LOINC Code: Start -->
     <translation key="2.16.840.1.113883.6.1-57058-0">
         <comment>Label: LOINC DOC code 57058-0</comment>
         <value lang="en-us">Maternal Discharge Summary ({Provider})</value>
         <value lang="nl-nl">Samenvattende ontslagbrief na zwangerschap ({Instelling})</value>
+        <value lang="fr-fr">Lettre de sortie de la mère ({Fournisseur})</value>
     </translation>
+    <!-- Deprecated LOINC Code: End -->
     <translation key="2.16.840.1.113883.6.1-56444-3">
         <comment>Label: LOINC DOC code 56444-3</comment>
         <value lang="en-us">Healthcare communication</value>
         <value lang="nl-nl">Zorginstellingsbrief</value>
+        <value lang="fr-fr">Document de santé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-56445-0">
         <comment>Label: LOINC DOC code 56445-0</comment>
         <value lang="en-us">Medication summary</value>
         <value lang="nl-nl">Medicijnkaart</value>
+        <value lang="fr-fr">Synthèse des traitements</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-56446-8">
         <comment>Label: LOINC DOC code 56446-8</comment>
         <value lang="en-us">Appointment summary</value>
         <value lang="nl-nl">Afsprakenkaart</value>
+        <value lang="fr-fr">Synthèse des rendez-vous</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-56447-6">
         <comment>Label: LOINC DOC code 56447-6</comment>
         <value lang="en-us">Treatment plan</value>
         <value lang="nl-nl">Behandelplan</value>
+        <value lang="fr-fr">Plan de traitement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57016-8">
         <comment>Label: LOINC DOC code 57016-8</comment>
         <value lang="en-us">Privacy policy acknowledgment</value>
         <value lang="nl-nl">Onderschrijving privacybeleid (Patiënt)</value>
+        <value lang="fr-fr">Acceptation de la politique de confidentialité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57017-6">
         <comment>Label: LOINC DOC code 57017-6</comment>
         <value lang="en-us">Privacy policy</value>
         <value lang="nl-nl">Privacybeleid ({Instelling})</value>
+        <value lang="fr-fr">Politique de confidentialité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57024-2">
         <comment>Label: LOINC DOC code 57024-2</comment>
         <value lang="en-us">Health Quality Measure document</value>
         <value lang="nl-nl">Document voor meting van zorgkwaliteit</value>
+        <value lang="fr-fr">Document de mesure de la qualité en santé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57053-1">
         <comment>Label: LOINC DOC code 57053-1</comment>
         <value lang="en-us">Note (Nursing)</value>
         <value lang="nl-nl">Verslag (Verpleging)</value>
+        <value lang="fr-fr">Note du service des urgences (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57054-9">
         <comment>Label: LOINC DOC code 57054-9</comment>
         <value lang="en-us">Triage and nursing note ({Provider})</value>
         <value lang="nl-nl">Verslag triage en verpleging ({Instelling})</value>
+        <value lang="fr-fr">Note de triage et infirmier du service des urgences ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57055-6">
         <comment>Label: LOINC DOC code 57055-6</comment>
         <value lang="en-us">Antepartum summary ({Provider})</value>
         <value lang="nl-nl">Antepartum samenvatting ({Instelling})</value>
+        <value lang="fr-fr">Synthèse Antepartum ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57129-9">
         <comment>Label: LOINC DOC code 57129-9</comment>
         <value lang="en-us">Full newborn screening summary report for display or printing</value>
         <value lang="nl-nl">Volledig verslag screening nieuwgeborene voor weergave en afdrukken</value>
+        <value lang="fr-fr">Synthèse du dépistage néonatal</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57133-1">
         <comment>Label: LOINC DOC code 57133-1</comment>
         <value lang="en-us">Referral note</value>
         <value lang="nl-nl">Verwijsbrief</value>
+        <value lang="fr-fr">Note de référence</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57134-9">
         <comment>Label: LOINC DOC code 57134-9</comment>
         <value lang="en-us">Referral note (Dentistry)</value>
         <value lang="nl-nl">Verwijsbrief (Tandheelkunde)</value>
+        <value lang="fr-fr">Note de référence (Dentisterie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57135-6">
         <comment>Label: LOINC DOC code 57135-6</comment>
         <value lang="en-us">Referral note (Dermatology)</value>
         <value lang="nl-nl">Verwijsbrief (Dermatologie)</value>
+        <value lang="fr-fr">Note de référence (Dermatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57136-4">
         <comment>Label: LOINC DOC code 57136-4</comment>
         <value lang="en-us">Referral note (Diabetology)</value>
         <value lang="nl-nl">Verwijsbrief (Diabeteszorg)</value>
+        <value lang="fr-fr">Note de référence (Diabétologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57137-2">
         <comment>Label: LOINC DOC code 57137-2</comment>
         <value lang="en-us">Referral note (Endocrinology)</value>
         <value lang="nl-nl">Verwijsbrief (Endocrinologie)</value>
+        <value lang="fr-fr">Note de référence (Endocrinologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57138-0">
         <comment>Label: LOINC DOC code 57138-0</comment>
         <value lang="en-us">Referral note (Gastroenterology)</value>
         <value lang="nl-nl">Verwijsbrief (Gastro-enterologie)</value>
+        <value lang="fr-fr">Note de référence (Gastro-entérologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57139-8">
         <comment>Label: LOINC DOC code 57139-8</comment>
         <value lang="en-us">Referral note (General medicine)</value>
         <value lang="nl-nl">Verwijsbrief (Algemene geneeskunde)</value>
+        <value lang="fr-fr">Note de référence (Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57140-6">
         <comment>Label: LOINC DOC code 57140-6</comment>
         <value lang="en-us">Referral note (General surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Algemene chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57141-4">
         <comment>Label: LOINC DOC code 57141-4</comment>
         <value lang="en-us">Referral note (Infectious disease)</value>
         <value lang="nl-nl">Verwijsbrief (Infectieziekten)</value>
+        <value lang="fr-fr">Note de référence (Maladies infectieuses)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57142-2">
         <comment>Label: LOINC DOC code 57142-2</comment>
         <value lang="en-us">Referral note (Kinesiotherapy)</value>
         <value lang="nl-nl">Verwijsbrief (Kinesiotherapie)</value>
+        <value lang="fr-fr">Note de référence (Kinésithérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57143-0">
         <comment>Label: LOINC DOC code 57143-0</comment>
         <value lang="en-us">Referral note (Mental health)</value>
         <value lang="nl-nl">Verwijsbrief (Geestelijke gezondheidszorg)</value>
+        <value lang="fr-fr">Note de référence (Santé mentale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57144-8">
         <comment>Label: LOINC DOC code 57144-8</comment>
         <value lang="en-us">Referral note (Nephrology)</value>
         <value lang="nl-nl">Verwijsbrief (Nephrologie)</value>
+        <value lang="fr-fr">Note de référence (Néphrologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57145-5">
         <comment>Label: LOINC DOC code 57145-5</comment>
         <value lang="en-us">Referral note (Neurology)</value>
         <value lang="nl-nl">Verwijsbrief (Neurologie)</value>
+        <value lang="fr-fr">Note de référence (Neurologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57146-3">
         <comment>Label: LOINC DOC code 57146-3</comment>
         <value lang="en-us">Referral note (Neurosurgery)</value>
         <value lang="nl-nl">Verwijsbrief (Neurochirurgie)</value>
+        <value lang="fr-fr">Note de référence (Neurochirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57147-1">
         <comment>Label: LOINC DOC code 57147-1</comment>
         <value lang="en-us">Referral note (Occupational health)</value>
         <value lang="nl-nl">Verwijsbrief (Bezigheidszorg)</value>
+        <value lang="fr-fr">Note de référence (Santé au travail)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57148-9">
         <comment>Label: LOINC DOC code 57148-9</comment>
         <value lang="en-us">Referral note (Occupational therapy)</value>
         <value lang="nl-nl">Verwijsbrief (Bezigheidstherapie)</value>
+        <value lang="fr-fr">Note de référence (Ergothérapie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57149-7">
         <comment>Label: LOINC DOC code 57149-7</comment>
         <value lang="en-us">Referral note (Oncology)</value>
         <value lang="nl-nl">Verwijsbrief (Oncologie)</value>
+        <value lang="fr-fr">Note de référence (Oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57150-5">
         <comment>Label: LOINC DOC code 57150-5</comment>
         <value lang="en-us">Referral note (Ophthalmology)</value>
         <value lang="nl-nl">Verwijsbrief (Oogheelkunde)</value>
+        <value lang="fr-fr">Note de référence (Ophthalmologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57151-3">
         <comment>Label: LOINC DOC code 57151-3</comment>
         <value lang="en-us">Referral note (Optometry)</value>
         <value lang="nl-nl">Verwijsbrief (Optometrie)</value>
+        <value lang="fr-fr">Note de référence (Optométrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57152-1">
         <comment>Label: LOINC DOC code 57152-1</comment>
         <value lang="en-us">Referral note (Pharmacy)</value>
         <value lang="nl-nl">Verwijsbrief (Apotheek)</value>
+        <value lang="fr-fr">Note de référence (Pharmacie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57153-9">
         <comment>Label: LOINC DOC code 57153-9</comment>
         <value lang="en-us">Referral note (Physical medicine and rehabilitation)</value>
         <value lang="nl-nl">Verwijsbrief (Lichaamsgeneeskunde en revalidatie)</value>
+        <value lang="fr-fr">Note de référence (Médecine physique et réadaptation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57154-7">
         <comment>Label: LOINC DOC code 57154-7</comment>
         <value lang="en-us">Referral note (Physical therapy)</value>
         <value lang="nl-nl">Verwijsbrief (Lichamelijke oefening)</value>
+        <value lang="fr-fr">Note de référence (Thérapie physique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57155-4">
         <comment>Label: LOINC DOC code 57155-4</comment>
         <value lang="en-us">Referral note (Plastic surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Plastische chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie plastique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57156-2">
         <comment>Label: LOINC DOC code 57156-2</comment>
         <value lang="en-us">Referral note (Podiatry)</value>
         <value lang="nl-nl">Verwijsbrief (Podologie)</value>
+        <value lang="fr-fr">Note de référence (Podologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57157-0">
         <comment>Label: LOINC DOC code 57157-0</comment>
         <value lang="en-us">Referral note (Psychiatry)</value>
         <value lang="nl-nl">Verwijsbrief (Psychiatrie)</value>
+        <value lang="fr-fr">Note de référence (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57158-8">
         <comment>Label: LOINC DOC code 57158-8</comment>
         <value lang="en-us">Referral note (Psychology)</value>
         <value lang="nl-nl">Verwijsbrief (Psychologie)</value>
+        <value lang="fr-fr">Note de référence (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57159-6">
         <comment>Label: LOINC DOC code 57159-6</comment>
         <value lang="en-us">Referral note (Radiation oncology)</value>
         <value lang="nl-nl">Verwijsbrief (Radiologische oncologie)</value>
+        <value lang="fr-fr">Note de référence (Radio-oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57160-4">
         <comment>Label: LOINC DOC code 57160-4</comment>
         <value lang="en-us">Referral note (Recreational therapy)</value>
         <value lang="nl-nl">Verwijsbrief (Recreationele therapie)</value>
+        <value lang="fr-fr">Note de référence (Thérapie récréative)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57161-2">
         <comment>Label: LOINC DOC code 57161-2</comment>
         <value lang="en-us">Referral note (Rehabilitation)</value>
         <value lang="nl-nl">Verwijsbrief (Revalidatie)</value>
+        <value lang="fr-fr">Note de référence (Réhabilitation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57162-0">
         <comment>Label: LOINC DOC code 57162-0</comment>
         <value lang="en-us">Referral note (Respiratory therapy)</value>
         <value lang="nl-nl">Verwijsbrief (Ademhalingstherapie)</value>
+        <value lang="fr-fr">Note de référence (Thérapie respiratoire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57163-8">
         <comment>Label: LOINC DOC code 57163-8</comment>
         <value lang="en-us">Referral note (Rheumatology)</value>
         <value lang="nl-nl">Verwijsbrief (Reumatologie)</value>
+        <value lang="fr-fr">Note de référence (Rhumatologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57164-6">
         <comment>Label: LOINC DOC code 57164-6</comment>
         <value lang="en-us">Referral note (Social Work)</value>
         <value lang="nl-nl">Verwijsbrief (Sociaal werk)</value>
+        <value lang="fr-fr">Note de référence (Social)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57165-3">
         <comment>Label: LOINC DOC code 57165-3</comment>
         <value lang="en-us">Referral note (Speech therapy)</value>
         <value lang="nl-nl">Verwijsbrief (Spraaktherapie)</value>
+        <value lang="fr-fr">Note de référence (Orthophonie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57166-1">
         <comment>Label: LOINC DOC code 57166-1</comment>
         <value lang="en-us">Referral note (Surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57167-9">
         <comment>Label: LOINC DOC code 57167-9</comment>
         <value lang="en-us">Referral note (Thoracic surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Thorax chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie thoracique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57168-7">
         <comment>Label: LOINC DOC code 57168-7</comment>
         <value lang="en-us">Referral note (Urology)</value>
         <value lang="nl-nl">Verwijsbrief (Urologie)</value>
+        <value lang="fr-fr">Note de référence (Urologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57169-5">
         <comment>Label: LOINC DOC code 57169-5</comment>
         <value lang="en-us">Referral note (Vascular surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Vasculaire chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie vasculaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57170-3">
         <comment>Label: LOINC DOC code 57170-3</comment>
         <value lang="en-us">Referral note (Cardiovascular disease)</value>
         <value lang="nl-nl">Verwijsbrief (Cardiovasculaire geneeskunde)</value>
+        <value lang="fr-fr">Note de référence (Maladie cardiovasculaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57171-1">
         <comment>Label: LOINC DOC code 57171-1</comment>
         <value lang="en-us">Referral note (Geriatric medicine)</value>
         <value lang="nl-nl">Verwijsbrief (Geriatrie)</value>
+        <value lang="fr-fr">Note de référence (Gériatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57172-9">
         <comment>Label: LOINC DOC code 57172-9</comment>
         <value lang="en-us">Referral note (Hematology and Oncology)</value>
         <value lang="nl-nl">Verwijsbrief (Hematologie en oncologie)</value>
+        <value lang="fr-fr">Note de référence (Hématologie et oncologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57173-7">
         <comment>Label: LOINC DOC code 57173-7</comment>
         <value lang="en-us">Referral note (Nutrition and Dietetics)</value>
         <value lang="nl-nl">Verwijsbrief (Voeding en diëtetiek)</value>
+        <value lang="fr-fr">Note de référence (Nutrition et diététique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57174-5">
         <comment>Label: LOINC DOC code 57174-5</comment>
         <value lang="en-us">Referral note (Oral surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Mondchirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie buccale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57175-2">
         <comment>Label: LOINC DOC code 57175-2</comment>
         <value lang="en-us">Referral note (Orthopedic surgery)</value>
         <value lang="nl-nl">Verwijsbrief (Orthopedische chirurgie)</value>
+        <value lang="fr-fr">Note de référence (Chirurgie orthopédique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57176-0">
         <comment>Label: LOINC DOC code 57176-0</comment>
         <value lang="en-us">Referral note (Otolaryngology)</value>
         <value lang="nl-nl">Verwijsbrief (KNO)</value>
+        <value lang="fr-fr">Note de référence (Oto-rhino-laryngologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57177-8">
         <comment>Label: LOINC DOC code 57177-8</comment>
         <value lang="en-us">Referral note (Pulmonary disease)</value>
         <value lang="nl-nl">Verwijsbrief (Vaatziekten)</value>
+        <value lang="fr-fr">Note de référence (Maladie pulmonaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57178-6">
         <comment>Label: LOINC DOC code 57178-6</comment>
         <value lang="en-us">Referral note (Critical care medicine)</value>
         <value lang="nl-nl">Verwijsbrief (Acute zorg)</value>
+        <value lang="fr-fr">Note de référence (Soins critiques)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57179-4">
         <comment>Label: LOINC DOC code 57179-4</comment>
         <value lang="en-us">Referral note (Obstetrics and Gynecology)</value>
         <value lang="nl-nl">Verwijsbrief (Obstetrie en gynaecologie)</value>
+        <value lang="fr-fr">Note de référence (Obstétrique et de gynécologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57829-4">
         <comment>Label: LOINC DOC code 57829-4</comment>
         <value lang="en-us">Prescription for medical equipment or product</value>
         <value lang="nl-nl">Indicatie voor medische hulpmiddelen of producten</value>
+        <value lang="fr-fr">Prescription de matériel médical ou produit</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57830-2">
         <comment>Label: LOINC DOC code 57830-2</comment>
         <value lang="en-us">Admission request</value>
         <value lang="nl-nl">Opnameverzoek</value>
+        <value lang="fr-fr">Demande d'admission</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57831-0">
         <comment>Label: LOINC DOC code 57831-0</comment>
         <value lang="en-us">Prescription for rehabilitation</value>
         <value lang="nl-nl">Indicatie voor revalidatie</value>
+        <value lang="fr-fr">Prescription de rééducation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57832-8">
         <comment>Label: LOINC DOC code 57832-8</comment>
         <value lang="en-us">Prescription for diagnostic or specialist care</value>
         <value lang="nl-nl">Indicatie voor diagnostische of specialistische zorg</value>
+        <value lang="fr-fr">Prescription pour diagnostic ou soins spécialisés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57833-6">
         <comment>Label: LOINC DOC code 57833-6</comment>
         <value lang="en-us">Prescription for medication</value>
         <value lang="nl-nl">Medicatievoorschrift</value>
+        <value lang="fr-fr">Prescription de médicaments</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57834-4">
         <comment>Label: LOINC DOC code 57834-4</comment>
         <value lang="en-us">Patient transportation request</value>
         <value lang="nl-nl">Patiënt transportverzoek</value>
+        <value lang="fr-fr">Demande de transport patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-58477-1">
         <comment>Label: LOINC DOC code 58477-1</comment>
         <value lang="en-us">Study report (Pulmonary function)</value>
         <value lang="nl-nl">Onderzoeksverslag (Vaatfunctie)</value>
+        <value lang="fr-fr">Compte-rendu (Fonction pulmonaire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59258-4">
         <comment>Label: LOINC DOC code 59258-4</comment>
         <value lang="en-us">Discharge summarization note ({Provider})</value>
         <value lang="nl-nl">Samenvattende ontslagbrief ({Instelling})</value>
+        <value lang="fr-fr">Lettre de sortie ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59259-2">
         <comment>Label: LOINC DOC code 59259-2</comment>
         <value lang="en-us">Discharge summarization note (Psychiatry)</value>
         <value lang="nl-nl">Samenvattende ontslagbrief (Psychiatrie)</value>
+        <value lang="fr-fr">Lettre de sortie (Psychiatrie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59268-3">
         <comment>Label: LOINC DOC code 59268-3</comment>
         <value lang="en-us">Neonatal care report</value>
         <value lang="nl-nl">Verslag neonatale zorg</value>
+        <value lang="fr-fr">Compte-rendu de soins néonataux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59281-6">
         <comment>Label: LOINC DOC code 59281-6</comment>
         <value lang="en-us">Transthoracic cardiac echo study report (US)</value>
         <value lang="nl-nl">Verslag trans-thorax echo-onderzoekt hart (US)</value>
+        <value lang="fr-fr">Compte-rendu d'échographie transthoracique cardiaque</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59282-4">
         <comment>Label: LOINC DOC code 59282-4</comment>
         <value lang="en-us">Stress cardiac echo study report (US)</value>
         <value lang="nl-nl">Verslag echo-onderzoek hartbelasting (US)</value>
+        <value lang="fr-fr">Échocardiographie de stress</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59283-2">
         <comment>Label: LOINC DOC code 59283-2</comment>
         <value lang="en-us">Well child visit note ({Provider})</value>
         <value lang="nl-nl">Well child visit note ({Instelling})</value>
+        <value lang="fr-fr">Note de suivi médical de l'enfant ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59284-0">
         <comment>Label: LOINC DOC code 59284-0</comment>
         <value lang="en-us">Consent (Patient)</value>
         <value lang="nl-nl">Toestemming (Patiënt)</value>
+        <value lang="fr-fr">Consentement(Patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60280-5">
         <comment>Label: LOINC DOC code 60280-5</comment>
         <value lang="en-us">Discharge instructions ({Provider})</value>
         <value lang="nl-nl">Ontslagaanwijzigingen ({Spoedeisende hulp})</value>
+        <value lang="fr-fr">Consignes de sortie du service des urgences ({Fournisseur})</value>
     </translation>
+    <!-- Deprecated LOINC Code : Start -->
     <translation key="2.16.840.1.113883.6.1-60281-3">
         <comment>Label: LOINC DOC code 60281-3</comment>
         <value lang="en-us">Discharge Instructions ({Provider})</value>
         <value lang="nl-nl">Ontslagaanwijzigingen ({Ziekenhuis})</value>
+        <value lang="fr-fr">Consignes de sortie d'hospitalisation ({Fournisseur})</value>
     </translation>
+    <!-- Deprecated LOINC Code : End -->
     <translation key="2.16.840.1.113883.6.1-60568-3">
         <comment>Label: LOINC DOC code 60568-3</comment>
         <value lang="en-us">Synoptic report</value>
         <value lang="nl-nl">Beknopt verslag report</value>
+        <value lang="fr-fr">Rapport synoptique de pathologie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60569-1">
         <comment>Label: LOINC DOC code 60569-1</comment>
         <value lang="en-us">Report addendum.synoptic</value>
         <value lang="nl-nl">Toevoeging verslag.beknopt</value>
+        <value lang="fr-fr">Addendum.Rapport synoptique de pathologie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60570-9">
         <comment>Label: LOINC DOC code 60570-9</comment>
         <value lang="en-us">Consultation note (Pathology)</value>
         <value lang="nl-nl">Consultverslag (Pathologie)</value>
+        <value lang="fr-fr">Note de consultation (Pathologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60571-7">
         <comment>Label: LOINC DOC code 60571-7</comment>
         <value lang="en-us">Consultation note.synoptic (Pathology)</value>
         <value lang="nl-nl">Consultverslag.beknopt (Pathologie)</value>
+        <value lang="fr-fr">Note de consultation.synoptique (Pathologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60590-7">
         <comment>Label: LOINC DOC code 60590-7</comment>
         <value lang="en-us">Medication dispensed.brief</value>
         <value lang="nl-nl">Verstrekte medicatie.kort</value>
+        <value lang="fr-fr">Traitement dispensé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60591-5">
         <comment>Label: LOINC DOC code 60591-5</comment>
         <value lang="en-us">Patient summary</value>
         <value lang="nl-nl">Patiënt samenvatting</value>
+        <value lang="fr-fr">Synthèse médicale</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60592-3">
         <comment>Label: LOINC DOC code 60592-3</comment>
         <value lang="en-us">Patient summary.unexpected contact</value>
         <value lang="nl-nl">Patiënt samenvatting.onverwacht contact</value>
+        <value lang="fr-fr">Synthèse médicale.contact non programmé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-60593-1">
         <comment>Label: LOINC DOC code 60593-1</comment>
         <value lang="en-us">Medication dispensed.extended</value>
         <value lang="nl-nl">Verstrekte medicatie.uitgebreid</value>
+        <value lang="fr-fr">Traitement dispensé.détaillé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61143-4">
         <comment>Label: LOINC DOC code 61143-4</comment>
         <value lang="en-us">Summary (Nursing)</value>
         <value lang="nl-nl">Samenvatting (Verpleging)</value>
+        <value lang="fr-fr">Synthèse (Infirmière)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61145-9">
         <comment>Label: LOINC DOC code 61145-9</comment>
         <value lang="en-us">Patient plan of care</value>
         <value lang="nl-nl">Patiënt zorgplan</value>
+        <value lang="fr-fr">Plant de soins du patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61356-2">
         <comment>Label: LOINC DOC code 61356-2</comment>
         <value lang="en-us">Medication pharmaceutical advice.extended</value>
         <value lang="nl-nl">Medicatie farmaceutisch advies.uitgebreid</value>
+        <value lang="fr-fr">Conseil pharmaceutique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61357-0">
         <comment>Label: LOINC DOC code 61357-0</comment>
         <value lang="en-us">Medication pharmaceutical advice.brief</value>
         <value lang="nl-nl">Medicatie farmaceutisch advies.kort</value>
+        <value lang="fr-fr">Conseil pharmaceutique.ligne</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61358-8">
         <comment>Label: LOINC DOC code 61358-8</comment>
         <value lang="en-us">Surgerical operation consent (Patient)</value>
         <value lang="nl-nl">Toestemming chirugische operatie (Patiënt)</value>
+        <value lang="fr-fr">Consentement pour une operation chirurgicale (Patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61359-6">
         <comment>Label: LOINC DOC code 61359-6</comment>
         <value lang="en-us">Anesthesia consent (Patient)</value>
         <value lang="nl-nl">Toestemming anasthesie (Patiënt)</value>
+        <value lang="fr-fr">Consentement pour une anesthésie (Patient)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-62385-0">
         <comment>Label: LOINC DOC code 62385-0</comment>
         <value lang="en-us">Recommendation</value>
         <value lang="nl-nl">Aanbeveling</value>
+        <value lang="fr-fr">Recommandation</value>
     </translation>
     <!-- End: LOINC where SCALE is Doc -->
     <!-- Start: LOINC where DOCUMENT_SECTION is DOCUMENT or SECTION and Scale is not Doc -->
@@ -6907,489 +8205,588 @@
         <comment>Label: LOINC DOC code 10160-0</comment>
         <value lang="en-us">History of medication use</value>
         <value lang="nl-nl">Geschiedenis medicijngebruik</value>
+        <value lang="fr-fr">Traitements</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10162-6">
         <comment>Label: LOINC DOC code 10162-6</comment>
         <value lang="en-us">History of pregnancies</value>
         <value lang="nl-nl">Geschiedenis zwangerschappen</value>
+        <value lang="fr-fr">Historique des grossesses</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10164-2">
         <comment>Label: LOINC DOC code 10164-2</comment>
         <value lang="en-us">History of present illness</value>
         <value lang="nl-nl">Geschiedenis van huidige ziekte</value>
+        <value lang="fr-fr">Histoire de la maladie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10167-5">
         <comment>Label: LOINC DOC code 10167-5</comment>
         <value lang="en-us">History of surgical procedures</value>
         <value lang="nl-nl">Geschiedenis van chirurgische ingrepen</value>
+        <value lang="fr-fr">Historique des opérations chirurgicales</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10830-8">
         <comment>Label: LOINC DOC code 10830-8</comment>
         <value lang="en-us">Surgical operation note complications</value>
         <value lang="nl-nl">Chirurgisch operatieverslag complicaties</value>
+        <value lang="fr-fr">Note sur les complications d'opération chirurgicale</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10154-3">
         <comment>Label: LOINC DOC code 10154-3</comment>
         <value lang="en-us">Chief complaint</value>
         <value lang="nl-nl">Belangrijkste klacht</value>
+        <value lang="fr-fr">Plainte du patient</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10155-0">
         <comment>Label: LOINC DOC code 10155-0</comment>
         <value lang="en-us">History of allergies</value>
         <value lang="nl-nl">Geschiedenis van allergieën</value>
+        <value lang="fr-fr">Historique des allergies</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10157-6">
         <comment>Label: LOINC DOC code 10157-6</comment>
         <value lang="en-us">History of family member diseases</value>
         <value lang="nl-nl">Geschiedenis van ziekte binnen de familie</value>
+        <value lang="fr-fr">Antecedents familiaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10183-2">
         <comment>Label: LOINC DOC code 10183-2</comment>
         <value lang="en-us">Hospital discharge medications</value>
         <value lang="nl-nl">Ziekenhuis ontslagmedicatie</value>
+        <value lang="fr-fr">Traitements à la sortie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10184-0">
         <comment>Label: LOINC DOC code 10184-0</comment>
         <value lang="en-us">Hospital discharge physical findings</value>
         <value lang="nl-nl">Ziekenhuis ontslag lichamelijke bevindingen</value>
+        <value lang="fr-fr">Résultats physiques à la sortie de l'hôpital</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10187-3">
         <comment>Label: LOINC DOC code 10187-3</comment>
         <value lang="en-us">Review of systems</value>
         <value lang="nl-nl">Review van systemen</value>
+        <value lang="fr-fr">Examen des systèmes</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10210-3">
         <comment>Label: LOINC DOC code 10210-3</comment>
         <value lang="en-us">Physical findings</value>
         <value lang="nl-nl">Lichamelijke bevindingen</value>
+        <value lang="fr-fr">État général</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10213-7">
         <comment>Label: LOINC DOC code 10213-7</comment>
         <value lang="en-us">Surgical operation note anesthesia</value>
         <value lang="nl-nl">Chirurgisch operatieverslag anesthesie</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (anesthésie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10215-2">
         <comment>Label: LOINC DOC code 10215-2</comment>
         <value lang="en-us">Surgical operation note findings</value>
         <value lang="nl-nl">Chirurgisch operatieverslag bevindingen</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (constatations)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10216-0">
         <comment>Label: LOINC DOC code 10216-0</comment>
         <value lang="en-us">Surgical operation note fluids</value>
         <value lang="nl-nl">Chirurgisch operatieverslag vloeistoffen</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (Fluides)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10217-8">
         <comment>Label: LOINC DOC code 10217-8</comment>
         <value lang="en-us">Surgical operation note indications</value>
         <value lang="nl-nl">Chirurgisch operatieverslag indicaties</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (indications)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10218-6">
         <comment>Label: LOINC DOC code 10218-6</comment>
         <value lang="en-us">Surgical operation note postoperative Dx</value>
         <value lang="nl-nl">Chirurgisch operatieverslag postoperatieve diagnose</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (post-opératoire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10219-4">
         <comment>Label: LOINC DOC code 10219-4</comment>
         <value lang="en-us">Surgical operation note preoperative Dx</value>
         <value lang="nl-nl">Chirurgisch operatieverslag preoperatieve diagnose</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (diagnostic pré-opératoire)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10221-0">
         <comment>Label: LOINC DOC code 10221-0</comment>
         <value lang="en-us">Surgical operation note specimens taken</value>
         <value lang="nl-nl">Chirurgisch operatieverslag genomen monsters</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (échantillons prélevés)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-10223-6">
         <comment>Label: LOINC DOC code 10223-6</comment>
         <value lang="en-us">Surgical operation note surgical procedure</value>
         <value lang="nl-nl">Chirurgisch operatieverslag chirurgische ingreep</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (procedure chirurgicale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11535-2">
         <comment>Label: LOINC DOC code 11535-2</comment>
         <value lang="en-us">Hospital discharge Dx</value>
         <value lang="nl-nl">Ziekenhuis onslagdiagnose</value>
+        <value lang="fr-fr">Lettre de sortie (diagnostic)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11537-8">
         <comment>Label: LOINC DOC code 11537-8</comment>
         <value lang="en-us">Surgical drains</value>
         <value lang="nl-nl">Chirurgische drains</value>
+        <value lang="fr-fr">Drains chirurgicaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11283-9">
         <comment>Label: LOINC DOC code 11283-9</comment>
         <value lang="en-us">Acuity assessment</value>
         <value lang="nl-nl">Vaststelling acute karakter</value>
+        <value lang="fr-fr">Évaluation de l'acuité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11302-7">
         <comment>Label: LOINC DOC code 11302-7</comment>
         <value lang="en-us">ED disposition</value>
         <value lang="nl-nl">ED dispositie</value>
+        <value lang="fr-fr">Disposition de sortie du service d'urgence</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11329-0">
         <comment>Label: LOINC DOC code 11329-0</comment>
         <value lang="en-us">History general</value>
         <value lang="nl-nl">Voorgeschiedenis</value>
+        <value lang="fr-fr">Historique général</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11332-4">
         <comment>Label: LOINC DOC code 11332-4</comment>
         <value lang="en-us">History of cognitive function</value>
         <value lang="nl-nl">Cognitieve functiegeschiedenis</value>
+        <value lang="fr-fr">Histoire de la fonction cognitive</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11336-5">
         <comment>Label: LOINC DOC code 11336-5</comment>
         <value lang="en-us">History of hospitalizations</value>
         <value lang="nl-nl">Ziekenhuisopnamegeschiedenis</value>
+        <value lang="fr-fr">Historique des hospitalisations</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11346-4">
         <comment>Label: LOINC DOC code 11346-4</comment>
         <value lang="en-us">History of outpatient visits</value>
         <value lang="nl-nl">Poliklinische bezoekgeschiedenis</value>
+        <value lang="fr-fr">historique des consultations ambulatoires</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11348-0">
         <comment>Label: LOINC DOC code 11348-0</comment>
         <value lang="en-us">History of past illness</value>
         <value lang="nl-nl">Ziektegeschiedenis</value>
+        <value lang="fr-fr">Antécédents médicaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11369-6">
         <comment>Label: LOINC DOC code 11369-6</comment>
         <value lang="en-us">History of immunization</value>
         <value lang="nl-nl">Inentingsgeschiedenis</value>
+        <value lang="fr-fr">Vaccinations</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11370-4">
         <comment>Label: LOINC DOC code 11370-4</comment>
         <value lang="en-us">Immunization status</value>
         <value lang="nl-nl">Status inentingen</value>
+        <value lang="fr-fr">Statut vaccinal</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11450-4">
         <comment>Label: LOINC DOC code 11450-4</comment>
         <value lang="en-us">Problem list</value>
         <value lang="nl-nl">Probleemlijst</value>
+        <value lang="fr-fr">Liste des problèmes</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11459-5">
         <comment>Label: LOINC DOC code 11459-5</comment>
         <value lang="en-us">Transport mode</value>
         <value lang="nl-nl">Transportmodus</value>
+        <value lang="fr-fr">Mode de transport</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11493-4">
         <comment>Label: LOINC DOC code 11493-4</comment>
         <value lang="en-us">Hospital discharge studies summary</value>
         <value lang="nl-nl">Ziekenhuis ontslag samenvatting onderzoeken</value>
+        <value lang="fr-fr">Résumé des études sur les sorties d'hôpital</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18769-0">
         <comment>Label: LOINC DOC code 18769-0</comment>
         <value lang="en-us">Microbial susceptibility tests</value>
+        <value lang="fr-fr">Antibiogramme</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18610-6">
         <comment>Label: LOINC DOC code 18610-6</comment>
         <value lang="en-us">Medication.administered</value>
         <value lang="nl-nl">Toegediende medicatie</value>
+        <value lang="fr-fr">Traitements administrés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18776-5">
         <comment>Label: LOINC DOC code 18776-5</comment>
         <value lang="en-us">Plan of treatment</value>
         <value lang="nl-nl">Behandelplan</value>
+        <value lang="fr-fr">Plan de traitement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18782-3">
         <comment>Label: LOINC DOC code 18782-3</comment>
         <value lang="en-us">Study observation</value>
         <value lang="nl-nl">Observatieonderzoek</value>
+        <value lang="fr-fr">Observation de l'étude</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18783-1">
         <comment>Label: LOINC DOC code 18783-1</comment>
         <value lang="en-us">Study recommendation</value>
         <value lang="nl-nl">Onderzoek aanbeveling</value>
+        <value lang="fr-fr">Recommandation de l'étude</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18785-6">
         <comment>Label: LOINC DOC code 18785-6</comment>
         <value lang="en-us">Reason for study</value>
         <value lang="nl-nl">Reden voor onderzoek</value>
+        <value lang="fr-fr">Raison de l'étude</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-18834-2">
         <comment>Label: LOINC DOC code 18834-2</comment>
         <value lang="en-us">Comparison.study</value>
         <value lang="nl-nl">Vergelijkend.onderzoek</value>
+        <value lang="fr-fr">Étude comparative</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-19005-8">
         <comment>Label: LOINC DOC code 19005-8</comment>
         <value lang="en-us">Imaging study</value>
         <value lang="nl-nl">Beeldvormend onderzoek study</value>
+        <value lang="fr-fr">Examen d'imagerie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-22029-3">
         <comment>Label: LOINC DOC code 22029-3</comment>
         <value lang="en-us">Physical exam.total</value>
         <value lang="nl-nl">Lichamelijk onderzoek.volledig</value>
+        <value lang="fr-fr">Examen physique complet</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29299-5">
         <comment>Label: LOINC DOC code 29299-5</comment>
         <value lang="en-us">Reason for visit</value>
         <value lang="nl-nl">Reden voor bezoek</value>
+        <value lang="fr-fr">Raison de la consultation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29545-1">
         <comment>Label: LOINC DOC code 29545-1</comment>
         <value lang="en-us">Physical findings</value>
         <value lang="nl-nl">Lichamelijke bevindingen</value>
+        <value lang="fr-fr">Constations physiques</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-29762-2">
         <comment>Label: LOINC DOC code 29762-2</comment>
         <value lang="en-us">Social history</value>
         <value lang="nl-nl">Sociale geschiedenis</value>
+        <value lang="fr-fr">Habitus, Mode de vie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-30954-2">
         <comment>Label: LOINC DOC code 30954-2</comment>
         <value lang="en-us">Relevant diagnostic tests &amp;or laboratory data</value>
         <value lang="nl-nl">Relevante diagnostische tests &amp; or laboratoriumgegevens</value>
+        <value lang="fr-fr">Test de diagnostic utiles et données de laboratoire</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38212-7">
         <comment>Label: LOINC DOC code 38212-7</comment>
         <value lang="en-us">Pain assessment panel</value>
         <value lang="nl-nl">Pijn vaststellingspanel</value>
+        <value lang="fr-fr">Panel d'évaluation de la douleur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38227-5">
         <comment>Label: LOINC DOC code 38227-5</comment>
         <value lang="en-us">Braden scale score.total</value>
         <value lang="nl-nl">Braden schaal score.volledig</value>
+        <value lang="fr-fr">Score total de Braden</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-42348-3">
         <comment>Label: LOINC DOC code 42348-3</comment>
         <value lang="en-us">Advance directives</value>
         <value lang="nl-nl">Wilsverklaring</value>
+        <value lang="fr-fr">Directives anticipées</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-42349-1">
         <comment>Label: LOINC DOC code 42349-1</comment>
         <value lang="en-us">Reason for referral</value>
         <value lang="nl-nl">Reden voor overplaatsing</value>
+        <value lang="fr-fr">Raison de la recommandation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46239-0">
         <comment>Label: LOINC DOC code 46239-0</comment>
         <value lang="en-us">Chief complaint+Reason for visit</value>
         <value lang="nl-nl">Belangrijkste klacht+Reden voor bezoek</value>
+        <value lang="fr-fr">Plainte principale + Raison de la visite</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46240-8">
         <comment>Label: LOINC DOC code 46240-8</comment>
         <value lang="en-us">History of hospitalizations+History of outpatient visits</value>
         <value lang="nl-nl">Geschiedenis van ziekenhuisopnames+Geschiedenis van poliklinische bezoeken</value>
+        <value lang="fr-fr">Historique des hospitalisations + Historique des consultations ambulatoires</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46241-6">
         <comment>Label: LOINC DOC code 46241-6</comment>
         <value lang="en-us">Hospital admission Dx</value>
         <value lang="nl-nl">Ziekenhuis opnamediagnose</value>
+        <value lang="fr-fr">Diagnostic d'admission à l'hôpital</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55102-8">
         <comment>Label: LOINC DOC code 55102-8</comment>
         <value lang="en-us">Surgical operation note disposition</value>
         <value lang="nl-nl">Chirurgisch operatieverslag dispositie</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (disposition)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55103-6">
         <comment>Label: LOINC DOC code 55103-6</comment>
         <value lang="en-us">Surgical operation note estimated blood loss</value>
         <value lang="nl-nl">Chirurgisch operatieverslag geschat bloedverlies</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (perte de sang estimée)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55104-4">
         <comment>Label: LOINC DOC code 55104-4</comment>
         <value lang="en-us">Surgical operation note planned procedure</value>
         <value lang="nl-nl">Chirurgisch operatieverslag geplande ingreep</value>
+        <value lang="fr-fr">Note d'opération chirurgicale (procédure planifiée)</value>
     </translation>
+    <!-- [ANS] Start: deprecated LOINC Code -->
     <translation key="2.16.840.1.113883.6.1-5511-1">
         <comment>Label: LOINC DOC code 5511-1</comment>
         <value lang="en-us">CD62E</value>
     </translation>
+    <!-- [ANS] End: deprecated LOINC Code -->
     <translation key="2.16.840.1.113883.6.1-57059-8">
         <comment>Label: LOINC DOC code 57059-8</comment>
         <value lang="en-us">Pregnancy visit summary</value>
         <value lang="nl-nl">Samenvatting zwangerschapbezoek</value>
+        <value lang="fr-fr">CR de consultation obstétrique</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57060-6">
         <comment>Label: LOINC DOC code 57060-6</comment>
         <value lang="en-us">Estimated date of delivery</value>
         <value lang="nl-nl">A terme datum</value>
+        <value lang="fr-fr">Date d'accouchement estimée</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57072-1">
         <comment>Label: LOINC DOC code 57072-1</comment>
         <value lang="en-us">Intravenous fluids administered</value>
         <value lang="nl-nl">Intraveneus toegediende vloeistoffen</value>
+        <value lang="fr-fr">Fluides intraveineux administrés</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57073-9">
         <comment>Label: LOINC DOC code 57073-9</comment>
         <value lang="en-us">Prenatal events</value>
         <value lang="nl-nl">Prenatale gebeurtenissen</value>
+        <value lang="fr-fr">Evènements prénataux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57074-7">
         <comment>Label: LOINC DOC code 57074-7</comment>
         <value lang="en-us">Labor and delivery process</value>
         <value lang="nl-nl">Verloop zwangerschap en bevalling</value>
+        <value lang="fr-fr">Travail et accouchement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57075-4">
         <comment>Label: LOINC DOC code 57075-4</comment>
         <value lang="en-us">Newborn delivery information</value>
         <value lang="nl-nl">Informatie bevalling nieuwgeborene</value>
+        <value lang="fr-fr">Informations sur l'accouche-ment et le nouveau-né</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57076-2">
         <comment>Label: LOINC DOC code 57076-2</comment>
         <value lang="en-us">Postpartum hospitalization treatment</value>
         <value lang="nl-nl">Postpartum ziekenhuisbehandeling</value>
+        <value lang="fr-fr">Traitement post-partum hospitalier</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57077-0">
         <comment>Label: LOINC DOC code 57077-0</comment>
         <value lang="en-us">Newborn status at maternal discharge</value>
         <value lang="nl-nl">Status nieuwgeborene bij ontslag moeder</value>
+        <value lang="fr-fr">Statut du nouveau-né à la sortie de la mère</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57078-8">
         <comment>Label: LOINC DOC code 57078-8</comment>
         <value lang="en-us">Antenatal testing and surveillance</value>
         <value lang="nl-nl">Antenatale testen en toezicht</value>
+        <value lang="fr-fr">Examens et surveillance prénataux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57079-6">
         <comment>Label: LOINC DOC code 57079-6</comment>
         <value lang="en-us">Birth plan</value>
         <value lang="nl-nl">Geboorteplan</value>
+        <value lang="fr-fr">Plan de travail et d'accouchement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57080-4">
         <comment>Label: LOINC DOC code 57080-4</comment>
         <value lang="en-us">Implanted medical device</value>
         <value lang="nl-nl">Geïmplanteerd medisch apparaat</value>
+        <value lang="fr-fr">Dispositif médical implanté</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57081-2">
         <comment>Label: LOINC DOC code 57081-2</comment>
         <value lang="en-us">Anesthesia risk review of systems</value>
         <value lang="nl-nl">Anesthesie risicoreview van systemen</value>
+        <value lang="fr-fr">Examen des risques d'anesthésie des systèmes</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-56836-0">
         <comment>Label: LOINC DOC code 56836-0</comment>
         <value lang="en-us">History of blood transfusion</value>
         <value lang="nl-nl">Geschiedenis van bloedtransfusies</value>
+        <value lang="fr-fr">Antécédent de transfusion sanguine</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-56838-6">
         <comment>Label: LOINC DOC code 56838-6</comment>
         <value lang="en-us">History of infectious disease</value>
         <value lang="nl-nl">Geschiedenis infectieziekten</value>
+        <value lang="fr-fr">Antécédents de maladies infectieuses</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57025-9">
         <comment>Label: LOINC DOC code 57025-9</comment>
         <value lang="en-us">Data criteria</value>
         <value lang="nl-nl">Datacriteria</value>
+        <value lang="fr-fr">Critères de données</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57026-7">
         <comment>Label: LOINC DOC code 57026-7</comment>
         <value lang="en-us">Population criteria</value>
         <value lang="nl-nl">Populatiecriteria</value>
+        <value lang="fr-fr">Critères de population</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57027-5">
         <comment>Label: LOINC DOC code 57027-5</comment>
         <value lang="en-us">Measure observations</value>
         <value lang="nl-nl">Metingen</value>
+        <value lang="fr-fr">Observations sur la mesure</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57827-8">
         <comment>Label: LOINC DOC code 57827-8</comment>
         <value lang="en-us">Reason for co-payment exemption</value>
         <value lang="nl-nl">Reden voor vrijstelling co-betaling</value>
+        <value lang="fr-fr">Raison de l'exonération du ticket modérateur</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-5782-8">
         <comment>Label: LOINC DOC code 5782-8</comment>
         <value lang="en-us">Crystals</value>
         <value lang="nl-nl">Kristalvorming</value>
+        <value lang="fr-fr">Formation de cristaux</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57828-6">
         <comment>Label: LOINC DOC code 57828-6</comment>
         <value lang="en-us">Prescriptions</value>
         <value lang="nl-nl">Medicatievoorschriften</value>
+        <value lang="fr-fr">Prescriptions</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57826-0">
         <comment>Label: LOINC DOC code 57826-0</comment>
         <value lang="en-us">Co-payment amount</value>
         <value lang="nl-nl">Co-betaling bedrag</value>
+        <value lang="fr-fr">Montant du co-paiement</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59768-2">
         <comment>Label: LOINC DOC code 59768-2</comment>
         <value lang="en-us">Procedure indications</value>
         <value lang="nl-nl">Indicaties ingreep</value>
+        <value lang="fr-fr">Motif de l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59769-0">
         <comment>Label: LOINC DOC code 59769-0</comment>
         <value lang="en-us">Postprocedure diagnosis</value>
         <value lang="nl-nl">Diagnose na ingreep</value>
+        <value lang="fr-fr">Diagnostic post-opératoire</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59770-8">
         <comment>Label: LOINC DOC code 59770-8</comment>
         <value lang="en-us">Procedure estimated blood loss</value>
         <value lang="nl-nl">Bloedverlies ingreep</value>
+        <value lang="fr-fr">Estimation de la perte de sang pendant l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59771-6">
         <comment>Label: LOINC DOC code 59771-6</comment>
         <value lang="en-us">Procedure implants</value>
         <value lang="nl-nl">Ingreep implantaten</value>
+        <value lang="fr-fr">Implants réalisés pendant l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59772-4">
         <comment>Label: LOINC DOC code 59772-4</comment>
         <value lang="en-us">Planned procedure</value>
         <value lang="nl-nl">Geplande ingreep</value>
+        <value lang="fr-fr">Acte planifié</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59773-2">
         <comment>Label: LOINC DOC code 59773-2</comment>
         <value lang="en-us">Procedure specimens taken</value>
         <value lang="nl-nl">Ingreep afgenomen monsters</value>
+        <value lang="fr-fr">Echantillons prélevés pendant l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59774-0">
         <comment>Label: LOINC DOC code 59774-0</comment>
         <value lang="en-us">Procedure anesthesia</value>
         <value lang="nl-nl">Ingreep anesthesie</value>
+        <value lang="fr-fr">Anesthésie</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59775-7">
         <comment>Label: LOINC DOC code 59775-7</comment>
         <value lang="en-us">Procedure disposition</value>
         <value lang="nl-nl">Ingreep dispositie</value>
+        <value lang="fr-fr">Dispositions post-opératoires</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-59776-5">
         <comment>Label: LOINC DOC code 59776-5</comment>
         <value lang="en-us">Procedure findings</value>
         <value lang="nl-nl">Ingreep bevindingen</value>
+        <value lang="fr-fr">Constations au cours de l'acte</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61144-2">
         <comment>Label: LOINC DOC code 61144-2</comment>
         <value lang="en-us">Diet and nutrition</value>
         <value lang="nl-nl">Dieet en voeding</value>
+        <value lang="fr-fr">Régime alimentaire et nutrition</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61146-7">
         <comment>Label: LOINC DOC code 61146-7</comment>
         <value lang="en-us">Goals</value>
         <value lang="nl-nl">Doelen</value>
+        <value lang="fr-fr">Buts</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-61147-5">
         <comment>Label: LOINC DOC code 61147-5</comment>
         <value lang="en-us">Expected outcomes</value>
         <value lang="nl-nl">Verwachte uitkomsten</value>
+        <value lang="fr-fr">Résultats attendus</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-8724-7">
         <comment>Label: LOINC DOC code 8724-7</comment>
         <value lang="en-us">Surgical operation note description</value>
         <value lang="nl-nl">Chirurgisch operatieverslag omschrijving </value>
+        <value lang="fr-fr">Note d'opération chirurgicale (description)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-8716-3">
         <comment>Label: LOINC DOC code 8716-3</comment>
         <value lang="en-us">Physical findings</value>
         <value lang="nl-nl">Lichamelijke bevindingen</value>
+        <value lang="fr-fr">Constatations physiques</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-8648-8">
         <comment>Label: LOINC DOC code 8648-8</comment>
         <value lang="en-us">Hospital course</value>
         <value lang="nl-nl">Ziekenhuis verloop</value>
+        <value lang="fr-fr">Parcours hospitalier</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-8658-7">
         <comment>Label: LOINC DOC code 8658-7</comment>
         <value lang="en-us">History of allergies</value>
         <value lang="nl-nl">Geschiedenis allergieën</value>
+        <value lang="fr-fr">Historique des allergies</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-8675-5">
         <comment>Label: LOINC DOC code 8658-7</comment>
         <value lang="en-us">Fluid intake.intravascular</value>
         <value lang="nl-nl">Vloeistof inname.intravasculair</value>
+        <value lang="fr-fr">Fluide intravasculaire</value>
     </translation>
     <!-- End: LOINC where DOCUMENT_SECTION is DOCUMENT or SECTION and Scale is not Doc -->
     <!-- Start: OIDs -->
     <translation key="1.0.3166.1.2.2">
         <comment>Label: OID ISO 3166 Alpha 2</comment>
         <value lang="nl-nl">ISO 3166 Alpha 2</value>
+        <value lang="fr-fr">ISO 3166 Alpha 2</value>
     </translation>
     <translation key="1.0.639.1">
         <comment>Label: OID ISO 639-1</comment>
         <value lang="nl-nl">ISO 639-1</value>
+        <value lang="fr-fr">ISO 639-1</value>
     </translation>
     <translation key="1.2.276.0.76.5.409">
         <comment>Label: OID WHO/DIMDI ICD-10-DE (German)</comment>
@@ -7416,6 +8813,7 @@
         <value lang="en-us">NHS Number</value>
         <value lang="nl-nl">NHS-nummer</value>
     </translation>
+    <!-- OID NL : Start -->
     <translation key="2.16.840.1.113883.2.4.15.1060">
         <comment>Label: OID RoleCodeNL - zorgaanbiedertype (organisaties)</comment>
         <value lang="nl-nl">RoleCodeNL Zorgaanbiedertype</value>
@@ -7625,15 +9023,24 @@
     <translation key="2.16.840.1.113883.2.4.6.70">
         <comment>Label: OID SBV-Z Identificatiedocumenttypes</comment>
         <value lang="nl-nl">SBV-Z Identificatiedocumenttypes</value>
-    </translation>
+    </translation>    
+    <!-- OID NL: End -->
+    
+    <!-- OID Military Health System (MHS): Start -->
     <translation key="2.16.840.1.113883.3.42">
         <comment>Label: DoD Military Health System (MHS)</comment>
         <value lang="en-us">DoD MHS</value>
-    </translation>
+    </translation>    
+    <!-- OID Military Health System (MHS): End -->
+    
+    <!-- OID HL7 Inc Demo OID: Start -->
     <translation key="2.16.840.1.113883.3.933">
         <comment>Label: HL7 Inc Demo OID</comment>
         <value lang="en-us">HL7 Demo</value>
     </translation>
+    <!-- OID HL7 Inc Demo OID: End -->
+    
+    <!-- OID United States: Start -->
     <translation key="2.16.840.1.113883.4.1">
         <comment>Label: OID US Social Security Number</comment>
         <value lang="en-us">SSN</value>
@@ -7642,6 +9049,9 @@
         <comment>Label: OID US National Provider Identifier</comment>
         <value lang="en-us">NPI</value>
     </translation>
+    <!-- OID United States: End -->
+    
+    <!-- OID HL7 v3 codeSystems: Start -->
     <translation key="2.16.840.1.113883.5.1">
         <comment>Label: OID AdministrativeGender</comment>
         <value lang="en-us">AdministrativeGender</value>
@@ -7787,7 +9197,10 @@
     <translation key="2.16.840.1.113883.5.89">
         <comment>Label: OID ParticipationSignature</comment>
         <value lang="en-us">ParticipationSignature</value>
-    </translation>
+    </translation>    
+    <!-- OID HL7 v3 codeSystems: End -->
+    
+    <!-- OID externalCodeSystems: Start -->
     <translation key="2.16.840.1.113883.6.1">
         <comment>Label: OID LOINC</comment>
         <value lang="en-us">LOINC</value>
@@ -7829,1767 +9242,2126 @@
         <value lang="en-us">Examples</value>
         <value lang="nl-nl">Voorbeelden</value>
     </translation>
+    <!-- OID externalCodeSystems: End -->
     <!-- End: OIDs -->
+    
     <translation key="iframe-warning-ie9">
         <comment>Label: unsupported browser for iframe</comment>
         <value lang="en-us">WARNING: This browser does not support sandboxed iframes which makes rendering here potentially unsafe. Please try a different browser.</value>
         <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen sandboxed iframes wat weergave op deze plaats onveilig maakt. Probeer een modernere browser.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes bac à sable, ce qui rend le rendu ici potentiellement dangereux. Veuillez essayer un autre navigateur.</value>
     </translation>
     <translation key="iframe-warning-pdf-ie9">
         <comment>Label: unsupported browser for iframe with pdf</comment>
         <value lang="en-us">WARNING: This browser does not support (sandboxed) iframes with inline pdf which makes rendering here potentially unsafe and/or impossible. Please try a different browser.</value>
         <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen (sandboxed) iframes met inline pdf wat weergave op deze plaats onveilig en/of onmogelijk maakt. Probeer een modernere browser.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes (sandbox) avec pdf en ligne, ce qui rend le rendu ici potentiellement dangereux et/ou impossible. Veuillez essayer un autre navigateur.</value>
     </translation>
     <translation key="iframe-warning-sandboxed-pdf">
         <comment>Label: unsupported browser for iframe with pdf (limit-pdf = yes)</comment>
         <value lang="en-us">WARNING: Due to the security setting of this rendering, it is not possible to show the pdf.</value>
         <value lang="nl-nl">WAARSCHUWING: Vanwege de beveiligingsinstellingen voor deze weergaven, is het niet mogelijk om de pdf weer te geven.</value>
+        <value lang="fr-fr">ATTENTION : En raison des paramètres de sécurité, il n'est pas possible d'afficher le pdf.</value>
     </translation>
     <translation key="javascript-injection-warning">
         <comment>Label: security warning text</comment>
         <value lang="en-us">WARNING: Javascript injection attempt detected in source CDA document. Terminating</value>
         <value lang="nl-nl">WAARSCHUWING: Javascript-injectiepoging gedetecteerd in bron CDA-document. Einde verwerking</value>
+        <value lang="fr-fr">AVERTISSEMENT : Tentative d'injection Javascript détectée dans le document source CDA.</value>
     </translation>
     <translation key="malicious-content-warning">
         <comment>Label: security warning text</comment>
         <value lang="en-us">WARNING: Potentially malicious content found in CDA document.</value>
         <value lang="nl-nl">WAARSCHUWING: potentieel gevaarlijke inhoud gevonden in CDA-document.</value>
+        <value lang="fr-fr">AVERTISSEMENT : contenu potentiellement malveillant trouvé dans le document CDA.</value>
     </translation>
     <translation key="is-in-the-whitelist">
         <comment>Label: security warning text</comment>
         <value lang="en-us"> is in the whitelist</value>
         <value lang="nl-nl"> staat op de whitelist</value>
+        <value lang="fr-fr"> est dans la liste blanche</value>
     </translation>
     <translation key="non-local-image-found-1">
         <comment>Label: security warning text part1</comment>
         <value lang="en-us">WARNING: non-local image found </value>
         <value lang="nl-nl">WAARSCHUWING: niet-lokale afbeelding gevonden </value>
+        <value lang="fr-fr">AVERTISSEMENT : image non locale détectée </value>
     </translation>
     <translation key="non-local-image-found-2">
         <comment>Label: security warning text part2</comment>
         <value lang="en-us">. Removing. If you wish to preserve non-local images please set the limit-external-images param to 'no'.</value>
         <value lang="nl-nl">. Wordt niet verwerkt. Als u niet-lokale afbeelding wilt behouden, dan stelt u de parameter limit-external-images in op 'no'.</value>
+        <value lang="fr-fr">. Retrait. Si vous souhaitez conserver des images non locales, définissez le paramètre limit-external-images sur 'no'.</value>
     </translation>
     <translation key="logicalOR">
         <comment>Label: logicalOR (e.g. query params with multiple value elements)</comment>
         <value lang="en-us"> OR </value>
         <value lang="nl-nl"> OF </value>
+        <value lang="fr-fr"> OU </value>
     </translation>
     <translation key="logicalAND">
         <comment>Label: logicalAND (e.g. multiple sibling query params)</comment>
         <value lang="en-us"> AND </value>
         <value lang="nl-nl"> AND </value>
+        <value lang="fr-fr"> ET </value>
     </translation>
     <translation key="Expand All">
         <comment>Label: Expand all sections</comment>
         <value lang="en-us">Expand All</value>
         <value lang="nl-nl">Alles uitvouwen</value>
+        <value lang="fr-fr">Développer</value>
     </translation>
     <translation key="Collapse All">
         <comment>Label: Collapse all sections</comment>
         <value lang="en-us">Collapse All</value>
         <value lang="nl-nl">Alles invouwen</value>
+        <value lang="fr-fr">Réduire</value>
     </translation>
     <translation key="Expand">
         <comment>Label: Expand section</comment>
         <value lang="en-us">Expand</value>
         <value lang="nl-nl">Uitvouwen</value>
+        <value lang="fr-fr">Développer</value>
     </translation>
     <translation key="Collapse">
         <comment>Label: Collapse section</comment>
         <value lang="en-us">Collapse</value>
         <value lang="nl-nl">Invouwen</value>
+        <value lang="fr-fr">Réduire</value>
     </translation>
     <translation key="untitled_doc">
         <comment>Label: when a document has no name</comment>
         <value lang="en-us">Untitled Document</value>
         <value lang="nl-nl">Naamloos document</value>
+        <value lang="fr-fr">Document sans titre</value>
     </translation>
     <translation key="no_human_display">
         <comment>Label: when a document has no human readable text</comment>
         <value lang="en-us">No human-readable content available</value>
         <value lang="nl-nl">Geen voor-mensen-leesbare content beschikbaar</value>
+        <value lang="fr-fr">Aucun contenu lisible par l'homme disponible</value>
     </translation>
     <translation key="subject-heading">
         <comment>Label: starting point for subject details</comment>
         <value lang="en-us">Subject Details</value>
         <value lang="nl-nl">Patiëntgegevens</value>
+        <value lang="fr-fr">Informations sur le patient</value>
     </translation>
     <translation key="author-heading">
         <comment>Label: starting point for author details</comment>
         <value lang="en-us">Author Details</value>
         <value lang="nl-nl">Auteurgegevens</value>
+        <value lang="fr-fr">Informations sur l'auteur</value>
     </translation>
     <translation key="encounter-heading">
         <comment>Label: starting point for encounter details</comment>
         <value lang="en-us">Encounter Details</value>
         <value lang="nl-nl">Bezoekgegevens</value>
+        <value lang="fr-fr">Informations sur la prise en charge</value>
     </translation>
     <translation key="untitled-section">
         <comment>Label: starting point for untitled section</comment>
         <value lang="en-us">Untitled Section</value>
         <value lang="nl-nl">Naamloze sectie</value>
+        <value lang="fr-fr">Section sans titre</value>
     </translation>
     <translation key="err-fhir-1">
         <comment>Error message: Source document must be a bundle</comment>
         <value lang="en-us">Source document must be a bundle</value>
         <value lang="nl-nl">Brondocument moet een bundle zijn</value>
+        <value lang="fr-fr">Le document source doit être un Bundle</value>
     </translation>
     <translation key="err-fhir-2">
         <comment>Error message: Bundle must start with a Composition resource</comment>
         <value lang="en-us">Bundle must start with a Composition resource</value>
         <value lang="nl-nl">Bundle moet beginnen met een Composition resource</value>
+        <value lang="fr-fr">Le Bundle doit commencer par une ressource Composition</value>
     </translation>
     <translation key="err-fhir-3">
         <comment>Error message: Warning: Bundle type does not indicate it is a document.</comment>
         <value lang="en-us">Warning: Bundle type does not indicate it is a document.</value>
         <value lang="nl-nl">Waarschuwing: Bundle type zegt niet dat dit een document is.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Le type de Bundle n'indique pas qu'il s'agit d'un document.</value>
     </translation>
     <translation key="err-fhir-4">
         <comment>Error message: Error: The document composition includes a reference to a resource not contained inside the document bundle:</comment>
         <value lang="en-us">Error: The document composition includes a reference to a resource not contained inside the document bundle: </value>
         <value lang="nl-nl">Fout: Er is een verwijzing in de document Composition naar een resource die ontbreekt in de Bundle: </value>
+        <value lang="fr-fr">ERREUR : La composition du document inclut une référence à une ressource non contenue dans le Bundle :</value>
     </translation>
     <translation key="err-fhir-5">
         <comment>Error message: Error: A referenced resource is not contained and is not fully qualified:</comment>
         <value lang="en-us">Error: A referenced resource is not contained and is not fully qualified: </value>
         <value lang="nl-nl">Fout: Er is een verwijzing naar een resource die ontbreekt en waarvan de verwijzing niet volledig is: </value>
+        <value lang="fr-fr">ERREUR : Une ressource référencée n'est pas contenue et n'est pas entièrement qualifiée : </value>
     </translation>
     <translation key="err-fhir-6">
         <comment>Error message: Warning: Headings exceed 6 levels deep. Remaining headings converted to simple paragraphs</comment>
         <value lang="en-us">Warning: Headings exceed 6 levels deep. Remaining headings converted to simple paragraphs</value>
         <value lang="nl-nl">Waarschuwing: Kopniveau's gaan dieper dan 6. De overgebleven kopniveau's worden omgezet naar normale paragrafen</value>
+        <value lang="fr-fr">AVERTISSEMENT : Les titres dépassent 6 niveaux de profondeur. Titres restants convertis en paragraphes simples.</value>
     </translation>
     <translation key="err-fhir-7">
         <comment>Error message: Source document must be a composition</comment>
         <value lang="en-us">Source document must be a composition</value>
         <value lang="nl-nl">Brondocument moet een composition zijn</value>
+        <value lang="fr-fr">Le document source doit être une composition.</value>
     </translation>
+    <!-- UCUM -->
     <translation key="ucum-s">
         <comment>UCUM code s</comment>
         <value lang="en-us">second</value>
         <value lang="nl-nl">seconde</value>
+        <value lang="fr-fr">seconde</value>
     </translation>
     <translation key="ucum-min">
         <comment>UCUM code min</comment>
         <value lang="en-us">minute</value>
         <value lang="nl-nl">minuut</value>
+        <value lang="fr-fr">minute</value>
     </translation>
     <translation key="ucum-h">
         <comment>UCUM code h</comment>
         <value lang="en-us">hour</value>
         <value lang="nl-nl">uur</value>
+        <value lang="fr-fr">heure</value>
     </translation>
     <translation key="ucum-d">
         <comment>UCUM code d</comment>
         <value lang="en-us">day</value>
         <value lang="nl-nl">dag</value>
+        <value lang="fr-fr">jour</value>
     </translation>
     <translation key="ucum-wk">
         <comment>UCUM code wk</comment>
         <value lang="en-us">week</value>
         <value lang="nl-nl">week</value>
+        <value lang="fr-fr">semaine</value>
     </translation>
     <translation key="ucum-mo">
         <comment>UCUM code mo</comment>
         <value lang="en-us">month</value>
         <value lang="nl-nl">maand</value>
+        <value lang="fr-fr">mois</value>
     </translation>
     <translation key="ucum-a">
         <comment>UCUM code a</comment>
         <value lang="en-us">year</value>
         <value lang="nl-nl">jaar</value>
+        <value lang="fr-fr">année</value>
     </translation>
     <translation key="ucums-s">
         <comment>seconds</comment>
         <value lang="en-us">seconds</value>
         <value lang="nl-nl">seconden</value>
+        <value lang="fr-fr">secondes</value>
     </translation>
     <translation key="ucums-min">
         <comment>UCUM code min</comment>
         <value lang="en-us">minutes</value>
         <value lang="nl-nl">minuten</value>
+        <value lang="fr-fr">minutes</value>
     </translation>
     <translation key="ucums-h">
         <comment>UCUM code h</comment>
         <value lang="en-us">hours</value>
         <value lang="nl-nl">uren</value>
+        <value lang="fr-fr">heures</value>
     </translation>
     <translation key="ucums-d">
         <comment>UCUM code d</comment>
         <value lang="en-us">days</value>
         <value lang="nl-nl">dagen</value>
+        <value lang="fr-fr">jours</value>
     </translation>
     <translation key="ucums-wk">
         <comment>UCUM code wk</comment>
         <value lang="en-us">weeks</value>
         <value lang="nl-nl">weken</value>
+        <value lang="fr-fr">semaines</value>
     </translation>
     <translation key="ucums-mo">
         <comment>UCUM code mo</comment>
         <value lang="en-us">months</value>
         <value lang="nl-nl">maanden</value>
+        <value lang="fr-fr">mois</value>
     </translation>
     <translation key="ucums-a">
         <comment>UCUM code a</comment>
         <value lang="en-us">year</value>
         <value lang="nl-nl">jaar</value>
+        <value lang="fr-fr">années</value>
     </translation>
     <translation key="eventtiming-HS">
         <comment>EventTiming code HS</comment>
         <value lang="en-us">before (trying to) sleep</value>
         <value lang="nl-nl">voor het (proberen te) slapen</value>
+        <value lang="fr-fr">avant (d'essayer) de dormir</value>
     </translation>
     <translation key="eventtiming-WAKE">
         <comment>EventTiming code WAKE</comment>
         <value lang="en-us">after waking</value>
         <value lang="nl-nl">na ontwaken</value>
+        <value lang="fr-fr">après le réveil</value>
     </translation>
     <translation key="eventtiming-C">
         <comment>EventTiming code C</comment>
         <value lang="en-us">at a meal</value>
         <value lang="nl-nl">bij de maaltijd</value>
+        <value lang="fr-fr">au repas</value>
     </translation>
     <translation key="eventtiming-CM">
         <comment>EventTiming code CM</comment>
         <value lang="en-us">at breakfast</value>
         <value lang="nl-nl">bij het ontbijt</value>
+        <value lang="fr-fr">au petit-déjeuner</value>
     </translation>
     <translation key="eventtiming-CD">
         <comment>EventTiming code CD</comment>
         <value lang="en-us">at lunch</value>
         <value lang="nl-nl">bij de lunch</value>
+        <value lang="fr-fr">au déjeuner</value>
     </translation>
     <translation key="eventtiming-CV">
         <comment>EventTiming code CV</comment>
         <value lang="en-us">at dinner</value>
         <value lang="nl-nl">bij het avondeten</value>
+        <value lang="fr-fr">au dîner</value>
     </translation>
     <translation key="eventtiming-AC">
         <comment>EventTiming code AC</comment>
         <value lang="en-us">before a meal</value>
         <value lang="nl-nl">voor de maaltijd</value>
+        <value lang="fr-fr">avant le repas</value>
     </translation>
     <translation key="eventtiming-ACM">
         <comment>EventTiming code ACM</comment>
         <value lang="en-us">before breakfast</value>
         <value lang="nl-nl">voor het ontbijt</value>
+        <value lang="fr-fr">avant le petit-déjeuner</value>
     </translation>
     <translation key="eventtiming-ACD">
         <comment>EventTiming code ACD</comment>
         <value lang="en-us">before lunch</value>
         <value lang="nl-nl">voor de lunch</value>
+        <value lang="fr-fr">avant le déjeuner</value>
     </translation>
     <translation key="eventtiming-ACV">
         <comment>EventTiming code ACV</comment>
         <value lang="en-us">before dinner</value>
         <value lang="nl-nl">voor het avondeten</value>
+        <value lang="fr-fr">avant le dîner</value>
     </translation>
     <translation key="eventtiming-PC">
         <comment>EventTiming code PC</comment>
         <value lang="en-us">after a meal</value>
         <value lang="nl-nl">na de maaltijd</value>
+        <value lang="fr-fr">après le repas</value>
     </translation>
     <translation key="eventtiming-PCM">
         <comment>EventTiming code PCM</comment>
         <value lang="en-us">after breakfast</value>
         <value lang="nl-nl">na het ontbijt</value>
+        <value lang="fr-fr">après le petit-déjeuner</value>
     </translation>
     <translation key="eventtiming-PCD">
         <comment>EventTiming code PCD</comment>
         <value lang="en-us">after lunch</value>
         <value lang="nl-nl">na de lunch</value>
+        <value lang="fr-fr">après le déjeuner</value>
     </translation>
     <translation key="eventtiming-PCV">
         <comment>EventTiming code PCV</comment>
         <value lang="en-us">after dinner</value>
         <value lang="nl-nl">na het avondeten</value>
+        <value lang="fr-fr">après le dîner</value>
     </translation>
     <translation key="status-draft">
         <comment>Status code draft</comment>
         <value lang="en-us">draft</value>
         <value lang="nl-nl">concept</value>
+        <value lang="fr-fr">brouillon</value>
     </translation>
     <translation key="status-active">
         <comment>Status code active</comment>
         <value lang="en-us">active</value>
         <value lang="nl-nl">actief</value>
+        <value lang="fr-fr">actif</value>
     </translation>
     <translation key="status-suspended">
         <comment>Status code suspended</comment>
         <value lang="en-us">suspended</value>
         <value lang="nl-nl">uitgesteld</value>
+        <value lang="fr-fr">suspendu</value>
     </translation>
     <translation key="status-completed">
         <comment>Status code completed</comment>
         <value lang="en-us">completed</value>
         <value lang="nl-nl">voltooid</value>
+        <value lang="fr-fr">terminé</value>
     </translation>
     <translation key="status-entered-in-error">
         <comment>Status code entered-in-error</comment>
         <value lang="en-us">entered-in-error</value>
         <value lang="nl-nl">foutieve invoer</value>
+        <value lang="fr-fr">saisi par erreur</value>
     </translation>
     <translation key="status-cancelled">
         <comment>Status code cancelled</comment>
         <value lang="en-us">cancelled</value>
         <value lang="nl-nl">geannuleerd</value>
+        <value lang="fr-fr">annulé</value>
     </translation>
     <translation key="status-unknown">
         <comment>Status code unknown</comment>
         <value lang="en-us">unknown</value>
         <value lang="nl-nl">onbekend</value>
+        <value lang="fr-fr">inconnu</value>
     </translation>
     <translation key="status-inactive">
         <comment>Status code inactive</comment>
         <value lang="en-us">inactive</value>
         <value lang="nl-nl">inactief</value>
+        <value lang="fr-fr">inactif</value>
     </translation>
     <translation key="status-resolved">
         <comment>Status code resolved</comment>
         <value lang="en-us">resolved</value>
         <value lang="nl-nl">opgelost</value>
+        <value lang="fr-fr">résolu</value>
     </translation>
     <translation key="status-unconfirmed">
         <comment>Status code unconfirmed</comment>
         <value lang="en-us">unconfirmed</value>
         <value lang="nl-nl">niet bevestigd</value>
+        <value lang="fr-fr">non confirmé</value>
     </translation>
     <translation key="status-confirmed">
         <comment>Status code confirmed</comment>
         <value lang="en-us">confirmed</value>
         <value lang="nl-nl">bevestigd</value>
+        <value lang="fr-fr">confirmé</value>
     </translation>
     <translation key="status-refuted">
         <comment>Status code refuted</comment>
         <value lang="en-us">refuted</value>
         <value lang="nl-nl">weerlegd</value>
+        <value lang="fr-fr">réfuté</value>
     </translation>
     <translation key="status-recurrence">
         <comment>Status code recurrence</comment>
         <value lang="en-us">recurrence</value>
         <value lang="nl-nl">teruggekeerd</value>
+        <value lang="fr-fr">recurrent</value>
     </translation>
     <translation key="status-remission">
         <comment>Status code remission</comment>
         <value lang="en-us">remission</value>
         <value lang="nl-nl">remissie</value>
+        <value lang="fr-fr">rémission</value>
     </translation>
     <translation key="status-provisional">
         <comment>Status code provisional</comment>
         <value lang="en-us">provisional</value>
         <value lang="nl-nl">voorlopig</value>
+        <value lang="fr-fr">provisoire</value>
     </translation>
     <translation key="status-differential">
         <comment>Status code differential</comment>
         <value lang="en-us">differential</value>
         <value lang="nl-nl">differentiaal</value>
+        <value lang="fr-fr">differentiel</value>
     </translation>
     <translation key="status-proposed">
         <comment>Status code proposed</comment>
         <value lang="en-us">proposed</value>
         <value lang="nl-nl">voorgesteld</value>
+        <value lang="fr-fr">proposé</value>
     </translation>
     <translation key="status-pending">
         <comment>Status code pending</comment>
         <value lang="en-us">pending</value>
         <value lang="nl-nl">in behandeling</value>
+        <value lang="fr-fr">en attente</value>
     </translation>
     <translation key="status-booked">
         <comment>Status code booked</comment>
         <value lang="en-us">booked</value>
         <value lang="nl-nl">geboekt</value>
+        <value lang="fr-fr">réservé</value>
     </translation>
     <translation key="status-arrived">
         <comment>Status code arrived</comment>
         <value lang="en-us">arrived</value>
         <value lang="nl-nl">gearriveerd</value>
+        <value lang="fr-fr">arrivé</value>
     </translation>
     <translation key="status-fulfilled">
         <comment>Status code fulfilled</comment>
         <value lang="en-us">fulfilled</value>
         <value lang="nl-nl">voltooid</value>
+        <value lang="fr-fr">rempli</value>
     </translation>
     <translation key="status-noshow">
         <comment>Status code noshow</comment>
         <value lang="en-us">noshow</value>
         <value lang="nl-nl">noshow</value>
+        <value lang="fr-fr">non-présentation</value>
     </translation>
     <translation key="status-busy">
         <comment>Status code busy</comment>
         <value lang="en-us">busy</value>
         <value lang="nl-nl">bezet</value>
+        <value lang="fr-fr">occupé</value>
     </translation>
     <translation key="status-free">
         <comment>Status code free</comment>
         <value lang="en-us">free</value>
         <value lang="nl-nl">vrij</value>
+        <value lang="fr-fr">libre</value>
     </translation>
     <translation key="status-busy-unavailable">
         <comment>Status code busy-unavailable</comment>
         <value lang="en-us">busy unavailable</value>
         <value lang="nl-nl">niet beschikbaar</value>
+        <value lang="fr-fr">indisponible</value>
     </translation>
     <translation key="status-busy-tentative">
         <comment>Status code busy-tentative</comment>
         <value lang="en-us">busy tentative</value>
         <value lang="nl-nl">mogelijk bezet</value>
+        <value lang="fr-fr">peut-être occupé</value>
     </translation>
     <translation key="status-not-started">
         <comment>Status code not-started</comment>
         <value lang="en-us">not started</value>
         <value lang="nl-nl">nog niet begonnen</value>
+        <value lang="fr-fr">pas commencé</value>
     </translation>
     <translation key="status-scheduled">
         <comment>Status code scheduled</comment>
         <value lang="en-us">scheduled</value>
         <value lang="nl-nl">gepland</value>
+        <value lang="fr-fr">programmé</value>
     </translation>
     <translation key="status-in-progress">
         <comment>Status code in-progress</comment>
         <value lang="en-us">in progress</value>
         <value lang="nl-nl">is bezig</value>
+        <value lang="fr-fr">en cours</value>
     </translation>
     <translation key="status-on-hold">
         <comment>Status code on-hold</comment>
         <value lang="en-us">on hold</value>
         <value lang="nl-nl">in de wacht</value>
+        <value lang="fr-fr">en attente</value>
     </translation>
     <translation key="status-onhold">
         <comment>Status code onhold</comment>
         <value lang="en-us">on hold</value>
         <value lang="nl-nl">in de wacht</value>
+        <value lang="fr-fr">en attente</value>
     </translation>
     <translation key="status-rejected">
         <comment>Status code rejected</comment>
         <value lang="en-us">rejected</value>
         <value lang="nl-nl">geweigerd</value>
+        <value lang="fr-fr">rejeté</value>
     </translation>
     <translation key="status-intended">
         <comment>Status code intended</comment>
         <value lang="en-us">intended</value>
         <value lang="nl-nl">bedoeld</value>
+        <value lang="fr-fr">destiné</value>
     </translation>
     <translation key="status-stopped">
         <comment>Status code stopped</comment>
         <value lang="en-us">stopped</value>
         <value lang="nl-nl">gestopt</value>
+        <value lang="fr-fr">arrêté</value>
     </translation>
     <translation key="status-finished">
         <comment>Status code finished</comment>
         <value lang="en-us">finished</value>
         <value lang="nl-nl">voltooid</value>
+        <value lang="fr-fr">fini</value>
     </translation>
     <translation key="status-planned">
         <comment>Status code planned</comment>
         <value lang="en-us">planned</value>
         <value lang="nl-nl">gepland</value>
+        <value lang="fr-fr">prévu</value>
     </translation>
     <translation key="status-available">
         <comment>Status code available</comment>
         <value lang="en-us">available</value>
         <value lang="nl-nl">beschikbaar</value>
+        <value lang="fr-fr">disponible</value>
     </translation>
     <translation key="status-unavailable">
         <comment>Status code unavailable</comment>
         <value lang="en-us">unavailable</value>
         <value lang="nl-nl">niet beschikbaar</value>
+        <value lang="fr-fr">indisponible</value>
     </translation>
     <translation key="status-unsatisfactory">
         <comment>Status code unsatisfactory</comment>
         <value lang="en-us">unsatisfactory</value>
         <value lang="nl-nl">onvoldoende</value>
+        <value lang="fr-fr">insatisfaisant</value>
     </translation>
     <translation key="status-final">
         <comment>Status code final</comment>
         <value lang="en-us">final</value>
         <value lang="nl-nl">definitief</value>
+        <value lang="fr-fr">final</value>
     </translation>
     <translation key="status-aborted">
         <comment>Status code aborted</comment>
         <value lang="en-us">aborted</value>
         <value lang="nl-nl">afgebroken</value>
+        <value lang="fr-fr">avorté</value>
     </translation>
     <translation key="status-preparation">
         <comment>Status code preparation</comment>
         <value lang="en-us">preparation</value>
         <value lang="nl-nl">in voorbereiding</value>
+        <value lang="fr-fr">en préparation</value>
     </translation>
     <translation key="status-amended">
         <comment>Status code amended</comment>
         <value lang="en-us">amended</value>
         <value lang="nl-nl">aangevuld</value>
+        <value lang="fr-fr">modifié</value>
     </translation>
     <translation key="status-corrected">
         <comment>Status code corrected</comment>
         <value lang="en-us">corrected</value>
         <value lang="nl-nl">gecorrigeerd</value>
+        <value lang="fr-fr">corrigé</value>
     </translation>
     <translation key="status-current">
         <comment>Status code current</comment>
         <value lang="en-us">current</value>
         <value lang="nl-nl">actueel</value>
+        <value lang="fr-fr">actuel</value>
     </translation>
     <translation key="status-registered">
         <comment>Status code registered</comment>
         <value lang="en-us">registered</value>
         <value lang="nl-nl">geregistreerd</value>
+        <value lang="fr-fr">inscrit</value>
     </translation>
     <translation key="status-preliminary">
         <comment>Status code preliminary</comment>
         <value lang="en-us">preliminary</value>
         <value lang="nl-nl">voorlopig</value>
+        <value lang="fr-fr">préliminaire</value>
     </translation>
     <translation key="status-retired">
         <comment>Status code retired</comment>
         <value lang="en-us">retired</value>
         <value lang="nl-nl">niet meer in gebruik</value>
+        <value lang="fr-fr">retiré</value>
     </translation>
     <translation key="status-requested">
         <comment>Status code requested</comment>
         <value lang="en-us">requested</value>
         <value lang="nl-nl">aangevraagd</value>
+        <value lang="fr-fr">demandé</value>
     </translation>
     <translation key="status-accepted">
         <comment>Status code accepted</comment>
         <value lang="en-us">accepted</value>
         <value lang="nl-nl">geaccepteerd</value>
+        <value lang="fr-fr">accepté</value>
     </translation>
     <translation key="status-on-target">
         <comment>Status code on-target</comment>
         <value lang="en-us">on target</value>
         <value lang="nl-nl">op schema</value>
+        <value lang="fr-fr">dans les délais</value>
     </translation>
     <translation key="status-ahead-of-target">
         <comment>Status code ahead-of-target</comment>
         <value lang="en-us">ahead of target</value>
         <value lang="nl-nl">voor op schema</value>
+        <value lang="fr-fr">en avance</value>
     </translation>
     <translation key="status-behind-target">
         <comment>Status code behind-target</comment>
         <value lang="en-us">behind target</value>
         <value lang="nl-nl">achter op schema</value>
+        <value lang="fr-fr">en retard</value>
     </translation>
     <translation key="status-sustaining">
         <comment>Status code sustaining</comment>
         <value lang="en-us">sustaining</value>
         <value lang="nl-nl">doel gehaald, actie blijft nodig</value>
+        <value lang="fr-fr">objectif atteint, action encore nécessaire</value>
     </translation>
     <translation key="status-achieved">
         <comment>Status code achieved</comment>
         <value lang="en-us">achieved</value>
         <value lang="nl-nl">doel gehaald</value>
+        <value lang="fr-fr">objectif atteint</value>
     </translation>
     <translation key="status-failed">
         <comment>Status code failed</comment>
         <value lang="en-us">failed</value>
         <value lang="nl-nl">mislukt</value>
+        <value lang="fr-fr">échoué</value>
     </translation>
     <translation key="status-ready">
         <comment>Status code ready</comment>
         <value lang="en-us">ready</value>
         <value lang="nl-nl">gereed</value>
+        <value lang="fr-fr">prêt</value>
     </translation>
     <translation key="status-waitlist">
         <comment>Status code waitlist</comment>
         <value lang="en-us">waitlist</value>
         <value lang="nl-nl">wachtlijst</value>
+        <value lang="fr-fr">liste d'attente</value>
     </translation>
     <translation key="intent-proposal">
         <comment>Status code proposal</comment>
         <value lang="en-us">proposal</value>
         <value lang="nl-nl">voorstel</value>
+        <value lang="fr-fr">proposition</value>
     </translation>
     <translation key="intent-plan">
         <comment>Status code plan</comment>
         <value lang="en-us">plan</value>
+        <value lang="fr-fr">plan</value>
     </translation>
     <translation key="intent-order">
         <comment>Status code order</comment>
         <value lang="en-us">order</value>
         <value lang="nl-nl">aanvraag</value>
+        <value lang="fr-fr">demmande</value>
     </translation>
     <translation key="intent-original-order">
         <comment>Status code original-order</comment>
         <value lang="en-us">original order</value>
         <value lang="nl-nl">oorspronkelijke aanvraag</value>
+        <value lang="fr-fr">demande originale</value>
     </translation>
     <translation key="intent-reflex-order">
         <comment>Status code reflex-order</comment>
         <value lang="en-us">reflex order</value>
         <value lang="nl-nl">aanvullende aanvraag</value>
+        <value lang="fr-fr">requête additionnelle</value>
     </translation>
     <translation key="intent-filler-order">
         <comment>Status code filler-order</comment>
         <value lang="en-us">filler order</value>
         <value lang="nl-nl">aanvraag (uitvoerende)</value>
+        <value lang="fr-fr">demande</value>
     </translation>
     <translation key="intent-instance-order">
         <comment>Status code instance-order</comment>
         <value lang="en-us">instance order</value>
         <value lang="nl-nl">deelaanvraag</value>
+        <value lang="fr-fr">demande partielle</value>
     </translation>
     <translation key="intent-option">
         <comment>Status code option</comment>
         <value lang="en-us">option</value>
         <value lang="nl-nl">optie</value>
+        <value lang="fr-fr">option</value>
     </translation>
     <translation key="listmode-working">
         <comment>List mode code working</comment>
         <value lang="en-us">Working List</value>
         <value lang="nl-nl">Werklijst</value>
+        <value lang="fr-fr">Liste de travail</value>
     </translation>
     <translation key="listmode-snapshot">
         <comment>List mode code snapshot</comment>
         <value lang="en-us">Snapshot List</value>
         <value lang="nl-nl">Snapshot-kopie</value>
+        <value lang="fr-fr">Liste d'instantanés</value>
     </translation>
     <translation key="listmode-changes">
         <comment>List mode code changes</comment>
         <value lang="en-us">Changes List</value>
         <value lang="nl-nl">Lijst van wijzigingen</value>
+        <value lang="fr-fr">Liste des modifications</value>
     </translation>
     <translation key="requestpriority-routine">
         <comment>Request priority code routine</comment>
         <value lang="en-us">routine</value>
+        <value lang="fr-fr">normal</value>
     </translation>
     <translation key="requestpriority-urgent">
         <comment>Request priority code urgent</comment>
         <value lang="en-us">urgent</value>
+        <value lang="fr-fr">urgent</value>
     </translation>
     <translation key="requestpriority-asap">
         <comment>Request priority code asap</comment>
         <value lang="en-us">asap</value>
+        <value lang="fr-fr">dès que possible</value>
     </translation>
     <translation key="requestpriority-stat">
         <comment>Request priority code stat</comment>
         <value lang="en-us">stat</value>
+        <value lang="fr-fr">très urgent</value>
     </translation>
     <translation key="Activity">
         <comment>Activity</comment>
         <value lang="en-us">Activity</value>
         <value lang="nl-nl">Activiteit</value>
+        <value lang="fr-fr">Activité</value>
     </translation>
     <translation key="Consenting Party">
         <comment>Consenting Party</comment>
         <value lang="en-us">Consenting Party</value>
         <value lang="nl-nl">Toestemminggevende partij</value>
+        <value lang="fr-fr">Partie consentante</value>
     </translation>
     <translation key="Method">
         <comment>Method</comment>
         <value lang="en-us">Method</value>
         <value lang="nl-nl">Methode</value>
+        <value lang="fr-fr">Méthode</value>
     </translation>
     <translation key="Dose Status">
         <comment>Dose Status</comment>
         <value lang="en-us">Dose Status</value>
         <value lang="nl-nl">Doseerstatus</value>
+        <value lang="fr-fr">Posologie</value>
     </translation>
     <translation key="Dose Status Reason">
         <comment>Dose Status Reason</comment>
         <value lang="en-us">Dose Status Reason</value>
         <value lang="nl-nl">Reden doseerstatus</value>
+        <value lang="fr-fr">Raison de la posologie</value>
     </translation>
     <translation key="Sequence">
         <comment>Sequence</comment>
         <value lang="en-us">Sequence</value>
         <value lang="nl-nl">Volgnummer</value>
+        <value lang="fr-fr">Séquence</value>
     </translation>
     <translation key="Practitioner">
         <comment>Practitioner</comment>
         <value lang="en-us">Practitioner</value>
         <value lang="nl-nl">Zorgverlener</value>
+        <value lang="fr-fr">Praticien</value>
     </translation>
     <translation key="PractitionerRole">
         <comment>PractitionerRole</comment>
         <value lang="en-us">Practitioner Role</value>
         <value lang="nl-nl">Zorgverlenerrol</value>
+        <value lang="fr-fr">Rôle du praticien</value>
     </translation>
     <translation key="Task">
         <comment>Task</comment>
         <value lang="en-us">Task</value>
         <value lang="nl-nl">Taak</value>
+        <value lang="fr-fr">Tâche</value>
     </translation>
     <translation key="Ordered By">
         <comment>Ordered By</comment>
         <value lang="en-us">Ordered By</value>
         <value lang="nl-nl">Aangevraagd door</value>
+        <value lang="fr-fr">Demandé par</value>
     </translation>
     <translation key="Preferred Pharmacy">
         <comment>Preferred Pharmacy</comment>
         <value lang="en-us">Preferred Pharmacy</value>
         <value lang="nl-nl">Voorkeursapotheek</value>
+        <value lang="fr-fr">Pharmacie préférée</value>
     </translation>
     <translation key="Operator">
         <comment>Operator</comment>
         <value lang="en-us">Operator</value>
+        <value lang="fr-fr">Opérateur</value>
     </translation>
     <translation key="Related">
         <comment>As in Related Observation</comment>
         <value lang="en-us">Related</value>
         <value lang="nl-nl">Gerelateerd</value>
+        <value lang="fr-fr">En rapport</value>
     </translation>
     <translation key="Based On">
         <comment>As in Based On</comment>
         <value lang="en-us">Based On</value>
         <value lang="nl-nl">Gebaseerd op</value>
+        <value lang="fr-fr">Basé sur</value>
     </translation>
     <translation key="Derived From">
         <comment>As in Derived From</comment>
         <value lang="en-us">Derived From</value>
         <value lang="nl-nl">Afgeleid van</value>
+        <value lang="fr-fr">Dérivé de</value>
     </translation>
     <translation key="Business Status">
         <comment>As in Business Status</comment>
         <value lang="en-us">Business Status</value>
         <value lang="nl-nl">Processtatus</value>
+        <value lang="fr-fr">Avancement</value>
     </translation>
     <translation key="Capacity">
         <comment>As in Capacity</comment>
         <value lang="en-us">Capacity</value>
         <value lang="nl-nl">Capaciteit</value>
+        <value lang="fr-fr">Capacité</value>
     </translation>
     <translation key="Group ID">
         <comment>As in Group ID</comment>
         <value lang="en-us">Group ID</value>
         <value lang="nl-nl">Id groep</value>
+        <value lang="fr-fr">Id. du groupe</value>
     </translation>
     <translation key="Effective Time">
         <comment>Effective Time</comment>
         <value lang="en-us">Effective Time</value>
         <value lang="nl-nl">Bepalingdatum/tijd</value>
+        <value lang="fr-fr">Date/Heure</value>
     </translation>
     <translation key="Enteral Formula">
         <comment>Enteral Formula</comment>
         <value lang="en-us">Enteral Formula</value>
         <value lang="nl-nl">Sondeformule</value>
+        <value lang="fr-fr">Sonde entérale</value>
     </translation>
     <translation key="Enteral Nutrition">
         <comment>Enteral Nutrition</comment>
         <value lang="en-us">Enteral Nutrition</value>
         <value lang="nl-nl">Sondevoeding</value>
+        <value lang="fr-fr">nutrition entérale</value>
     </translation>
     <translation key="Feeding Tube Length">
         <comment>Feeding Tube Length</comment>
         <value lang="en-us">Feeding Tube Length</value>
         <value lang="nl-nl">Sondelengte</value>
+        <value lang="fr-fr">Longueur du tube d'alimentation</value>
     </translation>
     <translation key="Administered">
         <comment>Administered</comment>
         <value lang="en-us">Administered</value>
         <value lang="nl-nl">Toegediend</value>
+        <value lang="fr-fr">Administré</value>
     </translation>
     <translation key="Container">
         <comment>Container</comment>
         <value lang="en-us">Container</value>
+        <value lang="fr-fr">Récipient</value>
     </translation>
     <translation key="Endpoint">
         <comment>Endpoint</comment>
         <value lang="en-us">Endpoint</value>
+        <value lang="fr-fr">point final</value>
     </translation>
     <translation key="Consent Period">
         <comment>Period that this consent applies</comment>
         <value lang="en-us">Consent Period</value>
         <value lang="nl-nl">Geldigheidsperiode</value>
+        <value lang="fr-fr">Période de consentement</value>
     </translation>
     <translation key="Repetitions">
         <comment>Repetitions</comment>
         <value lang="en-us">Repetitions</value>
         <value lang="nl-nl">Herhalingen</value>
+        <value lang="fr-fr">Répétitions</value>
     </translation>
     <translation key="Requested Performer">
         <comment>Requested Performer</comment>
         <value lang="en-us">Requested Performer</value>
         <value lang="nl-nl">Beoogde uitvoerende</value>
+        <value lang="fr-fr">Exécutant demandé</value>
     </translation>
     <translation key="Requested Performer Type">
         <comment>Requested Performer Type</comment>
         <value lang="en-us">Requested Performer Type</value>
         <value lang="nl-nl">Beoogd type uitvoerende</value>
+        <value lang="fr-fr">Type d'exécutant demandé</value>
     </translation>
     <translation key="Requester">
         <comment>Requester</comment>
         <value lang="en-us">Requester</value>
         <value lang="nl-nl">Aanvrager</value>
+        <value lang="fr-fr">Demandeur</value>
     </translation>
     <translation key="Relevant History">
         <comment>Relevant History</comment>
         <value lang="en-us">Relevant History</value>
         <value lang="nl-nl">Relevante historie</value>
+        <value lang="fr-fr">Antécédents pertinents</value>
     </translation>
     <translation key="Input">
         <comment>Input</comment>
         <value lang="en-us">Input</value>
+        <value lang="fr-fr">Entrée</value>
     </translation>
     <translation key="Output">
         <comment>Output</comment>
         <value lang="en-us">Output</value>
+        <value lang="fr-fr">Sortie</value>
     </translation>
     <translation key="Responsible Owner">
         <comment>Responsible Owner</comment>
         <value lang="en-us">Responsible Owner</value>
         <value lang="nl-nl">Verantwoordelijk eigenaar</value>
+        <value lang="fr-fr">Propriétaire responsable</value>
     </translation>
     <translation key="Instruction">
         <comment>Instruction</comment>
         <value lang="en-us">Instruction</value>
         <value lang="nl-nl">Instructie</value>
+        <value lang="fr-fr">Instruction</value>
     </translation>
     <translation key="Interpretation">
         <comment>Interpretation</comment>
         <value lang="en-us">Interpretation</value>
         <value lang="nl-nl">Interpretatie</value>
+        <value lang="fr-fr">Interpretation</value>
     </translation>
     <translation key="on behalf of">
         <comment>Practitioner(Role) on behalf of Organization</comment>
         <value lang="en-us">on behalf of</value>
         <value lang="nl-nl">uit naam van</value>
+        <value lang="fr-fr">au nom de</value>
     </translation>
     <translation key="Healthcare Service">
         <comment>Healthcare Service</comment>
         <value lang="en-us">Healthcare Service</value>
         <value lang="nl-nl">Type zorgservice</value>
+        <value lang="fr-fr">Service de santé</value>
     </translation>
     <translation key="Reported By Performer">
         <comment>Reported By Performer</comment>
         <value lang="en-us">Reported By Performer</value>
         <value lang="nl-nl">Gemeld door uitvoerende</value>
+        <value lang="fr-fr">Rapporté par l'exécutant</value>
     </translation>
     <translation key="Reference Range">
         <comment>Reference Range</comment>
         <value lang="en-us">Reference Range</value>
         <value lang="nl-nl">Referentiewaarden</value>
+        <value lang="fr-fr">Intervalle de référence</value>
     </translation>
     <translation key="Immunization">
         <comment>Immunization</comment>
         <value lang="en-us">Immunization</value>
         <value lang="nl-nl">Vaccinatie</value>
+        <value lang="fr-fr">Vaccination</value>
     </translation>
     <translation key="ImmunizationRecommendation">
         <comment>ImmunizationRecommendation</comment>
         <value lang="en-us">ImmunizationRecommendation</value>
         <value lang="nl-nl">Vaccinatieschema</value>
+        <value lang="fr-fr">Vaccinations recommandées</value>
     </translation>
     <translation key="Supporting Immunization">
         <comment>Supporting Immunization</comment>
         <value lang="en-us">Supporting Immunization</value>
         <value lang="nl-nl">Eerdere vaccinatie</value>
+        <value lang="fr-fr">Vaccination antérieure</value>
     </translation>
     <translation key="Supporting Information">
         <comment>Supporting Information</comment>
         <value lang="en-us">Supporting Information</value>
         <value lang="nl-nl">Ondersteunende informatie</value>
+        <value lang="fr-fr">Renseignements à l'appui</value>
     </translation>
     <translation key="Occurrence">
         <comment>Occurrence</comment>
         <value lang="en-us">Occurrence</value>
         <value lang="nl-nl">Voorkomen</value>
+        <value lang="fr-fr">Occurrence</value>
     </translation>
     <translation key="Media Collected DateTime">
         <comment>Media Collected DateTime</comment>
         <value lang="en-us">Media Collected DateTime</value>
         <value lang="nl-nl">Media verzameldatum/tijd</value>
+        <value lang="fr-fr">Date/heure de la collecte des médias</value>
     </translation>
     <translation key="Media Collected Period">
         <comment>Media Collected Period</comment>
         <value lang="en-us">Media Collected Period</value>
         <value lang="nl-nl">Media verzamelperiode</value>
+        <value lang="fr-fr">Période de la collecte des médias</value>
     </translation>
     <translation key="Mode">
         <comment>Mode</comment>
         <value lang="en-us">Mode</value>
         <value lang="nl-nl">Wijze</value>
+        <value lang="fr-fr">Mode</value>
     </translation>
     <translation key="Permission">
         <comment>Permission</comment>
         <value lang="en-us">Permission</value>
         <value lang="nl-nl">Toestemming</value>
+        <value lang="fr-fr">Autorisation</value>
     </translation>
     <translation key="Start">
         <comment>Start</comment>
         <value lang="en-us">Start</value>
+        <value lang="fr-fr">Début</value>
     </translation>
     <translation key="Available">
         <comment>Available</comment>
         <value lang="en-us">Available</value>
         <value lang="nl-nl">Beschikbaar</value>
+        <value lang="fr-fr">Disponible</value>
     </translation>
     <translation key="Not Available">
         <comment>Not Available</comment>
         <value lang="en-us">Not Available</value>
         <value lang="nl-nl">Niet beschikbaar</value>
+        <value lang="fr-fr">Indisponible</value>
     </translation>
     <translation key="Availability Exceptions">
         <comment>Availability Exceptions</comment>
         <value lang="en-us">Availability Exceptions</value>
         <value lang="nl-nl">Beschikbaarheidsuitzonderingen</value>
+        <value lang="fr-fr">Exceptions de disponibilité</value>
     </translation>
     <translation key="Living at home">
         <comment>Living at home</comment>
         <value lang="en-us">Living at home</value>
         <value lang="nl-nl">Inwonend</value>
+        <value lang="fr-fr">à la maison</value>
     </translation>
     <translation key="Living away from home">
         <comment>Living away from home</comment>
         <value lang="en-us">Living away from home</value>
         <value lang="nl-nl">Uitwonend</value>
+        <value lang="fr-fr">loin de chez soi</value>
     </translation>
     <translation key="Living at home unknown">
         <comment>Living at home status unknown</comment>
         <value lang="en-us">Living at home unknown</value>
         <value lang="nl-nl">Inwonend onbekend</value>
+        <value lang="fr-fr">inconnu</value>
     </translation>
     <translation key="All Day">
         <comment>All Day</comment>
         <value lang="en-us">All Day</value>
         <value lang="nl-nl">Hele dag</value>
+        <value lang="fr-fr">Toute la journée</value>
     </translation>
     <translation key="Amount">
         <comment>Amount</comment>
         <value lang="en-us">Amount</value>
         <value lang="nl-nl">Hoeveelheid</value>
+        <value lang="fr-fr">Quantité</value>
     </translation>
     <translation key="Legally Capable">
         <comment>Legally Capable</comment>
         <value lang="en-us">Legally Capable</value>
         <value lang="nl-nl">Wilsbekwaam</value>
+        <value lang="fr-fr">Quantité</value>
     </translation>
     <translation key="Legal Status">
         <comment>As in: Legal Status</comment>
         <value lang="en-us">Legal Status</value>
         <value lang="nl-nl">Juridische status</value>
+        <value lang="fr-fr">Légalement capable</value>
     </translation>
     <translation key="Due">
         <comment>Due</comment>
         <value lang="en-us">Due</value>
         <value lang="nl-nl">Streefdatum</value>
+        <value lang="fr-fr">Exigible</value>
     </translation>
     <translation key="Target">
         <comment>Target</comment>
         <value lang="en-us">Target</value>
         <value lang="nl-nl">Doel</value>
+        <value lang="fr-fr">But</value>
     </translation>
     <translation key="CareTeam">
         <comment>CareTeam</comment>
         <value lang="en-us">Care Team</value>
         <value lang="nl-nl">Zorgteam</value>
+        <value lang="fr-fr">Equipe de soins</value>
     </translation>
     <translation key="Performed">
         <comment>Performed</comment>
         <value lang="en-us">Performed</value>
         <value lang="nl-nl">Uitgevoerd</value>
+        <value lang="fr-fr">Réalisé</value>
     </translation>
     <translation key="General Practitioner">
         <comment>General Practitioner</comment>
         <value lang="en-us">General Practitioner</value>
         <value lang="nl-nl">Huisarts</value>
+        <value lang="fr-fr">Médecin généraliste</value>
     </translation>
     <translation key="Care Manager">
         <comment>Care Manager</comment>
         <value lang="en-us">Care Manager</value>
         <value lang="nl-nl">Zorgmanager</value>
+        <value lang="fr-fr">Gestionnaire de soins</value>
     </translation>
     <translation key="Managing Organization">
         <comment>Managing Organization</comment>
         <value lang="en-us">Managing Organization</value>
         <value lang="nl-nl">Verantwoordelijke organisatie</value>
+        <value lang="fr-fr">Organisation gestionnaire </value>
     </translation>
     <translation key="Category">
         <comment>Category</comment>
         <value lang="en-us">Category</value>
         <value lang="nl-nl">Categorie</value>
+        <value lang="fr-fr">Catégorie</value>
     </translation>
     <translation key="Deleted">
         <comment>Deleted</comment>
         <value lang="en-us">Deleted</value>
         <value lang="nl-nl">Verwijderd</value>
+        <value lang="fr-fr">Supprimé</value>
     </translation>
     <translation key="Data">
         <comment>Data</comment>
         <value lang="en-us">Data</value>
         <value lang="nl-nl">Gegevens</value>
+        <value lang="fr-fr">Donnée</value>
     </translation>
     <translation key="Data Period">
         <comment>Data Period</comment>
         <value lang="en-us">Data Period</value>
         <value lang="nl-nl">Gegevensperiode</value>
+        <value lang="fr-fr">Période de données</value>
     </translation>
     <translation key="Do NOT do">
         <comment>Do NOT do</comment>
         <value lang="en-us">Do NOT do</value>
         <value lang="nl-nl">NIET doen</value>
+        <value lang="fr-fr">Ne pas faire</value>
     </translation>
     <translation key="Dose Number">
         <comment>Dose Number</comment>
         <value lang="en-us">Dose Number</value>
         <value lang="nl-nl">Doseeraantal</value>
+        <value lang="fr-fr">Numéro de dose</value>
     </translation>
     <translation key="Do Not Perform">
         <comment>Do Not Perform</comment>
         <value lang="en-us">Do Not Perform</value>
         <value lang="nl-nl">Niet uitvoeren</value>
+        <value lang="fr-fr">Ne pas exécuter</value>
     </translation>
     <translation key="Context">
         <comment>Context</comment>
         <value lang="en-us">Context</value>
+        <value lang="fr-fr">Contexte</value>
     </translation>
     <translation key="Details">
         <comment>Details</comment>
         <value lang="en-us">Details</value>
+        <value lang="fr-fr">Détail</value>
     </translation>
     <translation key="Definition">
         <comment>Definition</comment>
         <value lang="en-us">Definition</value>
         <value lang="nl-nl">Definitie</value>
+        <value lang="fr-fr">Définition</value>
     </translation>
     <translation key="Detail Definition">
         <comment>Detail Definition</comment>
         <value lang="en-us">Detail Definition</value>
         <value lang="nl-nl">Detaildefinitie</value>
+        <value lang="fr-fr">Définition détaillée</value>
     </translation>
     <translation key="Medical Device">
         <comment>Medical Device</comment>
         <value lang="en-us">Medical Device</value>
         <value lang="nl-nl">Medisch hulpmiddel</value>
+        <value lang="fr-fr">Dispositif médical</value>
     </translation>
     <translation key="Goal">
         <comment>Goal</comment>
         <value lang="en-us">Goal</value>
         <value lang="nl-nl">Doel</value>
+        <value lang="fr-fr">But</value>
     </translation>
     <translation key="Linked To">
         <comment>As in: RelatedPerson Linked To Target</comment>
         <value lang="en-us">Linked To</value>
         <value lang="nl-nl">Gekoppeld aan</value>
+        <value lang="fr-fr">Lié à</value>
     </translation>
     <translation key="Location">
         <comment>Location</comment>
         <value lang="en-us">Location</value>
         <value lang="nl-nl">Locatie</value>
+        <value lang="fr-fr">Lieu</value>
     </translation>
     <translation key="Appointment">
         <comment>Appointment</comment>
         <value lang="en-us">Appointment</value>
         <value lang="nl-nl">Afspraak</value>
+        <value lang="fr-fr">Rendez-vous</value>
     </translation>
     <translation key="Binary">
         <comment>Binary</comment>
         <value lang="en-us">Binary</value>
         <value lang="nl-nl">Binair bestand</value>
+        <value lang="fr-fr">Binaire</value>
     </translation>
     <translation key="Slot">
         <comment>Slot in an agenda</comment>
         <value lang="en-us">Slot</value>
         <value lang="nl-nl">Slot</value>
+        <value lang="fr-fr">Créneau</value>
     </translation>
     <translation key="Specialty">
         <comment>Specialty</comment>
         <value lang="en-us">Specialty</value>
         <value lang="nl-nl">Specialisme</value>
+        <value lang="fr-fr">Spécialité</value>
     </translation>
     <translation key="Service Type">
         <comment>Service Type</comment>
         <value lang="en-us">Service Type</value>
         <value lang="nl-nl">Servicetype</value>
+        <value lang="fr-fr">Type de service</value>
     </translation>
     <translation key="Problem">
         <comment>Problem</comment>
         <value lang="en-us">Problem</value>
         <value lang="nl-nl">Probleem</value>
+        <value lang="fr-fr">Problème</value>
     </translation>
     <translation key="Note">
         <comment>Note as in a note for some topic</comment>
         <value lang="en-us">Note</value>
         <value lang="nl-nl">Notitie</value>
+        <value lang="fr-fr">Note</value>
     </translation>
     <translation key="Outcome">
         <comment>Outcome</comment>
         <value lang="en-us">Outcome</value>
         <value lang="nl-nl">Resultaat</value>
+        <value lang="fr-fr">Résultat</value>
     </translation>
     <translation key="Scheduled">
         <comment>Scheduled</comment>
         <value lang="en-us">Scheduled</value>
         <value lang="nl-nl">Schema</value>
+        <value lang="fr-fr">Programmé</value>
     </translation>
     <translation key="Schedule">
         <comment>Schedule</comment>
         <value lang="en-us">Schedule</value>
         <value lang="nl-nl">Schema</value>
+        <value lang="fr-fr">Calendrier</value>
     </translation>
     <translation key="Device">
         <comment>Device</comment>
         <value lang="en-us">Device</value>
         <value lang="nl-nl">Apparaat/Systeem</value>
+        <value lang="fr-fr">Dispositif</value>
     </translation>
     <translation key="Organization">
         <comment>Organization</comment>
         <value lang="en-us">Organization</value>
         <value lang="nl-nl">Organisatie</value>
+        <value lang="fr-fr">Organisation </value>
     </translation>
     <translation key="Nationality">
         <comment>Nationality</comment>
         <value lang="en-us">Nationality</value>
         <value lang="nl-nl">Nationaliteit</value>
+        <value lang="fr-fr">Nationalité</value>
     </translation>
     <translation key="Description">
         <comment>Description</comment>
         <value lang="en-us">Description</value>
         <value lang="nl-nl">Omschrijving</value>
+        <value lang="fr-fr">Description</value>
     </translation>
     <translation key="Patient Instructions">
         <comment>Patient Instructions</comment>
         <value lang="en-us">Patient Instructions</value>
         <value lang="nl-nl">Patiëntinstructies</value>
+        <value lang="fr-fr">Consignes au patient</value>
     </translation>
     <translation key="Timing">
         <comment>Timing</comment>
         <value lang="en-us">Timing</value>
         <value lang="nl-nl">Timing</value>
+        <value lang="fr-fr">Horaire</value>
     </translation>
     <translation key="Lumen or Line">
         <comment>Lumen or Line</comment>
         <value lang="en-us">Lumen or Line</value>
         <value lang="nl-nl">Lumen of lijn</value>
+        <value lang="fr-fr">Lumen ou ligne</value>
     </translation>
     <translation key="Line Status">
         <comment>Line Status</comment>
         <value lang="en-us">Line Status</value>
         <value lang="nl-nl">Lijnstatus</value>
+        <value lang="fr-fr">État de la ligne</value>
     </translation>
     <translation key="Lumen Location">
         <comment>Lumen Location</comment>
         <value lang="en-us">Lumen Location</value>
         <value lang="nl-nl">Lumenlocatie</value>
+        <value lang="fr-fr">Emplacement de la lumière</value>
     </translation>
     <translation key="Lock Fluid">
         <comment>Lock Fluid</comment>
         <value lang="en-us">Lock Fluid</value>
         <value lang="nl-nl">Slotvloeistof</value>
+        <value lang="fr-fr">Liquide de blocage</value>
     </translation>
     <translation key="Administering System">
         <comment>Administering System</comment>
         <value lang="en-us">Administering System</value>
         <value lang="nl-nl">Toedieningssysteem</value>
+        <value lang="fr-fr">Système d'administration</value>
     </translation>
     <translation key="Infusion Fluid">
         <comment>Infusion Fluid</comment>
         <value lang="en-us">Infusion Fluid</value>
         <value lang="nl-nl">Infuusvloeistof</value>
+        <value lang="fr-fr">Liquide de perfusion</value>
     </translation>
     <translation key="Peripheral">
         <comment>Peripheral</comment>
         <value lang="en-us">Peripheral</value>
         <value lang="nl-nl">Randapparaat</value>
+        <value lang="fr-fr">Périphérique</value>
     </translation>
     <translation key="Alias">
         <comment>Alias</comment>
         <value lang="en-us">Alias</value>
+        <value lang="fr-fr">Alias</value>
     </translation>
     <translation key="Online Editable">
         <comment>Online Editable</comment>
         <value lang="en-us">Online Editable</value>
         <value lang="nl-nl">Online wijzigbaar</value>
+        <value lang="fr-fr">Modifiable en ligne</value>
     </translation>
     <translation key="until">
         <comment>until</comment>
         <value lang="en-us">until</value>
         <value lang="nl-nl">tot</value>
+        <value lang="fr-fr">jusqu'à</value>
     </translation>
     <translation key="MedicationAdministration">
         <comment>MedicationAdministration</comment>
         <value lang="en-us">MedicationAdministration</value>
         <value lang="nl-nl">Medicatietoediening</value>
+        <value lang="fr-fr">Administration des médicaments</value>
     </translation>
     <translation key="Medication Agreement">
         <comment>Medication Agreement</comment>
         <value lang="en-us">Medication Agreement</value>
         <value lang="nl-nl">Medicatieafspraak</value>
+        <value lang="fr-fr">Accord sur les médicaments</value>
     </translation>
     <translation key="Dispense Request">
         <comment>Dispense Request</comment>
         <value lang="en-us">Dispense Request</value>
         <value lang="nl-nl">Toedieningsverzoek</value>
+        <value lang="fr-fr">Demande de dispensation</value>
     </translation>
     <translation key="Administration Agreement">
         <comment>Administration Agreement</comment>
         <value lang="en-us">Administration Agreement</value>
         <value lang="nl-nl">Toedieningsafspraak</value>
+        <value lang="fr-fr">Accord d'administration</value>
     </translation>
     <translation key="Medication Dispense">
         <comment>Medication Dispense</comment>
         <value lang="en-us">Medication Dispense</value>
         <value lang="nl-nl">Medicatieverstrekking</value>
+        <value lang="fr-fr">Dispensation de médicaments</value>
     </translation>
     <translation key="Medication Use">
         <comment>Medication Use</comment>
         <value lang="en-us">Medication Use</value>
         <value lang="nl-nl">Medicatiegebruik</value>
+        <value lang="fr-fr">Utilisation de médicaments</value>
     </translation>
     <translation key="DiagnosticReport">
         <comment>DiagnosticReport</comment>
         <value lang="en-us">DiagnosticReport</value>
         <value lang="nl-nl">Diagnostisch verslag</value>
+        <value lang="fr-fr">Compte-rendu diagnostique</value>
     </translation>
     <translation key="List">
         <comment>List</comment>
         <value lang="en-us">List</value>
         <value lang="nl-nl">Lijst</value>
+        <value lang="fr-fr">Liste</value>
     </translation>
     <translation key="Used Item">
         <comment>Used Item</comment>
         <value lang="en-us">Used Item</value>
         <value lang="nl-nl">Gebruikt item</value>
+        <value lang="fr-fr">Article d'occasion</value>
     </translation>
     <translation key="Participants">
         <comment>Participants</comment>
         <value lang="en-us">Participants</value>
         <value lang="nl-nl">Deelnemers</value>
+        <value lang="fr-fr">Participants</value>
     </translation>
     <translation key="Onset">
         <comment>E.g. When allergy or intolerance was identified</comment>
         <value lang="en-us">Onset</value>
         <value lang="nl-nl">Eerste symptomen</value>
+        <value lang="fr-fr">Date de début</value>
     </translation>
     <translation key="Abatement">
         <comment>E.g. If/when in resolution/remission</comment>
         <value lang="en-us">Abatement</value>
         <value lang="nl-nl">Oplossing/remissie</value>
+        <value lang="fr-fr">Amélioration/Rémission</value>
     </translation>
     <translation key="Last Occurrence">
         <comment>E.g. Date(/time) of last known occurrence of a reaction</comment>
         <value lang="en-us">Last Occurrence</value>
         <value lang="nl-nl">Meest recente voorkomen</value>
+        <value lang="fr-fr">Date de fin</value>
     </translation>
     <translation key="Modified Date">
         <comment>E.g. Date(/time) of last update</comment>
         <value lang="en-us">Modified Date</value>
         <value lang="nl-nl">Wijzigingsdatum</value>
+        <value lang="fr-fr">Date de dernière mise à jour</value>
     </translation>
     <translation key="Reaction">
         <comment>Reaction to an Allergy</comment>
         <value lang="en-us">Reaction</value>
         <value lang="nl-nl">Reactie</value>
+        <value lang="fr-fr">Réaction</value>
     </translation>
     <translation key="Stage">
         <comment>Condition stage</comment>
         <value lang="en-us">Stage</value>
         <value lang="nl-nl">Stadium</value>
+        <value lang="fr-fr">Stade</value>
     </translation>
     <translation key="Evidence">
         <comment>Condition evidence</comment>
         <value lang="en-us">Evidence</value>
         <value lang="nl-nl">Ondersteunend onderzoek</value>
+        <value lang="fr-fr">Preuve</value>
     </translation>
     <translation key="frequency">
         <comment>As in: frequency X times per Y</comment>
         <value lang="en-us">frequency</value>
         <value lang="nl-nl">frequentie</value>
+        <value lang="fr-fr">fréquence</value>
     </translation>
     <translation key="times">
         <comment>As in: X times per Y</comment>
         <value lang="en-us">times</value>
         <value lang="nl-nl">maal</value>
+        <value lang="fr-fr">fois</value>
     </translation>
     <translation key="of">
         <comment>As in: Relationship of Patient</comment>
         <value lang="en-us">of</value>
         <value lang="nl-nl">van</value>
+        <value lang="fr-fr">de</value>
     </translation>
     <translation key="once">
         <comment>once</comment>
         <value lang="en-us">once</value>
         <value lang="nl-nl">eenmalig</value>
+        <value lang="fr-fr">une fois</value>
     </translation>
     <translation key="max">
         <comment>max</comment>
         <value lang="en-us">max</value>
         <value lang="nl-nl">max</value>
+        <value lang="fr-fr">max</value>
     </translation>
     <translation key="frequency max">
         <comment>frequency max</comment>
         <value lang="en-us">frequency max</value>
         <value lang="nl-nl">max frequentie</value>
+        <value lang="fr-fr">Fréquence max</value>
     </translation>
     <translation key="bounds">
         <comment>bounds</comment>
         <value lang="en-us">bounds</value>
         <value lang="nl-nl">grenswaarden</value>
+        <value lang="fr-fr">bornes</value>
     </translation>
     <translation key="preferred">
         <comment>As in: preferred language</comment>
         <value lang="en-us">preferred</value>
         <value lang="nl-nl">voorkeur</value>
+        <value lang="fr-fr">préféré</value>
     </translation>
     <translation key="not preferred">
         <comment>As in: not preferred language</comment>
         <value lang="en-us">not preferred</value>
         <value lang="nl-nl">geen voorkeur</value>
+        <value lang="fr-fr">pas préféré</value>
     </translation>
     <translation key="Complication">
         <comment>As in: Complication</comment>
         <value lang="en-us">Complication</value>
         <value lang="nl-nl">Complicatie</value>
+        <value lang="fr-fr">Complication</value>
     </translation>
     <translation key="Body Site">
         <comment>As in: Body Site</comment>
         <value lang="en-us">Body Site</value>
         <value lang="nl-nl">Deel van lichaam</value>
+        <value lang="fr-fr">Localisation anatomique</value>
     </translation>
     <translation key="Usage Period">
         <comment>As in: Period device was used</comment>
         <value lang="en-us">Usage Period</value>
         <value lang="nl-nl">Gebruiksperiode</value>
+        <value lang="fr-fr">Période d'utilisation</value>
     </translation>
     <translation key="Collection">
         <comment>As in: Collection</comment>
         <value lang="en-us">Collection</value>
         <value lang="nl-nl">Inzameling</value>
+        <value lang="fr-fr">Collection</value>
     </translation>
     <translation key="Indication">
         <comment>As in: Indication</comment>
         <value lang="en-us">Indication</value>
         <value lang="nl-nl">Indicatie</value>
+        <value lang="fr-fr">Indication</value>
     </translation>
     <translation key="UDI">
         <comment>As in: UDI</comment>
         <value lang="en-us">UDI</value>
+        <value lang="fr-fr">UDI</value>
     </translation>
     <translation key="UDI Barcode">
         <comment>As in: UDI Barcode</comment>
         <value lang="en-us">UDI Barcode</value>
         <value lang="nl-nl">UDI barcode</value>
+        <value lang="fr-fr">Code-barres UDI</value>
     </translation>
     <translation key="Request Date">
         <comment>As in: Request Date</comment>
         <value lang="en-us">Request Date</value>
         <value lang="nl-nl">Aanvraagdatum</value>
+        <value lang="fr-fr">Date de la demande</value>
     </translation>
     <translation key="Oral Diet">
         <comment>As in: Oral Diet</comment>
         <value lang="en-us">Oral Diet</value>
         <value lang="nl-nl">Orale voeding</value>
+        <value lang="fr-fr">Régime oral</value>
     </translation>
     <translation key="Fluid Consistency">
         <comment>As in: Fluid Consistency</comment>
         <value lang="en-us">Fluid Consistency</value>
         <value lang="nl-nl">Vloeistofconsistentie</value>
+        <value lang="fr-fr">Consistance du fluide</value>
     </translation>
     <translation key="Verified">
         <comment>As in: Verified</comment>
         <value lang="en-us">Verified</value>
         <value lang="nl-nl">Geverifieerd</value>
+        <value lang="fr-fr">Vérifié</value>
     </translation>
     <translation key="Actor">
         <comment>As in: Actor</comment>
         <value lang="en-us">Actor</value>
         <value lang="nl-nl">Actor</value>
+        <value lang="fr-fr">Acteur</value>
     </translation>
     <translation key="Additive">
         <comment>As in: Additive</comment>
         <value lang="en-us">Additive</value>
         <value lang="nl-nl">Toevoeging</value>
+        <value lang="fr-fr">Additif</value>
     </translation>
     <translation key="Purpose">
         <comment>As in: Purpose</comment>
         <value lang="en-us">Purpose</value>
         <value lang="nl-nl">Doel</value>
+        <value lang="fr-fr">But</value>
     </translation>
     <translation key="Action">
         <comment>As in: Action</comment>
         <value lang="en-us">Action</value>
         <value lang="nl-nl">Actie</value>
+        <value lang="fr-fr">Action</value>
     </translation>
     <translation key="Security Label">
         <comment>As in: Security Label</comment>
         <value lang="en-us">Security Label</value>
         <value lang="nl-nl">Securitylabel</value>
+        <value lang="fr-fr">Label de sécurité</value>
     </translation>
     <translation key="Not permitted unless">
         <comment>As in: Not permitted unless</comment>
         <value lang="en-us">Not permitted unless</value>
         <value lang="nl-nl">Niet toegestaan tenzij</value>
+        <value lang="fr-fr">Interdit sauf si</value>
     </translation>
     <translation key="Permitted if">
         <comment>As in: Permitted if</comment>
         <value lang="en-us">Permitted if</value>
         <value lang="nl-nl">Toegestaan als</value>
+        <value lang="fr-fr">Autorisé si</value>
     </translation>
     <translation key="Allowed">
         <comment>As in: Allowed</comment>
         <value lang="en-us">Allowed</value>
         <value lang="nl-nl">Toegestaan</value>
+        <value lang="fr-fr">Autorisé</value>
     </translation>
     <translation key="Treatment Restriction">
         <comment>As in: Treatment Restriction</comment>
         <value lang="en-us">Treatment Restriction</value>
         <value lang="nl-nl">Behandelrestrictie</value>
+        <value lang="fr-fr">Restriction de traitement</value>
     </translation>
     <translation key="Source">
         <comment>As in: Source</comment>
         <value lang="en-us">Source</value>
         <value lang="nl-nl">Bron</value>
+        <value lang="fr-fr">Source</value>
     </translation>
     <translation key="Expiration Date">
         <comment>As in: Expiration Date</comment>
         <value lang="en-us">Expiration Date</value>
         <value lang="nl-nl">Verloopdatum</value>
+        <value lang="fr-fr">Date d'expiration</value>
     </translation>
     <translation key="When">
         <comment>As in: When</comment>
         <value lang="en-us">When</value>
         <value lang="nl-nl">Wanneer</value>
+        <value lang="fr-fr">Quand</value>
     </translation>
     <translation key="Event">
         <comment>As in: Event</comment>
         <value lang="en-us">Event</value>
         <value lang="nl-nl">Gebeurtenis</value>
+        <value lang="fr-fr">Événement</value>
     </translation>
     <translation key="Conclusion">
         <comment>As in: Conclusion</comment>
         <value lang="en-us">Conclusion</value>
         <value lang="nl-nl">Conclusie</value>
+        <value lang="fr-fr">Conclusion</value>
     </translation>
     <translation key="Medication">
         <comment>As in: Medication</comment>
         <value lang="en-us">Medication</value>
         <value lang="nl-nl">Medicatie</value>
+        <value lang="fr-fr">Traitement</value>
     </translation>
     <translation key="Restriction">
         <comment>As in: Restriction</comment>
         <value lang="en-us">Restriction</value>
         <value lang="nl-nl">Restrictie</value>
+        <value lang="fr-fr">Restriction</value>
     </translation>
     <translation key="Task Focus">
         <comment>As in: Task Focus</comment>
         <value lang="en-us">Task Focus</value>
         <value lang="nl-nl">Taak focus</value>
+        <value lang="fr-fr">Focus sur la tâche</value>
     </translation>
     <translation key="Part Of">
         <comment>As in: Task Part Of</comment>
         <value lang="en-us">Part Of</value>
         <value lang="nl-nl">Deel van</value>
+        <value lang="fr-fr">Partie de</value>
     </translation>
     <translation key="Execution Period">
         <comment>As in: Task Execution Period</comment>
         <value lang="en-us">Execution Period</value>
         <value lang="nl-nl">Uitvoeringsperiode</value>
+        <value lang="fr-fr">Période d'exécution</value>
     </translation>
     <translation key="Task For">
         <comment>As in: Task For</comment>
         <value lang="en-us">Task Beneficiary</value>
         <value lang="nl-nl">Taak bedoeld voor</value>
+        <value lang="fr-fr">Bénéficiaire de la tâche</value>
     </translation>
     <translation key="Result">
         <comment>As in: Result</comment>
         <value lang="en-us">Result</value>
         <value lang="nl-nl">Resultaat</value>
+        <value lang="fr-fr">Résultat</value>
     </translation>
     <translation key="Diagnosis">
         <comment>As in: Diagnosis</comment>
         <value lang="en-us">Diagnosis</value>
         <value lang="nl-nl">Diagnose</value>
+        <value lang="fr-fr">Diagnostic</value>
     </translation>
     <translation key="Lot Number">
         <comment>As in: Lot Number</comment>
         <value lang="en-us">Lot Number</value>
         <value lang="nl-nl">Partijnummer</value>
+        <value lang="fr-fr">Numéro de lot</value>
     </translation>
     <translation key="Intent">
         <comment>As in: Intent of a CarePlan</comment>
         <value lang="en-us">Intent</value>
         <value lang="nl-nl">Intentie</value>
+        <value lang="fr-fr">Intention </value>
     </translation>
     <translation key="Entire Report">
         <comment>As in: Entire Report</comment>
         <value lang="en-us">Entire Report</value>
         <value lang="nl-nl">Geheel rapport</value>
+        <value lang="fr-fr">Rapport complet</value>
     </translation>
     <translation key="CarePlan">
         <comment>As in: CarePlan</comment>
         <value lang="en-us">Care Plan</value>
         <value lang="nl-nl">Zorgplan</value>
+        <value lang="fr-fr">Plan de soins</value>
     </translation>
     <translation key="Coverage">
         <comment>As in: Coverage</comment>
         <value lang="en-us">Coverage</value>
         <value lang="nl-nl">Verzekering/garantstelling</value>
+        <value lang="fr-fr">Couverture</value>
     </translation>
     <translation key="Composition">
         <comment>As in: Composition</comment>
         <value lang="en-us">Composition</value>
         <value lang="nl-nl">Samengestelde informatie</value>
+        <value lang="fr-fr">Composition</value>
     </translation>
     <translation key="Condition">
         <comment>As in: Condition</comment>
         <value lang="en-us">Condition</value>
         <value lang="nl-nl">Aandoening</value>
+        <value lang="fr-fr">Condition</value>
     </translation>
     <translation key="Flag">
         <comment>As in: Flag</comment>
         <value lang="en-us">Flag</value>
         <value lang="nl-nl">Attentievlag</value>
+        <value lang="fr-fr">Attention</value>
     </translation>
     <translation key="Observation">
         <comment>As in: Observation</comment>
         <value lang="en-us">Observation</value>
         <value lang="nl-nl">Observatie/bepaling</value>
+        <value lang="fr-fr">Observation</value>
     </translation>
     <translation key="Procedure">
         <comment>As in: Procedure</comment>
         <value lang="en-us">Procedure</value>
         <value lang="nl-nl">Verrichting</value>
+        <value lang="fr-fr">Opération</value>
     </translation>
     <translation key="Consent">
         <comment>As in: Consent</comment>
         <value lang="en-us">Consent</value>
         <value lang="nl-nl">Toestemming</value>
+        <value lang="fr-fr">Consentement</value>
     </translation>
     <translation key="Specimen">
         <comment>As in: Specimen</comment>
         <value lang="en-us">Specimen</value>
         <value lang="nl-nl">Specimen</value>
+        <value lang="fr-fr">Echantillon</value>
     </translation>
     <translation key="NutritionOrder">
         <comment>As in: NutritionOrder</comment>
         <value lang="en-us">NutritionOrder</value>
         <value lang="nl-nl">Voedingsadvies</value>
+        <value lang="fr-fr">Conseils nutritionnels</value>
     </translation>
     <translation key="DeviceUseStatement">
         <comment>As in: DeviceUseStatement</comment>
         <value lang="en-us">Device Use Statement</value>
         <value lang="nl-nl">Beschrijving apparaatgebruik</value>
+        <value lang="fr-fr">Description d'utilisation de l'appareil</value>
     </translation>
     <translation key="Encounter">
         <comment>As in: Encounter</comment>
         <value lang="en-us">Encounter</value>
         <value lang="nl-nl">Contact</value>
+        <value lang="fr-fr">Prise en charge</value>
     </translation>
     <translation key="AllergyIntolerance">
         <comment>As in: AllergyIntolerance</comment>
         <value lang="en-us">Allergy/Intolerance</value>
         <value lang="nl-nl">Allergie/intolerantie</value>
+        <value lang="fr-fr">Allergie/Hypersensibilité</value>
     </translation>
     <translation key="Bank Name">
         <comment>As in: Bank name</comment>
         <value lang="en-us">Bank Name</value>
         <value lang="nl-nl">Bank naam</value>
+        <value lang="fr-fr">Nom de la banque</value>
     </translation>
     <translation key="data absent">
         <comment>As in: data absent</comment>
         <value lang="en-us">data absent</value>
         <value lang="nl-nl">ontbrekend gegeven</value>
+        <value lang="fr-fr">données absentes</value>
     </translation>
     <translation key="Account Number">
         <comment>As in: Bank account number</comment>
         <value lang="en-us">Account Number</value>
         <value lang="nl-nl">Rekeningnummer</value>
+        <value lang="fr-fr">Numéro de compte</value>
     </translation>
     <translation key="Bank Code">
         <comment>As in: Bank code</comment>
         <value lang="en-us">Bank code</value>
         <value lang="nl-nl">Bank code</value>
+        <value lang="fr-fr">Code banque</value>
     </translation>
     <translation key="This Version">
         <comment>As in: This Version</comment>
         <value lang="en-us">This Version</value>
         <value lang="nl-nl">Deze versie</value>
+        <value lang="fr-fr">Cette version</value>
     </translation>
     <translation key="Media">
         <comment>As in: Media</comment>
         <value lang="en-us">Media</value>
         <value lang="nl-nl">Media</value>
+        <value lang="fr-fr">Media</value>
     </translation>
     <translation key="Prescriber">
         <comment>As in: Prescriber</comment>
         <value lang="en-us">Prescriber</value>
         <value lang="nl-nl">Voorschrijver</value>
+        <value lang="fr-fr">Prescripteur</value>
     </translation>
     <translation key="Days Supply">
         <comment>As in: Days Supply</comment>
         <value lang="en-us">Days Supply</value>
         <value lang="nl-nl">Dagen voorraad</value>
+        <value lang="fr-fr">Jours d'approvisionnement</value>
     </translation>
     <translation key="When Prepared">
         <comment>As in: When Prepared</comment>
         <value lang="en-us">When Prepared</value>
         <value lang="nl-nl">Datum bereid/gemaakt</value>
+        <value lang="fr-fr">Date de préparation</value>
     </translation>
     <translation key="When Handed Over">
         <comment>As in: When Handed Over</comment>
         <value lang="en-us">When Handed Over</value>
         <value lang="nl-nl">Datum overhandigd</value>
+        <value lang="fr-fr">Date de remise</value>
     </translation>
     <translation key="Taken As Agreed">
         <comment>As in: Taken As Agreed</comment>
         <value lang="en-us">Taken As Agreed</value>
         <value lang="nl-nl">Genomen zoals afgesproken</value>
+        <value lang="fr-fr">Pris comme convenu</value>
     </translation>
     <translation key="Not Taken As Agreed">
         <comment>As in: Not Taken As Agreed</comment>
         <value lang="en-us">Not Taken As Agreed</value>
         <value lang="nl-nl">Niet genomen zoals afgesproken</value>
+        <value lang="fr-fr">Pas pris comme convenu</value>
     </translation>
     <translation key="Reason For Change Or Discontinuation">
         <comment>As in: Reason For Change Or Discontinuation</comment>
         <value lang="en-us">Reason For Change Or Discontinuation</value>
         <value lang="nl-nl">Reden voor wijzigen of stoppen</value>
+        <value lang="fr-fr">Raison du changement ou de l'arrêt</value>
     </translation>
     <translation key="Substitution">
         <comment>As in: Substitution</comment>
         <value lang="en-us">Substitution</value>
         <value lang="nl-nl">Substitutie</value>
+        <value lang="fr-fr">Substitution</value>
     </translation>
     <translation key="Inactive record">
         <comment>As in: Inactive record</comment>
         <value lang="en-us">Inactive record</value>
         <value lang="nl-nl">Inactief record</value>
+        <value lang="fr-fr">Dossier inactif</value>
     </translation>
     <translation key="Use Duration">
         <comment>As in: Use Duration</comment>
         <value lang="en-us">Use Duration</value>
         <value lang="nl-nl">Gebruiksduur</value>
+        <value lang="fr-fr">Durée d'utilisation</value>
     </translation>
     <translation key="This information is copied from a third party">
         <comment>As in: This information is copied from a third party</comment>
         <value lang="en-us">This information is copied from a third party</value>
         <value lang="nl-nl">Deze informatie is gekopieerd van een derde partij</value>
+        <value lang="fr-fr">Ces informations sont copiées d'un tiers</value>
     </translation>
     <translation key="Medication has been stopped">
         <comment>As in: Medication has been stopped</comment>
         <value lang="en-us">Medication has been stopped</value>
         <value lang="nl-nl">Medicatie is gestopt</value>
+        <value lang="fr-fr">Le traitement a été arrêté</value>
     </translation>
     <translation key="Repeat Period Cyclical Schedule">
         <comment>As in: Repeat Period Cyclical Schedule</comment>
         <value lang="en-us">Repeat Period Cyclical Schedule</value>
         <value lang="nl-nl">Herhaalperiode cyclisch schedule</value>
+        <value lang="fr-fr">Période répétitive de programme cyclique</value>
     </translation>
     <translation key="Medication Treatment ID">
         <comment>As in: Medication Treatment ID</comment>
         <value lang="en-us">Medication Treatment ID</value>
         <value lang="nl-nl">Medicamenteuze behandel-id</value>
+        <value lang="fr-fr">Identifiant du traitement</value>
     </translation>
     <translation key="Prior Request">
         <comment>As in: Prior Medication Request</comment>
         <value lang="en-us">Prior Medication Request</value>
         <value lang="nl-nl">Voorgaande medicatieverzoek</value>
+        <value lang="fr-fr">Demande de traitement précédente</value>
     </translation>
     <translation key="Attester">
         <comment>As in: Attester</comment>
         <value lang="en-us">Attester</value>
         <value lang="nl-nl">Attester</value>
+        <value lang="fr-fr">Attestation</value>
     </translation>
     <translation key="Authority">
         <comment>As in: Authority</comment>
         <value lang="en-us">Authority</value>
         <value lang="nl-nl">Bevoegdheid</value>
+        <value lang="fr-fr">Autorité</value>
     </translation>
     <translation key="Assessment">
         <comment>As in: Assessment</comment>
         <value lang="en-us">Assessment</value>
         <value lang="nl-nl">Vaststelling</value>
+        <value lang="fr-fr">Évaluation</value>
     </translation>
     <translation key="As Needed">
         <comment>As in: As Needed</comment>
         <value lang="en-us">As Needed</value>
         <value lang="nl-nl">Zo nodig</value>
+        <value lang="fr-fr">selon le besoin</value>
     </translation>
     <translation key="Route Of Administration">
         <comment>Label: Route Of Administration</comment>
         <value lang="en-us">Route Of Administration</value>
         <value lang="nl-nl">Toedieningsweg</value>
+        <value lang="fr-fr">Voie d'administration</value>
     </translation>
     <translation key="Expected Supply Duration">
         <comment>As in: Expected Supply Duration</comment>
         <value lang="en-us">Expected Supply Duration</value>
         <value lang="nl-nl">Verwachte duur voorraad</value>
+        <value lang="fr-fr">Durée d'approvisionnement prévue</value>
     </translation>
     <translation key="Number of Repeats Allowed">
         <comment>As in: Max Repeats</comment>
         <value lang="en-us">Max Repeats</value>
         <value lang="nl-nl">Max herhalingen</value>
+        <value lang="fr-fr">Nombre maximum de répétitions</value>
     </translation>
     <translation key="official">
         <comment>As in: official address qualifier</comment>
         <value lang="en-us">official</value>
         <value lang="nl-nl">officieel</value>
+        <value lang="fr-fr">officiel</value>
     </translation>
     <translation key="Validity Period">
         <comment>As in: Validity Period</comment>
         <value lang="en-us">Validity Period</value>
         <value lang="nl-nl">Geldigheidsperiode</value>
+        <value lang="fr-fr">Période de validité</value>
     </translation>
     <translation key="Destination">
         <comment>Label: Destination</comment>
         <value lang="en-us">Destination</value>
         <value lang="nl-nl">Bestemming</value>
+        <value lang="fr-fr">Destination</value>
     </translation>
     <translation key="Dosage">
         <comment>As in: Dosage</comment>
         <value lang="en-us">Dosage</value>
         <value lang="nl-nl">Dosering</value>
+        <value lang="fr-fr">Dose</value>
     </translation>
     <translation key="Dosage Instruction">
         <comment>As in: Dosage Instruction</comment>
         <value lang="en-us">Dosage Instruction</value>
         <value lang="nl-nl">Doseerinstructie</value>
+        <value lang="fr-fr">Posologie</value>
     </translation>
     <translation key="Medication Taken">
         <comment>As in: Medication Taken</comment>
         <value lang="en-us">Medication Taken</value>
         <value lang="nl-nl">Medicatie gebruikt</value>
+        <value lang="fr-fr">Traitement pris</value>
     </translation>
     <translation key="Reason For Medication">
         <comment>As in: Reason For Medication</comment>
         <value lang="en-us">Reason For Medication</value>
         <value lang="nl-nl">Reden voor medicatie</value>
+        <value lang="fr-fr">Raison du traitement</value>
     </translation>
     <translation key="Distribution Form">
         <comment>As in: Distribution Form</comment>
         <value lang="en-us">Distribution Form</value>
         <value lang="nl-nl">Distributievorm</value>
+        <value lang="fr-fr">Présentation</value>
     </translation>
     <translation key="Medication Dispensed">
         <comment>As in: Medication Dispensed</comment>
         <value lang="en-us">Medication Dispensed</value>
         <value lang="nl-nl">Medicatie verstrekt</value>
+        <value lang="fr-fr">Traitement dispensé</value>
     </translation>
     <translation key="Daily">
         <comment>As in: Daily</comment>
         <value lang="en-us">Daily</value>
         <value lang="nl-nl">Dagelijks</value>
+        <value lang="fr-fr">Quotidien</value>
     </translation>
     <translation key="Reason Not Dispensed">
         <comment>As in: Reason Not Dispensed</comment>
         <value lang="en-us">Reason Not Dispensed</value>
         <value lang="nl-nl">Reden niet verstrekt</value>
+        <value lang="fr-fr">Raison de non dispensation</value>
     </translation>
     <translation key="Reason Not Given">
         <comment>As in: Reason Not Given</comment>
         <value lang="en-us">Reason Not Given</value>
         <value lang="nl-nl">Reden niet gegeven</value>
+        <value lang="fr-fr">Raison non donnée</value>
     </translation>
     <translation key="Substituted">
         <comment>As in: Substituted</comment>
         <value lang="en-us">Substituted</value>
         <value lang="nl-nl">Vervangen</value>
+        <value lang="fr-fr">Substitué</value>
     </translation>
     <translation key="ProcedureRequest">
         <comment>As in: ProcedureRequest</comment>
         <value lang="en-us">Procedure Request</value>
         <value lang="nl-nl">Verrichtingaanvraag</value>
+        <value lang="fr-fr">Demande d'acte</value>
     </translation>
     <translation key="EpisodeOfCare">
         <comment>As in: EpisodeOfCare</comment>
         <value lang="en-us">Episode of Care</value>
         <value lang="nl-nl">Zorgepisode</value>
+        <value lang="fr-fr">Épisode de soins</value>
     </translation>
     <translation key="Image Study">
         <comment>As in: Image Study</comment>
         <value lang="en-us">Image Study</value>
         <value lang="nl-nl">Beeldonderzoek</value>
+        <value lang="fr-fr">Examen d'imagerie</value>
     </translation>
+    <!-- OIDs NL: Start -->
     <translation key="2.16.840.1.113883.2.4.6.7">
         <comment>As in: 2.16.840.1.113883.2.4.6.7</comment>
         <value lang="en-us">AGB-medical specialism</value>
@@ -9605,56 +11377,67 @@
         <value lang="en-us">RoleCodeList (COD472-VEKT)</value>
         <value lang="nl-nl">RoleCodeLijst (COD472-VEKT)</value>
     </translation>
+    <!-- OIDs NL: End -->
     <translation key="dataAbsentReason_unknown">
         <comment>Label: DataAbsentReason unknown</comment>
         <value lang="en-us">unknown</value>
         <value lang="de-ch">unbekannt</value>
         <value lang="nl-nl">onbekend</value>
+        <value lang="fr-fr">inconnu</value>
     </translation>
     <translation key="dataAbsentReason_asked">
         <comment>Label: DataAbsentReason asked</comment>
         <value lang="en-us">asked but unknown</value>
         <value lang="nl-nl">gevraagd maar onbekend</value>
+        <value lang="fr-fr">demandé mais inconnu</value>
     </translation>
     <translation key="dataAbsentReason_temp">
         <comment>Label: DataAbsentReason unknown</comment>
         <value lang="en-us">temporarily unknown</value>
         <value lang="nl-nl">nog niet bekend</value>
+        <value lang="fr-fr">temporairement inconnu</value>
     </translation>
     <translation key="dataAbsentReason_not-asked">
         <comment>Label: DataAbsentReason noot-asked</comment>
         <value lang="en-us">not asked</value>
         <value lang="nl-nl">niet gevraagd</value>
+        <value lang="fr-fr">non demandé</value>
     </translation>
     <translation key="dataAbsentReason_masked">
         <comment>Label: DataAbsentReason masked</comment>
         <value lang="en-us">masked</value>
         <value lang="de-ch">maskiert</value>
         <value lang="nl-nl">afgeschermd</value>
+        <value lang="fr-fr">masqué</value>
     </translation>
     <translation key="dataAbsentReason_unsupported">
         <comment>Label: DataAbsentReason unsupported</comment>
         <value lang="en-us">unsupported</value>
         <value lang="nl-nl">niet-ondersteund</value>
+        <value lang="fr-fr">non supporté</value>
     </translation>
     <translation key="dataAbsentReason_astext">
         <comment>Label: DataAbsentReason astext</comment>
         <value lang="en-us">as text</value>
         <value lang="nl-nl">in tekst</value>
+        <value lang="fr-fr">sous forme textuelle</value>
     </translation>
     <translation key="dataAbsentReason_error">
         <comment>Label: DataAbsentReason error</comment>
         <value lang="en-us">system/workflow failure</value>
         <value lang="nl-nl">systeem/workflow fout</value>
+        <value lang="fr-fr">défaillance du système/du flux</value>
     </translation>
     <translation key="dataAbsentReason_NaN">
         <comment>Label: DataAbsentReason NaN</comment>
         <value lang="en-us">not a number</value>
         <value lang="nl-nl">geen getal</value>
+        <value lang="fr-fr">pas un nombre</value>
     </translation>
     <translation key="dataAbsentReason_not-performed">
         <comment>Label: DataAbsentReason not-performed</comment>
         <value lang="en-us">not performed</value>
         <value lang="nl-nl">niet gedaan</value>
+        <value lang="fr-fr">pas effectué</value>
     </translation>
 </translations>


### PR DESCRIPTION
Source: Agence du Numérique en Santé
Alain PERIE
Directeur de programme
Dir. expertise, innovation et international
Interopérabilité

> I’m working at the ANS (Agence du numérique en santé) which is the French eHealth Agency and I’m the manager of the team producing the CDA specifications for the French clinical documents.
> 
> I found on GITHUB/HL7 the CDA stylesheet cda_l10n.xml file containing the us and nl translations.
>I have added the French translations and I would like to know if you can publish it for those who would like to have the French translations.