### PR TITLE
changes in this version

### DIFF
--- a/01_Modèles_contenus_CDA.xml
+++ b/01_Modèles_contenus_CDA.xml
@@ -1,0 +1,9047 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-stylesheet type="text/xsl" href="CDA.xsl"?>
+
+<?oxygen SCHSchema="../schematrons/profils/IHE.sch"?>
+<?oxygen SCHSchema="../schematrons/profils/IHE_XDS-SD.sch"?>
+<?oxygen SCHSchema="../schematrons/profils/CI-SIS_StructurationMinimale.sch"?>
+<?oxygen SCHSchema="../schematrons/profils/CI-SIS_ModelesDeContenusCDA.sch"?>
+<?oxygen SCHSchema="../Schematrons/profils/terminologies/schematron/terminologie.sch"?> 
+<?oxygen SCHSchema="../schematrons/profils/CI-SIS_Modeles_ANS.sch"?>
+
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:hl7-org:v3 ../infrastructure/cda/CDA_extended.xsd" xmlns="urn:hl7-org:v3" 
+	xmlns:sdtc="urn:hl7-org:sdtc" xmlns:ps3-20="urn:dicom-org:ps3-20" xmlns:pharm="urn:ihe:pharm:medication">
+	<!-- 
+      **********************************************************************************************************
+      Système : ANS
+      Document : Document CDA avec les exemples de sections et entrées les plus courants
+      **********************************************************************************************************
+      format HL7 - CDA Release 2 - selon schéma XML (CDA.xsd) du standard ANSI/HL7 CDA, R2-2005 4/21/2005
+      **********************************************************************************************************
+      Notes:
+      - TemplateId du modèle de document: Synthèse Médicale (VSM): 1.2.250.1.213.1.1.1.13
+      - Type de documents (Matrice): SYNTH (Synthèse)
+      - OID temporaire du LPS producteur de document: root="1.2.250.1.213.1.1.9" 
+      
+      	15/05/2012 : Création 
+     	11/06/2018 : Correction d'erreurs suite à la mise à jour des schématrons
+     	19/09/2019 : Ajout de sections et entrées pour vérifier les exemples du Volet Modèles de contenus CDA
+     	06/11/2020 : Ajout des OIDs France
+     	09/02/2023 : Mise à jour MC-CDA v3
+      **********************************************************************************************************
+   -->
+	<realmCode code="FR"/>
+	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+	<!-- Conformité spécifications HL7 France -->
+	<templateId root="2.16.840.1.113883.2.8.2.1"/>
+	<!-- Conformité spécifications au CI-SIS -->
+	<templateId root="1.2.250.1.213.1.1.1.1"/>
+	<!-- Conformité au Volet Synthèse Médicale (VSM)-->
+	<templateId root="1.2.250.1.213.1.1.1.13"/>
+	<!-- Unique ID obligatoire -->
+	<id root="1.2.250.1.213.1.1.1.13.1.2"/>
+	<!-- Type de document -->
+	<code code="60591-5" displayName="Synthèse du dossier médical" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>		
+	<!-- Titre de documeunt -->
+	<title>SYNTHESE MEDICALE</title>
+	<!-- Date et heure de création du document -->
+	<effectiveTime value="202302091130+0100"/>
+	<!-- Niveau de confidentialité -->
+	<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal"/>
+	<!-- Langue du document -->
+	<languageCode code="fr-FR"/>
+	<!-- Identifiant du lot de version d'un même document -->
+	<setId root="1.2.250.1.213.1.1.1.13.1"/>
+	<!-- numéro de la version courante (entier positif) -->
+	<versionNumber value="2"/>
+	
+	<!-- Patient -->
+	<recordTarget>
+		<patientRole>
+			<!-- INS-NIR de production : 1.2.250.1.213.1.4.8 -->
+			<id extension="277076322082910" root="1.2.250.1.213.1.4.8"/>
+			<!-- IPP du patient dans l'établissement avec root = l'OID de l'ES -->
+			<id extension="1234567890121" root="1.2.3.4.567.8.9.10"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<!-- Identité du patient -->
+			<patient classCode="PSN">
+				<name>
+					<!-- Nom et 1er prénom de naissance : Affichés en gras -->
+					<family qualifier="BR">NESSI</family>			
+					<given qualifier="BR">Ruth</given>
+					<!-- Nom et prénom utilisés : Pas affichés en gras -->
+					<family qualifier="CL">DECOURCY</family>
+					<given qualifier="CL">Véronique</given>
+					<!-- Noms d’usage : Pas affichés en gras -->
+					<family qualifier="SP">DECOURCY</family>					
+					<!-- Liste des prénoms de l’acte de naissance : Pas affichés en gras -->
+					<given>Ruth</given>			
+					<given>Isabelle</given>	
+				</name>
+				<administrativeGenderCode code="F" displayName="Féminin" codeSystem="2.16.840.1.113883.5.1"/>
+				<birthTime value="19770714"/>
+				<!-- Représentant du patient 1 -->
+				<guardian>
+					<telecom value="tel:01111111"/>
+					<telecom value="tel:04425151" use="WP"/>
+					<telecom value="tel:00000300" use="H"/>
+					<telecom value="tel:00000300" use="HP"/>
+					<telecom value="tel:00000300" use="HV"/>
+					<telecom value="tel:00000300" use="DIR"/>
+					<telecom value="tel:00000300" use="PUB"/>
+					<telecom value="tel:00000300" use="EC"/>
+					<telecom value="tel:00000300" use="MC"/>
+					<telecom value="tel:00000300" use="PG"/>
+					<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+					<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+					<addr>
+						<houseNumber>142</houseNumber>
+						<streetName>Rue Belvédère</streetName>
+						<postalCode>92100</postalCode>
+						<city>Boulogne-Billancourt</city>
+					</addr>
+					<addr use="H">
+						<houseNumber>27</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="TMP">
+						<houseNumber>29</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="WP">
+						<houseNumber>26</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HP">
+						<houseNumber>30</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HV">
+						<houseNumber>25</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<guardianPerson>
+						<name>
+							<prefix>MME</prefix>
+							<family>NESSI</family>
+							<given>Jeanne</given>
+						</name>
+					</guardianPerson>
+				</guardian>
+				<!-- Représentant du patient 2 -->
+				<guardian>
+					<telecom value="tel:0111111122"/>
+					<telecom value="tel:0442515151" use="WP"/>
+					<telecom value="tel:00000300" use="H"/>
+					<telecom value="tel:00000300" use="HP"/>
+					<telecom value="tel:00000300" use="HV"/>
+					<telecom value="tel:00000300" use="DIR"/>
+					<telecom value="tel:00000300" use="PUB"/>
+					<telecom value="tel:00000300" use="EC"/>
+					<telecom value="tel:00000300" use="MC"/>
+					<telecom value="tel:00000300" use="PG"/>
+					<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+					<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+					<addr>
+						<houseNumber>142</houseNumber>
+						<streetName>Rue Belvédère</streetName>
+						<postalCode>92100</postalCode>
+						<city>Boulogne-Billancourt</city>
+					</addr>
+					<addr use="H">
+						<houseNumber>27</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="TMP">
+						<houseNumber>29</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="WP">
+						<houseNumber>26</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HP">
+						<houseNumber>30</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HV">
+						<houseNumber>25</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<guardianPerson>
+						<name>
+							<prefix>M</prefix>
+							<family>DECOURCY</family>
+							<given>Pierre</given>
+						</name>
+					</guardianPerson>
+				</guardian>
+				
+				<!-- Lieu de naissance du patient -->
+				<birthplace>
+					<place>
+						<addr>
+							<county>63220</county>
+							<city>MAZOIRES</city>
+						</addr>
+					</place>
+				</birthplace>
+			</patient>
+		</patientRole>
+	</recordTarget>
+	
+	<!-- Auteur du document -->
+	<author>
+		<time value="202302091130+0100"/>
+		<assignedAuthor>
+			<!-- PS identifié par son N°RPPS -->
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<!-- Profession -->
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecin Générale (SM)"/> 
+			<!-- <code code="72" codeSystem="1.2.250.1.213.1.6.1.109"
+				displayName="Psychothérapeute"/> -->
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<assignedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Charles </given>
+					<family>BOILEAU</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+				<name>Centre de soins du Belvédère</name>				
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<standardIndustryClassCode code="ETABLISSEMENT"
+					displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+					codeSystemName="practiceSettingCode"/>
+			</representedOrganization>
+		</assignedAuthor>
+	</author>
+	
+	<!-- Opérateur de saisie -->
+	<dataEnterer>
+		<time value="202302091110+0100"/>
+		<assignedEntity classCode="ASSIGNED">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<assignedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<family>ANDRE</family>
+					<given>Jacques</given>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+				<name>Centre de soins du Belvédère</name>				
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<standardIndustryClassCode code="ETABLISSEMENT"
+					displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+					codeSystemName="practiceSettingCode"/>
+			</representedOrganization>
+		</assignedEntity>
+	</dataEnterer>
+	
+	<!-- Personne 1 à prévenir en cas d'urgence -->
+	<informant>
+		<relatedEntity classCode="ECON">
+			<code code="SIS" displayName="Soeur" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<family>NESSI</family>
+					<given>Jeanne</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Personne 2 à prévenir en cas d'urgence -->
+	<informant>
+		<relatedEntity classCode="ECON">
+			<code code="HUSB" displayName="Mari" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<family>DECOURCY</family>
+					<given>Pierre</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Personne 1 de confiance -->
+	<informant>
+		<relatedEntity classCode="NOK">
+			<code code="SIS" displayName="Soeur" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<family>NESSI</family>
+					<given>Jeanne</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Personne 2 de confiance -->
+	<informant>
+		<relatedEntity classCode="NOK">
+			<code code="HUSB" displayName="Mari" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<family>DECOURCY</family>
+					<given>Pierre</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Aidant 1 -->
+	<informant>
+		<relatedEntity classCode="CAREGIVER">
+			<code code="SIS" displayName="Soeur" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<family>NESSI</family>
+					<given>Jeanne</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Aidant 2 -->
+	<informant>
+		<relatedEntity classCode="CAREGIVER">
+			<code code="HUSB" displayName="Mari" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<family>DECOURCY</family>
+					<given>Pierre</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Aidé 1 -->
+	<informant>
+		<relatedEntity classCode="PAT">
+			<code code="DAUC" displayName="Fille" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>MLLE</prefix>
+					<family>DECOURCY</family>
+					<given>Isabelle</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>	
+	
+	<!-- Informateur non professionnel  -->
+	<informant>
+		<relatedEntity classCode="CON">
+			<code code="BRO" displayName="Frère" codeSystem="2.16.840.1.113883.5.111"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<relatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<family>DECOURCY</family>
+					<given>Yvan</given>
+				</name>
+			</relatedPerson>
+		</relatedEntity>
+	</informant>
+	
+	<!-- Informateur PS  -->
+	<informant>
+		<assignedEntity classCode="ASSIGNED">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<assignedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<family>ANDRE</family>
+					<given>Jacques</given>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+				<name>Centre de soins du Belvédère</name>				
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<standardIndustryClassCode code="ETABLISSEMENT"
+					displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+					codeSystemName="practiceSettingCode"/>
+			</representedOrganization>
+		</assignedEntity>
+	</informant>
+	
+	<!-- Organisation chargée de la conservation du document -->
+	<custodian>
+		<assignedCustodian>
+			<representedCustodianOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="1120456789"/>
+				<name>Centre Médical du Belvédère</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</representedCustodianOrganization>
+		</assignedCustodian>
+	</custodian>
+
+	<!-- Destinataire du document -->
+	<informationRecipient typeCode="PRCP">
+		<intendedRecipient classCode="ASSIGNED">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>		
+			<informationRecipient>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Stéphane</given>
+					<family>MEDIONI</family>
+				</name>
+			</informationRecipient>
+			<receivedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="1120456791"/>
+				<name>Cabinet du Dr Stéphane MEDIONI</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</receivedOrganization>
+		</intendedRecipient>
+	</informationRecipient>
+	
+	<!-- Signataire du document -->
+	<legalAuthenticator>
+		<time value="202302091130+0100"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecin Générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<assignedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Charles </given>
+					<family>BOILEAU</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+				<name>Centre de soins du Belvédère</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<standardIndustryClassCode code="ETABLISSEMENT"
+					displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+					codeSystemName="practiceSettingCode"/>
+			</representedOrganization>
+		</assignedEntity>
+	</legalAuthenticator>
+
+	<!-- PS attestant de la validité du document -->
+	<authenticator>
+		<time value="202302091130+0100"/>
+		<signatureCode code="S"/>
+		<assignedEntity>
+			<id root="1.2.250.1.71.4.2.1" extension="801234567845"/>
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecin Générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<assignedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Pierre </given>
+					<family>BOLD</family>
+				</name>
+			</assignedPerson>
+			<representedOrganization>
+				<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+				<name>Centre de soins du Belvédère</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<standardIndustryClassCode code="ETABLISSEMENT"
+					displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+					codeSystemName="practiceSettingCode"/>
+			</representedOrganization>
+		</assignedEntity>
+	</authenticator>
+
+	<!-- [0..*] Responsable de l'acte (typeCode="RESP") -->
+	<participant typeCode="RESP">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr MEDIONI</originalText>
+		</functionCode>
+		<time nullFlavor="NA"></time>
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecine Générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Stéphane</given>
+					<family>MEDIONI</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="101235555"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR MEDIONI</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Prescripteur (typeCode="REF")-->
+	<participant typeCode="REF">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr BLUE</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567892"/>
+			<code code="G15_10/C25" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Gynécologie médicale (C)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<suffix>DR</suffix>
+					<given>Eva</given>
+					<family>BLUE</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120459384"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR BLUE</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Prescripteur remplacé (typeCode="REF" et functionCode code="353")-->
+	<participant typeCode="REF">
+		<functionCode code="353" displayName="Membre de l'équipe de soins" codeSystem="1.2.250.1.213.1.6.1.107">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr MEDIONI</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecine Générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Stéphane</given>
+					<family>MEDIONI</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="101235555"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR MEDIONI</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>	
+	
+	<!-- [0..*] Praticien adresseur (typeCode="REFB")-->
+	<participant typeCode="REFB">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr MORVAN</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234576543"/>
+			<code code="G15_10/SM36" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Oncologie option médicale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Roland</given>
+					<family>MORVAN</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1801234567897"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du Dr MORVAN</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Médecin traitant (typeCode="INF" et functionCode code="PCP") -->
+	<participant typeCode="INF">
+		<functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88" displayName="Médecin Traitant">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr MEDIONI</originalText>
+		</functionCode>
+		<time nullFlavor="NA"></time>
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+			<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Qualifié en Médecine Générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Stéphane</given>
+					<family>MEDIONI</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="101235555"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR MEDIONI</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Informateur (typeCode="INF")-->
+	<participant typeCode="INF">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr TOUTOU</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234574597"/>
+			<code code="G15_10/SM36" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Oncologie option médicale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Eric</given>
+					<family>TOUTOU</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="101235542"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du Dr TOUTOU</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Responsable de l'équipe de soins (typeCode="PRF" et functionCode code="ATTPHYS")-->
+	<participant typeCode="PRF">
+		<functionCode code="ATTPHYS" displayName="Référent - Responsable du patient dans la structure de soins" codeSystem="2.16.840.1.113883.5.88">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr DUCOUT</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234576521"/>
+			<code code="G15_10/SM36" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Oncologie option médicale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<suffix>DR</suffix>
+					<given>Sylvie</given>
+					<family>DUCOUT</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1801234567897"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du Dr DUCOUT</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Membre de l'équipe de soins (typeCode="PRF" et functionCode code="353")-->
+	<participant typeCode="PRF">
+		<functionCode code="353" displayName="Membre de l'équipe de soins" codeSystem="1.2.250.1.213.1.6.1.107">
+			<!-- Commentaire sur le PS Membre de l'équipe de soins -->
+			<originalText>Commentaire sur le Dr MORVAN</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<!-- PS membre de l'équipe de soins -->
+			<id root="1.2.250.1.71.4.2.1" extension="801234576543"/>
+			<code code="G15_10/SM36" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Oncologie option médicale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Roland</given>
+					<family>MORVAN</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1801234567897"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du Dr MORVAN</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Correspondant (typeCode="PRF" et functionCode code="CORRE")-->
+	<participant typeCode="PRF">
+		<functionCode code="CORRE" displayName="Correspondant" codeSystem="1.2.250.1.213.1.1.4.2.280">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le Dr FAVIER</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234576543"/>
+			<code code="G15_10/SM36" codeSystem="1.2.250.1.213.1.1.4.5"
+				displayName="Médecin - Oncologie option médicale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Thierry</given>
+					<family>FAVIER</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1801234567897"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du Dr FAVIER</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Préleveur (typeCode="PRF" et functionCode code="PRELV")-->
+	<participant typeCode="PRF">
+		<functionCode code="PRELV" displayName="Préleveur" codeSystem="1.2.250.1.213.1.1.4.2.280">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur MME SISSI</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567893"/>
+			<code code="G15_60" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Infirmier"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<given>Roberta</given>
+					<family>BLEEDER</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452948"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet d'infirmières de BB</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Exécutant (typeCode="PRF")-->
+	<participant typeCode="PRF">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR GUIGUES</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567898"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>MME</prefix>
+					<suffix>DR</suffix>
+					<given>Laurence</given>
+					<family>GUIGUES</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452949"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR GUIGUES</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Correspondant (typeCode="CON" et functionCode code="CORRE")-->
+	<participant typeCode="CON">
+		<functionCode code="CORRE" codeSystem="1.2.250.1.213.1.1.4.2.280" displayName="Correspondant">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR DUPUY</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234567828"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Laurent</given>
+					<family>DUPUY</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452953"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR DUPUY</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Consultant (typeCode="CON")-->
+	<participant typeCode="CON">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur MLLE VAN</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234563948"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>MLLE</prefix>
+					<given>Delphine</given>
+					<family>VAN</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452964"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet de MLLE VAN</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Vérificateur (typeCode="VRF")-->
+	<participant typeCode="VRF">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR LEBOEUF</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234563948"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Emmanuel</given>
+					<family>LEBOEUF</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452964"/>
+				<!-- Nom de l'établissement -->
+				<name>Cabinet du DR LEBOEUF</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Responsable de l'admission (typeCode="ADM" et functionCode code="ADMPHYS")-->
+	<participant typeCode="ADM">
+		<functionCode code="ADMPHYS" codeSystem="2.16.840.1.113883.5.88" displayName="Responsable de l'admission">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR ADMISSION</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234563975"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Philippe</given>
+					<family>ADMISSION</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452949"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du DR ADMISSION</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Responsable de la sortie (typeCode="DIS" et functionCode code="ADMPHYS")-->
+	<participant typeCode="DIS">
+		<functionCode code="DISPHYS" codeSystem="2.16.840.1.113883.5.88" displayName="Responsable de la sortie">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR SORTIE</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234563976"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Lucien</given>
+					<family>SORTIE</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452949"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du DR ADMISSION</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+	
+	<!-- [0..*] Valideur des résultats (typeCode="AUTHEN")-->
+	<participant typeCode="AUTHEN">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le PS -->
+			<originalText>Commentaire sur le DR VALID</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>
+		<!-- PS / ES -->
+		<associatedEntity classCode="PROV">
+			<id root="1.2.250.1.71.4.2.1" extension="801234563977"/>
+			<code code="G15_10/SM05" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Chirurgie générale (SM)"/>
+			<telecom value="tel:0111111111"/>
+			<telecom value="tel:0442515151" use="WP"/>
+			<telecom value="tel:00000300" use="H"/>
+			<telecom value="tel:00000300" use="HP"/>
+			<telecom value="tel:00000300" use="HV"/>
+			<telecom value="tel:00000300" use="DIR"/>
+			<telecom value="tel:00000300" use="PUB"/>
+			<telecom value="tel:00000300" use="EC"/>
+			<telecom value="tel:00000300" use="MC"/>
+			<telecom value="tel:00000300" use="PG"/>
+			<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+			<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+			<addr>
+				<houseNumber>142</houseNumber>
+				<streetName>Rue Belvédère</streetName>
+				<postalCode>92100</postalCode>
+				<city>Boulogne-Billancourt</city>
+			</addr>
+			<addr use="H">
+				<houseNumber>27</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="TMP">
+				<houseNumber>29</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="WP">
+				<houseNumber>26</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HP">
+				<houseNumber>30</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<addr use="HV">
+				<houseNumber>25</houseNumber>
+				<streetNameType>Av</streetNameType>
+				<streetName>de Breteuil</streetName>
+				<additionalLocator nullFlavor="NA"/>
+				<postalCode>75007</postalCode>
+				<city>PARIS</city>
+				<country>FRANCE</country>
+			</addr>
+			<associatedPerson>
+				<name>
+					<prefix>M</prefix>
+					<suffix>DR</suffix>
+					<given>Etienne</given>
+					<family>VALID</family>
+				</name>
+			</associatedPerson>
+			<!-- Etablissement de référence -->
+			<scopingOrganization>
+				<!-- Identifiant FINESS de l'établissement -->
+				<id root="1.2.250.1.71.4.2.2" extension="1120452949"/>
+				<!-- Nom de l'établissement -->
+				<name>Clinique du DR ADMISSION</name>
+				<!-- Télécom de l'établissement -->
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>	
+	
+	<!-- [0..*] Autre participant : Employeur (autre combinaison typeCode / functionCode) -->
+	<participant typeCode="WIT">
+		<functionCode nullFlavor="NA">
+			<!-- Commentaire sur le participant -->
+			<originalText>Employeur</originalText>
+		</functionCode>
+		<time xsi:type="IVL_TS" nullFlavor="UNK"/>		
+		<associatedEntity classCode="AGNT">
+			<id root="XXXYYY" extension="XXXYYY"/>
+			<associatedPerson>
+				<name>
+					<family>WORK</family>
+					<given>Emmanuel</given>
+				</name>
+			</associatedPerson>
+			<scopingOrganization>
+				<name>Entreprise THIERRY</name>
+				<telecom value="tel:0111111111"/>
+				<telecom value="tel:0442515151" use="WP"/>
+				<telecom value="tel:00000300" use="H"/>
+				<telecom value="tel:00000300" use="HP"/>
+				<telecom value="tel:00000300" use="HV"/>
+				<telecom value="tel:00000300" use="DIR"/>
+				<telecom value="tel:00000300" use="PUB"/>
+				<telecom value="tel:00000300" use="EC"/>
+				<telecom value="tel:00000300" use="MC"/>
+				<telecom value="tel:00000300" use="PG"/>
+				<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+				<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+				<addr>
+					<houseNumber>142</houseNumber>
+					<streetName>Rue Belvédère</streetName>
+					<postalCode>92100</postalCode>
+					<city>Boulogne-Billancourt</city>
+				</addr>
+				<addr use="H">
+					<houseNumber>27</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="TMP">
+					<houseNumber>29</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="WP">
+					<houseNumber>26</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HP">
+					<houseNumber>30</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+				<addr use="HV">
+					<houseNumber>25</houseNumber>
+					<streetNameType>Av</streetNameType>
+					<streetName>de Breteuil</streetName>
+					<additionalLocator nullFlavor="NA"/>
+					<postalCode>75007</postalCode>
+					<city>PARIS</city>
+					<country>FRANCE</country>
+				</addr>
+			</scopingOrganization>
+		</associatedEntity>
+	</participant>
+
+	<!-- [0..*] Association du document à une prescription -->
+	<inFulfillmentOf>
+		<order>      
+			<!-- Order Place Number : Numéro de la demande attribué par le demandeur -->
+			<id root="1.2.250.1.748.12345678.12" extension="984375862"/>
+			<!-- Accession Number -->
+			<ps3-20:accessionNumber root="1.2.250.1.925.994044785528.27" extension="105234751"/>     
+		</order>
+	</inFulfillmentOf>
+	
+	<!-- [0..*] Demande d'acte d'imagerie correspondante -->
+	<inFulfillmentOf>
+		<order>
+			<!-- Order Place Number : Numéro de la demande attribué par le demandeur -->
+			<id root="1.2.250.1.748.12345678.12" extension="984375863"/>
+			<!-- Accession Number -->
+			<ps3-20:accessionNumber root="1.2.250.1.925.994044785528.27" extension="105234752"/>
+		</order>
+	</inFulfillmentOf>
+	
+	<!-- Informations sur sur le document -->
+	<documentationOf>
+		<serviceEvent>			
+			<code code="34117-2" displayName="Historique et clinique"
+				codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+			<effectiveTime>
+				<low value="2023020911700+0100"/>
+			</effectiveTime>
+			<performer typeCode="PRF">
+				<assignedEntity>
+					<!-- N° RPPS du PS -->
+					<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+					<addr nullFlavor="NASK"/>
+					<telecom nullFlavor="NASK"/>
+					<assignedPerson>
+						<name>
+							<given>Charles </given>
+							<family>BOILEAU</family>
+							<prefix>M</prefix>
+							<suffix>DR</suffix>
+						</name>
+					</assignedPerson>
+					<!-- Numéro FINESS de l'ES  -->
+					<representedOrganization>
+						<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+						<name>Centre de soins du Belvédère</name>
+						<telecom value="tel:0111111111"/>
+						<telecom value="tel:0442515151" use="WP"/>
+						<telecom value="tel:00000300" use="H"/>
+						<telecom value="tel:00000300" use="HP"/>
+						<telecom value="tel:00000300" use="HV"/>
+						<telecom value="tel:00000300" use="DIR"/>
+						<telecom value="tel:00000300" use="PUB"/>
+						<telecom value="tel:00000300" use="EC"/>
+						<telecom value="tel:00000300" use="MC"/>
+						<telecom value="tel:00000300" use="PG"/>
+						<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+						<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+						<addr>
+							<houseNumber>142</houseNumber>
+							<streetName>Rue Belvédère</streetName>
+							<postalCode>92100</postalCode>
+							<city>Boulogne-Billancourt</city>
+						</addr>
+						<addr use="H">
+							<houseNumber>27</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="TMP">
+							<houseNumber>29</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="WP">
+							<houseNumber>26</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HP">
+							<houseNumber>30</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HV">
+							<houseNumber>25</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<standardIndustryClassCode code="ETABLISSEMENT"
+							displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+							codeSystemName="practiceSettingCode"/>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+
+	<!-- Acte documenté (CT Tête) -->
+	<documentationOf>
+		<serviceEvent classCode="ACT">
+			<!-- [1..1] Identifiant de l'examen (DICOM Study Instance UID)-->
+			<id root="E6D40CB0-8500-11EC-A8A3-0242AC120002"/>
+			<!-- [1..1] Code de l'acte documenté -->
+			<code code="24727-0"  displayName="CT Head W contrast IV"  codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+				<!-- [0..1] code CCAM de l'acte documenté  --> 
+				<translation code="ACQH004"  displayName="Scanographie du crâne, de son contenu et du tronc, avec injection intraveineuse de produit de contraste" 
+					codeSystem="1.2.250.1.213.2.5" codeSystemName="CCAM"/>
+				<!-- [1..*] Modalité d'imagerie : Valeur issue du JDV_ModaliteAcquisition-CISIS (1.2.250.1.213.1.1.5.618) -->
+				<translation code="CT" displayName="Tomodensitométrie" codeSystem="1.2.840.10008.2.16.4" codeSystemName="DCM">
+					<qualifier>
+						<name code="121139" displayName="Modalité d'imagerie" codeSystem="1.2.840.10008.2.16.4" codeSystemName="DCM"/>
+					</qualifier>
+				</translation>
+				<!-- [0..*] Région anatomique : Valeur issue du JDV_RegionAnatomique-CISIS (1.2.250.1.213.1.1.5.695) --> 
+				<translation code="69536005" displayName="tête" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+					<qualifier>
+						<name code="39111-0" displayName="localisation anatomique" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					</qualifier>
+				</translation>
+			</code>
+			<effectiveTime>
+				<!-- Date (et heure) de début d'exécution -->
+				<low value="20210108102500+0100"/>
+				<!-- Date (et heure) de fin d'exécution -->
+				<high value="20210108111700+0100" />
+			</effectiveTime>
+			<!-- [1..1] PS exécutant : Radiologue -->
+			<performer typeCode="PRF">
+				<assignedEntity>
+					<id root="1.2.250.1.71.4.2.1" extension="801234560801"/>
+					<code code="G15_10/SM44" displayName="Médecin - Radio-diagnostic (SM)"
+						codeSystem="1.2.250.1.213.1.1.4.5"/>
+					<telecom value="tel:0111111111"/>
+					<telecom value="tel:0442515151" use="WP"/>
+					<telecom value="tel:00000300" use="H"/>
+					<telecom value="tel:00000300" use="HP"/>
+					<telecom value="tel:00000300" use="HV"/>
+					<telecom value="tel:00000300" use="DIR"/>
+					<telecom value="tel:00000300" use="PUB"/>
+					<telecom value="tel:00000300" use="EC"/>
+					<telecom value="tel:00000300" use="MC"/>
+					<telecom value="tel:00000300" use="PG"/>
+					<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+					<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+					<addr>
+						<houseNumber>142</houseNumber>
+						<streetName>Rue Belvédère</streetName>
+						<postalCode>92100</postalCode>
+						<city>Boulogne-Billancourt</city>
+					</addr>
+					<addr use="H">
+						<houseNumber>27</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="TMP">
+						<houseNumber>29</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="WP">
+						<houseNumber>26</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HP">
+						<houseNumber>30</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HV">
+						<houseNumber>25</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<assignedPerson>
+						<name>
+							<prefix>M</prefix>
+							<given>Jacques</given>
+							<family>BIDEAULT</family>
+							<suffix>DR</suffix>
+						</name>
+					</assignedPerson>
+					<representedOrganization>
+						<!-- [1..1] Identifiant de l'établissement : obligatoire pour la DRIM Box -->
+						<id root="1.2.250.1.71.4.2.2" extension="101235555"/>
+						<name>Centre de radiologie Ambroise</name>
+						<telecom value="tel:0111111111"/>
+						<telecom value="tel:0442515151" use="WP"/>
+						<telecom value="tel:00000300" use="H"/>
+						<telecom value="tel:00000300" use="HP"/>
+						<telecom value="tel:00000300" use="HV"/>
+						<telecom value="tel:00000300" use="DIR"/>
+						<telecom value="tel:00000300" use="PUB"/>
+						<telecom value="tel:00000300" use="EC"/>
+						<telecom value="tel:00000300" use="MC"/>
+						<telecom value="tel:00000300" use="PG"/>
+						<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+						<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+						<addr>
+							<houseNumber>142</houseNumber>
+							<streetName>Rue Belvédère</streetName>
+							<postalCode>92100</postalCode>
+							<city>Boulogne-Billancourt</city>
+						</addr>
+						<addr use="H">
+							<houseNumber>27</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="TMP">
+							<houseNumber>29</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="WP">
+							<houseNumber>26</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HP">
+							<houseNumber>30</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HV">
+							<houseNumber>25</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<standardIndustryClassCode code="AMBULATOIRE" displayName="Ambulatoire"
+							codeSystem="1.2.250.1.213.1.1.4.9"/>
+					</representedOrganization>
+				</assignedEntity>
+			</performer>
+		</serviceEvent>
+	</documentationOf>
+	
+	<!-- Document remplacé -->
+	<relatedDocument typeCode="RPLC">
+		<parentDocument>
+			<!-- Identifiant du document remplacé -->
+			<id root="1.2.250.1.213.1.1.1.13.1.1"/>
+			<versionNumber value="1"/>
+		</parentDocument>
+	</relatedDocument>
+	
+	<!-- Non-opposition du patient pour une réutilisation des données -->  
+	<authorization typeCode="AUTH">
+		<consent  classCode="CONS" moodCode="EVN">
+			<code code="64292-6" displayName="Non-opposition du patient pour réutilisation des données" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+			<statusCode code="completed"/>
+		</consent>
+	</authorization>
+	
+	<!-- Prise en charge -->
+	<componentOf>
+		<encompassingEncounter>
+			<code code="EXTERNE" displayName="acte et consultation externe (établissement)"
+				codeSystem="1.2.250.1.213.1.1.4.2.291"/>
+			<effectiveTime>
+				<high value="2023020911700+0100"/>
+			</effectiveTime>
+			<!-- Responsable de la prise en charge -->
+			<responsibleParty>
+				<assignedEntity>
+					<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+					<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+						displayName="Médecin - Qualifié en Médecin Générale (SM)"/>
+					<telecom value="tel:0111111111"/>
+					<telecom value="tel:0442515151" use="WP"/>
+					<telecom value="tel:00000300" use="H"/>
+					<telecom value="tel:00000300" use="HP"/>
+					<telecom value="tel:00000300" use="HV"/>
+					<telecom value="tel:00000300" use="DIR"/>
+					<telecom value="tel:00000300" use="PUB"/>
+					<telecom value="tel:00000300" use="EC"/>
+					<telecom value="tel:00000300" use="MC"/>
+					<telecom value="tel:00000300" use="PG"/>
+					<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+					<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+					<addr>
+						<houseNumber>142</houseNumber>
+						<streetName>Rue Belvédère</streetName>
+						<postalCode>92100</postalCode>
+						<city>Boulogne-Billancourt</city>
+					</addr>
+					<addr use="H">
+						<houseNumber>27</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="TMP">
+						<houseNumber>29</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="WP">
+						<houseNumber>26</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HP">
+						<houseNumber>30</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HV">
+						<houseNumber>25</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<assignedPerson>
+						<name>
+							<prefix>M</prefix>
+							<suffix>DR</suffix>
+							<given>Charles </given>
+							<family>BOILEAU</family>
+						</name>
+					</assignedPerson>
+					<representedOrganization>
+						<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+						<name>Centre de soins du Belvédère</name>
+						<telecom value="tel:0111111111"/>
+						<telecom value="tel:0442515151" use="WP"/>
+						<telecom value="tel:00000300" use="H"/>
+						<telecom value="tel:00000300" use="HP"/>
+						<telecom value="tel:00000300" use="HV"/>
+						<telecom value="tel:00000300" use="DIR"/>
+						<telecom value="tel:00000300" use="PUB"/>
+						<telecom value="tel:00000300" use="EC"/>
+						<telecom value="tel:00000300" use="MC"/>
+						<telecom value="tel:00000300" use="PG"/>
+						<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+						<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+						<addr>
+							<houseNumber>142</houseNumber>
+							<streetName>Rue Belvédère</streetName>
+							<postalCode>92100</postalCode>
+							<city>Boulogne-Billancourt</city>
+						</addr>
+						<addr use="H">
+							<houseNumber>27</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="TMP">
+							<houseNumber>29</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="WP">
+							<houseNumber>26</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HP">
+							<houseNumber>30</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HV">
+							<houseNumber>25</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<standardIndustryClassCode code="ETABLISSEMENT"
+							displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+							codeSystemName="practiceSettingCode"/>
+					</representedOrganization>
+				</assignedEntity>
+			</responsibleParty>
+			<!-- PS impliqué (Responsable de l'admission du patient) : N'est pas affiché par la feuille de style -->
+			<encounterParticipant typeCode="ADM">
+				<time value="20200331"/>
+				<assignedEntity>
+					<id root="1.2.250.1.71.4.2.1" extension="801234567583"/>
+					<code code="G15_10/SM26" codeSystem="1.2.250.1.213.1.1.4.5"
+						displayName="Médecin - Qualifié en Médecin Générale (SM)"/>
+					<telecom value="tel:0111111111"/>
+					<telecom value="tel:0442515151" use="WP"/>
+					<telecom value="tel:00000300" use="H"/>
+					<telecom value="tel:00000300" use="HP"/>
+					<telecom value="tel:00000300" use="HV"/>
+					<telecom value="tel:00000300" use="DIR"/>
+					<telecom value="tel:00000300" use="PUB"/>
+					<telecom value="tel:00000300" use="EC"/>
+					<telecom value="tel:00000300" use="MC"/>
+					<telecom value="tel:00000300" use="PG"/>
+					<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+					<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+					<addr>
+						<houseNumber>142</houseNumber>
+						<streetName>Rue Belvédère</streetName>
+						<postalCode>92100</postalCode>
+						<city>Boulogne-Billancourt</city>
+					</addr>
+					<addr use="H">
+						<houseNumber>27</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="TMP">
+						<houseNumber>29</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="WP">
+						<houseNumber>26</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HP">
+						<houseNumber>30</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<addr use="HV">
+						<houseNumber>25</houseNumber>
+						<streetNameType>Av</streetNameType>
+						<streetName>de Breteuil</streetName>
+						<additionalLocator nullFlavor="NA"/>
+						<postalCode>75007</postalCode>
+						<city>PARIS</city>
+						<country>FRANCE</country>
+					</addr>
+					<assignedPerson>
+						<name>
+							<prefix>M</prefix>
+							<suffix>DR</suffix>
+							<given>Pierre </given>
+							<family>DULOUP</family>
+						</name>
+					</assignedPerson>
+					<representedOrganization>
+						<id root="1.2.250.1.71.4.2.2" extension="101238887"/>
+						<name>Centre de soins du Belvédère</name>
+						<telecom value="tel:0111111111"/>
+						<telecom value="tel:0442515151" use="WP"/>
+						<telecom value="tel:00000300" use="H"/>
+						<telecom value="tel:00000300" use="HP"/>
+						<telecom value="tel:00000300" use="HV"/>
+						<telecom value="tel:00000300" use="DIR"/>
+						<telecom value="tel:00000300" use="PUB"/>
+						<telecom value="tel:00000300" use="EC"/>
+						<telecom value="tel:00000300" use="MC"/>
+						<telecom value="tel:00000300" use="PG"/>
+						<telecom value="mailto:277076322082955@patient.mssante.fr"/>
+						<telecom value="mailto:277076322082965@patient.mssante.fr" use="H"/>
+						<addr>
+							<houseNumber>142</houseNumber>
+							<streetName>Rue Belvédère</streetName>
+							<postalCode>92100</postalCode>
+							<city>Boulogne-Billancourt</city>
+						</addr>
+						<addr use="H">
+							<houseNumber>27</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="TMP">
+							<houseNumber>29</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="WP">
+							<houseNumber>26</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HP">
+							<houseNumber>30</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<addr use="HV">
+							<houseNumber>25</houseNumber>
+							<streetNameType>Av</streetNameType>
+							<streetName>de Breteuil</streetName>
+							<additionalLocator nullFlavor="NA"/>
+							<postalCode>75007</postalCode>
+							<city>PARIS</city>
+							<country>FRANCE</country>
+						</addr>
+						<standardIndustryClassCode code="ETABLISSEMENT"
+							displayName="Établissement de santé" codeSystem="1.2.250.1.213.1.1.4.9"
+							codeSystemName="practiceSettingCode"/>
+					</representedOrganization>
+				</assignedEntity>
+			</encounterParticipant>
+			<location>
+				<healthCareFacility>
+					<id root="1.2.250.1.213.1.1.9" extension="11223344"
+						assigningAuthorityName="Centre de Soins du belvédère"/>
+					<code code="SA04" displayName="Etablissement Privé Non PSPH"
+						codeSystem="1.2.250.1.71.4.2.4" codeSystemName="R02"> </code>
+				</healthCareFacility>
+			</location>
+		</encompassingEncounter>
+	</componentOf>
+
+	<!-- 
+      ********************************************************
+      Corps du document
+      ********************************************************
+	-->
+	<component>
+		<structuredBody>
+
+			<!-- Section FR-Problemes-actifs -->
+			<component>
+				<section>
+					<!-- Conformité Problems Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.11" />
+					<!-- Conformité Active Problems Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.6" />
+					<!-- Conformité FR-Problemes-actifs (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.132" />
+					<id root="E52A7B75-3B12-44DF-80B3-3DEA64E25B4B"/>
+					<code code="11450-4" displayName="Liste des problèmes actifs"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Problèmes actifs</title>					
+					<!-- Bloc narratif de la section -->
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date de début</th>
+									<th>Type d'observation</th>                                
+									<th>Problème</th>                                      
+									<th>Sévérité</th>                          
+									<th>Statut du problème</th>                          
+									<th>Statut clinique du patient</th>                   
+									<th>Certitude</th>                  
+									<th>Commentaire</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>26/06/2021</td>
+									<td><content ID="problem-001-type">interprétation diagnostique</content></td>                                
+									<td><content ID="problem-001-pb">Accident ischémique cérébral transitoire</content></td>                             
+									<td><content ID="problem-001-severite">Modéré</content></td>                             
+									<td><content ID="problem-001-statut-probleme">Active</content></td>                                 
+									<td><content ID="problem-001-statut-clinique">Asymptomatique</content></td>                                  
+									<td><content ID="problem-001-certitude">Confirmé</content></td>                          
+									<td><content ID="problem-001-comment">(texte libre)</content></td> 
+								</tr>
+								<tr>
+									<td>08/12/2019</td>
+									<td><content ID="problem-002-type">interprétation diagnostique</content></td>                                
+									<td><content ID="problem-002-pb">Angine de poitrine instable</content></td>                              
+									<td><content ID="problem-002-severite">Modéré</content></td>                             
+									<td><content ID="problem-002-statut-probleme">Active</content></td>                           
+									<td><content ID="problem-002-statut-clinique">Asymptomatique</content></td>                                  
+									<td><content ID="problem-002-certitude">Non confirmé</content></td>                                                                 
+									<td><content ID="problem-002-comment">(texte libre)</content></td> 
+								</tr>
+							</tbody>
+						</table>
+					</text>
+
+					<!-- [1..*] Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="cdbd5b08-6cde-11db-9fe1-0800200c9a66"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor="MSK"/>
+								<high nullFlavor="MSK"/>
+							</effectiveTime>
+							
+							<!-- Entrée FR-Probleme (AIT) -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+									<code code="282291009" displayName="interprétation diagnostique" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text>
+										<reference value="#problem-001-type"/>
+									</text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low value="20210626"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="G45.9" displayName="Accident Ischémique Cérébral Transitoire"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#problem-001-pb"/></originalText>
+									</value>
+									<!-- FR-Severite -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Severity observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.55" />
+											<!-- Conformité Severity Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1" />
+											<!-- Conformité FR-Severite (FR CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.29" />
+											<code code="SEV" displayName="Sévérité"
+												codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+											<text><reference value="#problem-001-severite"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="6736007" displayName="modéré" 
+												   codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Statut-du-probleme -->
+									<entryRelationship typeCode="REFR">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem status observation (CCD) --> 
+											<templateId root="2.16.840.1.113883.10.20.1.50" />
+											<!-- Conformité Status observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.57" />
+											<!-- Conformité Problem Status Observation (IHE PCC) --> 
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1.1" />
+											<!-- Conformité FR-Statut-du-probleme (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.30" />
+											<code code="33999-4" displayName="Status"
+												codeSystem="2.16.840.1.113883.6.1"/>
+											<text><reference value="#problem-001-statut-probleme"/></text>
+											<statusCode code="completed"/>
+											<!-- valeur issue du JDV_HL7_ConditionClinical-CISIS (2.16.840.1.113883.4.642.3.164) -->
+											<value xsi:type="CE" code="active" displayName="Actif" codeSystem="2.16.840.1.113883.4.642.1.1074" codeSystemName="HL7:condition-clinical"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Statut-clinique-du-patient -->
+									<entryRelationship typeCode="REFR" inversionInd="false">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem healthstatus observation (CCD) --> 
+											<templateId root="2.16.840.1.113883.10.20.1.51" />
+											<!-- Conformité Health Status Observation (IHE PCC) --> 
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1.2" />
+											<!-- Conformité FR-Statut-clinique-du-patient (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.31" />
+											<code code="11323-3" displayName="Statut clinique du patient"
+												codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+											<text><reference value="#problem-001-statut-clinique"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CE" code="162467007" displayName="asymptomatique"
+												codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Certitude -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">											
+											<!-- Conformité FR-Certitude (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.171"/>
+											<code code="66455-7" displayName="Certitude"
+												codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+											<text><reference value="#problem-001-certitude"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CE" code="confirmed" displayName="Confirmé"
+												codeSystem="2.16.840.1.113883.4.642.4.1075" codeSystemName="HL7:condition-ver-status"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Commentaire-ER -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<act classCode="ACT" moodCode="EVN">
+											<!-- Conformité Comment (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.40" />
+											<!-- Conformité Comment Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+											<!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.32" />
+											<code code="48767-8" displayName="Commentaire"
+												codeSystem="2.16.840.1.113883.6.1"
+												codeSystemName="LOINC"/>
+											<text><reference value="#problem-001-comment"/></text>
+											<statusCode code="completed"/>
+										</act>
+									</entryRelationship>
+								</observation>								
+							</entryRelationship>
+							
+							<!-- Entrée FR-Probleme (Angine de Poitrine instable) -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12DA3A06-18E7-40B7-9397-1FA5B1552472"/>
+									<code code="282291009" displayName="interprétation diagnostique" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#problem-002-type"/></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low value="20190812"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="I20.0" displayName="Angine de poitrine instable"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#problem-002-pb"/></originalText>
+									</value>
+									<!-- FR-Severite -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Severity observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.55" />
+											<!-- Conformité Severity Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1" />
+											<!-- Conformité FR-Severite (FR CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.29" />
+											<code code="SEV" displayName="Sévérité"
+												codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+											<text><reference value="#problem-002-severite"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CD" code="6736007" displayName="modéré" 
+												codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Statut-du-probleme -->
+									<entryRelationship typeCode="REFR">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem status observation (CCD) --> 
+											<templateId root="2.16.840.1.113883.10.20.1.50" />
+											<!-- Conformité Status observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.57" />
+											<!-- Conformité Problem Status Observation (IHE PCC) --> 
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1.1" />
+											<!-- Conformité FR-Statut-du-probleme (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.30" />
+											<code code="33999-4" displayName="Status"
+												codeSystem="2.16.840.1.113883.6.1"/>
+											<text><reference value="#problem-002-statut-probleme"/></text>
+											<statusCode code="completed"/>
+											<!-- valeur issue du JDV_HL7_ConditionClinical-CISIS (2.16.840.1.113883.4.642.3.164) -->
+											<value xsi:type="CE" code="active" displayName="Actif" codeSystem="2.16.840.1.113883.4.642.1.1074" codeSystemName="HL7:condition-clinical"/>
+										</observation>
+									</entryRelationship>									
+									<!-- FR-Statut-clinique-du-patient -->
+									<entryRelationship typeCode="REFR" inversionInd="false">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem healthstatus observation (CCD) --> 
+											<templateId root="2.16.840.1.113883.10.20.1.51" />
+											<!-- Conformité Health Status Observation (IHE PCC) --> 
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1.2" />
+											<!-- Conformité FR-Statut-clinique-du-patient (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.31" />
+											<code code="11323-3" displayName="Statut clinique du patient"
+												codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+											<text><reference value="#problem-002-statut-clinique"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CE" code="162467007" displayName="asymptomatique"
+												codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Certitude -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN">											
+											<!-- Conformité FR-Certitude (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.171"/>
+											<code code="66455-7" displayName="Certitude"
+												codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+											<text><reference value="#problem-002-certitude"/></text>
+											<statusCode code="completed"/>
+											<value xsi:type="CE" code="unconfirmed" displayName="Non confirmé"
+												codeSystem="2.16.840.1.113883.4.642.4.1075" codeSystemName="HL7:condition-ver-status"/>
+										</observation>
+									</entryRelationship>
+									<!-- FR-Commentaire-ER -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<act classCode="ACT" moodCode="EVN">
+											<!-- Conformité Comment (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.40" />
+											<!-- Conformité Comment Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+											<!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.32" />
+											<code code="48767-8" displayName="Commentaire"
+												codeSystem="2.16.840.1.113883.6.1"
+												codeSystemName="LOINC"/>
+											<text><reference value="#problem-002-comment"/></text>
+											<statusCode code="completed"/>
+										</act>
+									</entryRelationship>
+								</observation>								
+							</entryRelationship>
+							
+						</act>
+					</entry>
+					
+				</section>
+			</component>
+
+			<!-- Section FR-Problemes-actifs : Pas d'information -->
+			<component>
+				<section>
+					<!-- Conformité Problems Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.11" />
+					<!-- Conformité Active Problems Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.6" />
+					<!-- Conformité FR-Problemes-actifs (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.132" />
+					<id root="E52A7B75-3B12-44DF-80B3-3DEA64E25B4B"/>
+					<code code="11450-4" displayName="Liste des problèmes actifs"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Problèmes actifs</title>					
+					<text ID="MED-UNK">Pas d'information</text>
+					<!-- Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor ="UNK"/>
+								<high nullFlavor ="UNK"/>
+							</effectiveTime>
+							<!-- Entrée FR-Probleme -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#MED-UNK"></reference></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low nullFlavor ="UNK"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="no-problem-info" 
+										displayName="Pas d'information sur les problèmes"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">										
+										<originalText><reference value="#MED-UNK"></reference></originalText>
+									</value>
+								</observation>
+							</entryRelationship>							
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Problemes-actifs : Aucun problème actif -->
+			<component>
+				<section>
+					<!-- Conformité Problems Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.11" />
+					<!-- Conformité Active Problems Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.6" />
+					<!-- Conformité FR-Problemes-actifs (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.132" />
+					<id root="E52A7B75-3B12-44DF-80B3-3DEA64E25B4B"/>
+					<code code="11450-4" displayName="Liste des problèmes actifs"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Problèmes actifs</title>					
+					<text ID="NO-PROBLEM">Aucune pathologie en cours</text>
+					<!-- Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor="UNK"/>
+								<high nullFlavor="UNK"/>
+							</effectiveTime>
+							<!-- Entrée FR-Probleme -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#NO-PROBLEM"></reference></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low nullFlavor ="UNK"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="no-known-problems" displayName="Pas de problème connu"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">										
+										<originalText><reference value="#NO-PROBLEM"></reference></originalText>
+									</value>
+								</observation>
+							</entryRelationship>							
+						</act>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Antecedents-medicaux -->
+			<component>
+				<section>
+					<!-- Conformité History of Past Illness (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.8" />
+					<!-- Conformité FR-Antecedents-medicaux (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.134" />
+					<id root="8eb396a9-79a4-4716-bf9d-38f5ce2652e3"/>
+					<code code="11348-0" displayName="Antécédents médicaux"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents Médicaux</title>
+					<!-- Bloc narratif de la section -->
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date de début</th>
+									<th>Date de fin</th>
+									<th>Type d'observation</th>                                
+									<th>Problème</th>                      
+									<th>Commentaire</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>11/08/2019</td>
+									<td>inconnue</td>
+									<td><content ID="ant-med-002-type">interprétation diagnostique</content></td>                                
+									<td><content ID="ant-med-002-pb">Pyélonéphrite aiguë</content></td>                                                 
+									<td><content ID="ant-med-002-comment">(texte libre)</content></td> 
+								</tr>
+								<tr>
+									<td>23/06/2014</td>
+									<td>05/09/2014</td>
+									<td><content ID="ant-med-001-type">interprétation diagnostique</content></td>                                
+									<td><content ID="ant-med-001-pb">Infarctus transmural inférieur</content></td>             
+									<td><content ID="ant-med-001-comment">(texte libre)</content></td> 
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					
+					<!-- Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="D3DCE1E0-EB52-47CB-8507-D33F0041D138"/>
+							<code nullFlavor="NA"/>
+							<text/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low value="20190811"/>
+								<high value="20190811"/>
+							</effectiveTime>
+							
+							<!-- [1..*] Entrée FR-Probleme (Pyélonéphrite aiguë) -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="21872220-FBDF-4BCC-85B1-61D1BBB420A5"/>
+									<code code="282291009" displayName="interprétation diagnostique" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#ant-med-002-type"/></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low value="20190811"/>
+										<high nullFlavor="UNK"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="N10" displayName="Pyélonéphrite aiguë"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#ant-med-002-pb"/></originalText>
+									</value>
+									<!-- FR-Commentaire-ER -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<act classCode="ACT" moodCode="EVN">
+											<!-- Conformité Comment (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.40" />
+											<!-- Conformité Comment Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+											<!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.32" />
+											<code code="48767-8" displayName="Commentaire"
+												codeSystem="2.16.840.1.113883.6.1"
+												codeSystemName="LOINC"/>
+											<text><reference value="#ant-med-002-comment"/></text>
+											<statusCode code="completed"/>
+										</act>
+									</entryRelationship>
+								</observation>
+							</entryRelationship>
+						
+							<!-- [1..*] Entrée FR-Probleme (Infarctus inférieur transmural) -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="fc21dc59-43d5-4bb0-acc7-3601784bfbc0"/>
+									<code code="282291009" displayName="interprétation diagnostique" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text>
+										<reference value="#ant-med-001-type"/>
+									</text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low value="20140623"/>
+										<high value="20140905"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="I21.1" displayName="Infarctus transmural inférieur"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#ant-med-001-pb"/></originalText>
+									</value>
+									<!-- FR-Commentaire-ER -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<act classCode="ACT" moodCode="EVN">
+											<!-- Conformité Comment (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.40" />
+											<!-- Conformité Comment Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+											<!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.32" />
+											<code code="48767-8" displayName="Commentaire"
+												codeSystem="2.16.840.1.113883.6.1"
+												codeSystemName="LOINC"/>
+											<text><reference value="#ant-med-001-comment"/></text>
+											<statusCode code="completed"/>
+										</act>
+									</entryRelationship>
+								</observation>
+							</entryRelationship>
+							
+						</act>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Antecedents-medicaux : Pas d'information -->
+			<component>
+				<section>
+					<!-- Conformité History of Past Illness (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.8" />
+					<!-- Conformité FR-Antecedents-medicaux (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.134" />
+					<id root="8eb396a9-79a4-4716-bf9d-38f5ce2652e3"/>
+					<code code="11348-0" displayName="Antécédents médicaux"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents Médicaux</title>
+					<text ID="PAST-MED-UNK">Pas d'information</text>
+					<!-- Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor="UNK"/>
+								<high nullFlavor="UNK"/>
+							</effectiveTime>
+							<!-- Entrée Problème -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#PAST-MED-UNK"></reference></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low nullFlavor ="UNK"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="no-problem-info" 
+										displayName="Pas d'information sur les problèmes"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">
+										<originalText><reference value="#PAST-MED-UNK"></reference></originalText>
+									</value>
+								</observation>
+							</entryRelationship>							
+						</act>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Antecedents-medicaux : Aucun antécédent -->
+			<component>
+				<section>
+					<!-- Conformité History of Past Illness (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.8" />
+					<!-- Conformité FR-Antecedents-medicaux (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.134" />
+					<id root="8eb396a9-79a4-4716-bf9d-38f5ce2652e3"/>
+					<code code="11348-0" displayName="Antécédents médicaux"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents médicaux</title>
+					<text ID="NO-PAST-MED">Aucun antécédent médical</text>
+					
+					<!-- Entrée FR-Liste-des-problemes -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27" />
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1" />
+							<!-- Conformité Problem Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.2" />
+							<!-- Conformité FR-Liste-des-problemes (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.39" />
+							<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor ="UNK"/>
+								<high nullFlavor ="UNK"/>
+							</effectiveTime>
+							
+							<!-- Entrée Problème -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="true">
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28" />
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+									<!-- Conformité FR-Probleme (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.37" />
+									<id root="12da3a06-18e7-40b7-9397-1fa5b1552472"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#NO-PAST-MED"></reference></text>
+									<statusCode code="completed"/>
+									<effectiveTime>
+										<low nullFlavor ="UNK"/>
+									</effectiveTime>
+									<value xsi:type="CD" code="no-known-problems" displayName="Pas de problème connu"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">
+										<originalText><reference value="#NO-PAST-MED"></reference></originalText>
+									</value>
+								</observation>
+							</entryRelationship>							
+						</act>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Antecedents-chirurgicaux -->
+			<component>
+				<section>
+					<!-- Conformité CCD -->
+					<templateId root="2.16.840.1.113883.10.20.1.12"/>
+					<!-- Conformité IHE PCC Antécédents chirurgicaux non codes -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.11"/>
+					<!-- Conformité IHE PCC -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.12"/>
+					<!-- Conformité CI-SIS -->
+					<templateId root="1.2.250.1.213.1.1.2.136"/>
+					<id root="6F7DBEC2-0E15-48F0-B61E-00B0753BFCAD"/>
+					<code code="47519-4" displayName="Historique des actes chirurgicaux"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents chirurgicaux</title>
+					<!-- Bloc narratif de la section -->
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Acte</th>                         
+									<th>Motif</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>12/08/1999</td>
+									<td><content ID="ant-chir-001-act">Dilatation intraluminale de deux
+										vaisseaux coronaires avec pose d'endoprothèse, par voie
+										artérielle transcutanée</content></td>                                                 
+									<td><content ID="ant-chir-001-motif">Infarctus inférieur transmural</content></td> 
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					
+					<!-- [1..*] Entrée FR-Acte -->
+					<entry>
+						<procedure classCode="PROC" moodCode="EVN">
+							<!-- Conformité CCD -->
+							<templateId root="2.16.840.1.113883.10.20.1.29"/>
+							<!-- Conformité IHE PCC -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.19"/>
+							<!-- Conformité CI-SIS -->
+							<templateId root="1.2.250.1.213.1.1.3.62"/>
+							<id root="a6bc7fd2-ec3f-4e01-b567-854b087d1d9b"/>
+							<code code="DDAF004"
+								displayName="'Dilatation intraluminale de deux vaisseaux coronaires avec pose d'endoprothèse, par voie artérielle transcutanée"
+								codeSystem="1.2.250.1.213.2.5" codeSystemName="CCAM"/>
+							<text><reference value="#ant-chir-001-act"/></text>
+							<statusCode code="completed"/>
+							<effectiveTime value="20190812"/>
+							<!-- Priorité de l'acte  -->
+							<priorityCode code="UR" displayName="Urgent"
+								codeSystem="2.16.840.1.113883.5.7" codeSystemName="HL7:ActPriority"/>
+							<!-- Voie d'abord -->
+							<approachSiteCode code="F" displayName="ACCÈS INTRALUMINAL TRANSPARIÉTAL"
+								codeSystem="1.2.250.1.213.2.5" codeSystemName="CCAM"/>
+							<!-- Localisation anatomique -->
+							<targetSiteCode code="DD" displayName="Artères coronaires "
+								codeSystem="1.2.250.1.213.2.5" codeSystemName="CCAM"/>
+							<!-- Auteur -->
+							<author>
+								<time value="20190812"/>
+								<assignedAuthor>
+									<id nullFlavor="UNK"/>
+									<addr nullFlavor="NAV"/>
+									<telecom nullFlavor="NAV"/>
+									<assignedPerson>
+										<name>
+											<prefix>M</prefix>
+											<given>Jacques</given>
+											<family>PETITJEAN</family>
+											<suffix>PR</suffix>
+										</name>
+									</assignedPerson>
+									<representedOrganization>
+										<name>Hôpital Lariboisière</name>
+										<addr nullFlavor="NAV"/>
+									</representedOrganization>
+								</assignedAuthor>
+							</author>
+							<!-- Entrée FR-Reference-interne : Motif de l'acte -->
+							<entryRelationship typeCode="RSON" inversionInd="false">
+								<act classCode="ACT" moodCode="EVN">
+									<!-- Conformité IHE PCC -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.4.1"/>
+									<!-- Conformité CI-SIS -->
+									<templateId root="1.2.250.1.213.1.1.3.36"/>
+									<!-- Id de l'entrée Etat clinique correspondante -->
+									<id root="fc21dc59-43d5-4bb0-acc7-3601784bfbc0"/>
+									<code code="I21.1" displayName="Infarctus transmural inférieur"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#ant-chir-001-motif"/></originalText>
+									</code>
+								</act>
+							</entryRelationship>
+						</procedure>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Allergies-et-hypersensibilites -->
+			<component>
+				<section>
+					<!-- Conformité Alerts Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.2"/>
+					<!-- Conformité Allergies and Other Adverse Reactions Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.13"/>
+					<!-- Conformité FR-Allergies-et-hypersensibilites (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.137"/>
+					<id root="7649c5fa-a444-49a6-91e9-78d2e5880c67"/>
+					<code code="48765-2" displayName="Allergies et hypersensibilités"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Allergies et hypersensibilités</title>
+					<!-- Partie narrative de la section -->
+					<text>
+						<table>
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Type d'allergie</th>
+									<th>Agent responsable</th>
+									<th>Statut</th>
+									<th>Criticité</th>
+									<th>Certitude</th>
+									<th>Réaction(s)</th>
+									<th>Sévérité réaction(s)</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>03/06/2018</td>
+									<td>
+										<content ID="allergie-01-type">Allergie médicamenteuse</content>
+									</td>
+									<td>
+										<content ID="allergie-01-agent">Paracétamol</content>
+									</td>         
+									<td>
+										<content ID="allergie-01-statut-01">Actif</content>
+									</td>
+									<td>Bas</td>
+									<td>Confirmé</td>
+									<td>
+										<content ID="allergie-01-reaction-1">Bronchospasme d'origine médicamenteuse</content><br/>                    
+										<content ID="allergie-01-reaction-2">Troubles allergiques ou d'hypersensibilité de la peau ou des muqueuses</content>
+									</td>
+									<td>
+										<content ID="allergie-01-reaction-1-severite">modéré</content><br/>                 
+										<content ID="allergie-01-reaction-2-severite">léger</content>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+
+					<!-- Entrée FR-Liste-des-allergies-et-hypersensibilites -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27"/>
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1"/>
+							<!-- Conformité Allergy and Intolerance Concern (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.3"/>
+							<!-- Conformité FR-Liste-des-allergies-et-hypersensibilites (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.40"/>
+							<id root="1269C206-4D59-4A9D-AA2D-AA0C4622D525" />
+							<code nullFlavor="NA"/>
+							<statusCode code="active" />
+							<!-- Date de début et de fin du problème -->
+							<effectiveTime>
+								<low nullFlavor="UNK" />
+							</effectiveTime>
+							<!-- [1..*] Entrée FR-Allergie-ou-hypersensibilites (PARACETAMOL) -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Alert observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.18"/>
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28"/>
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5"/>
+									<!-- Conformité Allergies And Intolerances Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.6"/>
+									<!-- Conformité FR-Allergie-ou-hypersensibilite (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.41"/>
+									<id root="C64C6013-C8AF-4938-AD10-1B7D26DEE2A0" />
+									<!-- Type d'allergie / hypersensibilité -->
+									<!-- valeur issue du JDV_HL7_ObservationIntoleranceType-CISIS (2.16.840.1.113883.1.11.19700) -->
+									<code code="DALG" displayName="Allergie médicamenteuse" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ObservationIntoleranceType" />
+									<text>
+										<reference value="#allergie-01-type"/>
+									</text>
+									<statusCode code="completed" />
+									<!-- Date de l'allergie / hypersensibilité -->
+									<effectiveTime xsi:type="IVL_TS">
+										<low value="20180603" />
+									</effectiveTime>
+									<!-- Description clinique de l'allergie / hypersensibilité : non renseigné -->
+									<value xsi:type="CD">
+										<originalText>
+											<reference value="#" />
+										</originalText>
+									</value>
+									<!-- Agent responsable de l'allergie / de l'hypersensibilité -->
+									<participant typeCode="CSM">
+										<participantRole classCode="MANU">
+											<playingEntity classCode="MMAT">
+												<code code="XM5DJ7" displayName="PARACETAMOL" 
+													codeSystem="2.16.840.1.113883.6.347" codeSystemName="CIM-11">	
+													<originalText><reference value="#allergie-01-agent" /></originalText>
+												</code>
+												<name>Paracétamol</name>
+											</playingEntity>
+										</participantRole>
+									</participant>
+									
+									<!-- Entrée FR-Statut-du-probleme : Statut clinique de l'allergie -->
+									<entryRelationship typeCode="REFR" inversionInd="false">
+										<observation classCode="OBS" moodCode="EVN" negationInd="false">
+											<!-- Conformité Problem status observation (CCD) --> 
+											<templateId root="2.16.840.1.113883.10.20.1.50" />
+											<!-- Conformité Status observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.57" />
+											<!-- Conformité Problem Status Observation (IHE PCC) --> 
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1.1" />
+											<!-- Conformité FR-Statut-du-probleme (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.30" />
+											<code code="33999-4" displayName="Status" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+											<text>
+												<reference value="#allergie-statut-01" />
+											</text>
+											<statusCode code="completed" />
+											<!-- valeur du JDV_HL7_allergyintolerance-clinical-CISIS (2.16.840.1.113883.4.642.3.1372) -->
+											<value xsi:type="CE" code="active" displayName="Actif" codeSystem="2.16.840.1.113883.4.642.4.1373" codeSystemName="HL7:allergyintolerance-clinical"/>
+										</observation>
+									</entryRelationship>   
+									
+									<!-- Entrée FR-Criticite : Criticité de l'allergie -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN" negationInd="false">       
+											<!-- Conformité FR-Criticite (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.172" />
+											<code code="82606-5" displayName="Criticité" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+											<statusCode code="completed" />
+											<!-- valeur du JDV_HL7_allergy-intolerance-criticality-CISIS (2.16.840.1.113883.4.642.3.129) -->
+											<value xsi:type="CE" code="low" displayName="Bas" 
+												codeSystem="2.16.840.1.113883.4.642.4.130" codeSystemName="HL7:allergy-intolerance-criticality"/>
+										</observation>
+									</entryRelationship>   
+									
+									<!-- Entrée FR-Certitude : Certitude de l'allergie -->
+									<entryRelationship typeCode="SUBJ" inversionInd="true">
+										<observation classCode="OBS" moodCode="EVN" negationInd="false">   
+											<!-- Conformité FR-Certitude (FR CI-SIS) --> 
+											<templateId root="1.2.250.1.213.1.1.3.171" />
+											<code code="66455-7" displayName="Certitude" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+											<statusCode code="completed" />
+											<!-- valeur du JDV_HL7_condition-ver-status-CISIS (2.16.840.1.113883.4.642.3.166) -->
+											<value xsi:type="CE" code="confirmed" displayName="Confirmé" 
+												codeSystem="2.16.840.1.113883.4.642.4.130" codeSystemName="HL7:condition-ver-status"/>
+										</observation>
+									</entryRelationship>   
+									
+									<!-- [0..*] Entrée FR-Probleme : Réaction 1 observée -->
+									<entryRelationship typeCode="MFST">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.28" />
+											<!-- Conformité Problem Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+											<!-- Conformité Reaction (IHE PCC) -->
+											<templateId root="2.16.840.1.113883.10.20.1.54" />
+											<!-- Conformité FR-Probleme (FR CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.37" />
+											<id root="C64C6013-C8AF-4938-AD10-1B7D26DEE2B1"/>
+											<code code="55607006" displayName="Problème" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+											<text><reference value="#allergie-reaction-01" /></text>
+											<statusCode code="completed" />
+											<effectiveTime xsi:type="IVL_TS">
+												<low value="20180603"/>
+											</effectiveTime>
+											<!-- valeur issue de la CIM-11 / Chapitre 04 Maladies du système immunitaire / Bloc Affections allergiques ou d'hypersensibilité -->
+											<value xsi:type="CD" code="4A80.0" displayName="Bronchospasme d'origine médicamenteuse" codeSystem="2.16.840.1.113883.6.347" codeSystemName="CIM-11">
+												<originalText>
+													<reference value="#allergie-01-reaction-1" />
+												</originalText>
+											</value>
+											<!-- [0..1] Entrée FR-Severite : Sévérité de la réaction -->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<!-- Conformité Severity observation (CCD) -->
+													<templateId root="2.16.840.1.113883.10.20.1.55" />
+													<!-- Conformité Severity Entry (IHE PCC) -->
+													<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1" />
+													<!-- Conformité FR-Severite (FR CI-SIS) -->
+													<templateId root="1.2.250.1.213.1.1.3.29" />
+													<code code="SEV" displayName="Sévérité" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode" />
+													<text>
+														<reference value="#allergie-01-reaction-1-severite" />
+													</text>
+													<statusCode code="completed" />
+													<!-- valeur issue du JDV_SeveriteObservation-CISIS (1.2.250.1.213.1.1.5.675) -->
+													<value xsi:type="CD" code="6736007" displayName="modéré" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+												</observation>
+											</entryRelationship>                      
+										</observation>
+									</entryRelationship>
+									
+									<!-- [0..*] Entrée FR-Probleme : Réaction 2 observée -->
+									<entryRelationship typeCode="MFST">
+										<observation classCode="OBS" moodCode="EVN">
+											<!-- Conformité Problem observation (CCD) -->
+											<templateId root="2.16.840.1.113883.10.20.1.28" />
+											<!-- Conformité Problem Entry (IHE PCC) -->
+											<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+											<!-- Conformité Reaction (IHE PCC) -->
+											<templateId root="2.16.840.1.113883.10.20.1.54" />
+											<!-- Conformité FR-Probleme (FR CI-SIS) -->
+											<templateId root="1.2.250.1.213.1.1.3.37" />
+											<id root="C64C6013-C8AF-4938-AD10-1B7D26DEE2B1"/>
+											<code code="55607006" displayName="Problème" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+											<text><reference value="#allergie-reaction-01" /></text>
+											<statusCode code="completed" />
+											<effectiveTime xsi:type="IVL_TS">
+												<low value="20180603"/>
+											</effectiveTime>
+											<!-- valeur issue de la CIM-11 / Chapitre 04 Maladies du système immunitaire / Bloc Affections allergiques ou d'hypersensibilité -->
+											<value xsi:type="CD" code="4A82" displayName="Troubles allergiques ou d'hypersensibilité de la peau ou des muqueuses" codeSystem="2.16.840.1.113883.6.347" codeSystemName="CIM-11">
+												<originalText>
+													<reference value="#allergie-01-reaction-2" />
+												</originalText>
+											</value>
+											<!-- [0..1] Entrée FR-Severite : Sévérité de la réaction -->
+											<entryRelationship typeCode="SUBJ" inversionInd="true">
+												<observation classCode="OBS" moodCode="EVN">
+													<!-- Conformité Severity Observation (IPS) -->
+													<templateId root="2.16.840.1.113883.10.22.4.25" />
+													<!-- Conformité Severity observation (CCD) -->
+													<templateId root="2.16.840.1.113883.10.20.1.55" />
+													<!-- Conformité Severity Entry (IHE PCC) -->
+													<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.1" />
+													<!-- Conformité FR-Severite (FR CI-SIS) -->
+													<templateId root="1.2.250.1.213.1.1.3.29" />
+													<code code="SEV" displayName="Sévérité" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode" />
+													<text>
+														<reference value="#allergie-01-reaction-2-severite" />
+													</text>
+													<statusCode code="completed" />
+													<!-- valeur issue du JDV_SeveriteObservation-CISIS (1.2.250.1.213.1.1.5.675) -->
+													<value xsi:type="CD" code="255604002" displayName="léger" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+												</observation>
+											</entryRelationship>                      
+										</observation>
+									</entryRelationship>
+									
+								</observation>
+							</entryRelationship>
+						</act>
+					</entry>
+				</section>
+
+			</component>
+
+			<!-- Section FR-Allergies-et-hypersensibilites : Pas d'allergie / hypersensibilité connue -->
+			<component>
+				<section>
+					<!-- Conformité Alerts Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.2"/>
+					<!-- Conformité Allergies and Other Adverse Reactions Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.13"/>
+					<!-- Conformité FR-Allergies-et-hypersensibilites (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.137"/>
+					<id root="7649c5fa-a444-49a6-91e9-78d2e5880c67"/>
+					<code code="48765-2" displayName="Allergies et hypersensibilités"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Allergies et hypersensibilités</title>
+					<!-- Partie narrative de la section -->
+					<text ID="NO-ALL">Pas d'allergie / hypersensibilité connue</text>
+					<!-- Entrée FR-Liste-des-allergies-et-hypersensibilites -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27"/>
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1"/>
+							<!-- Conformité Allergy and Intolerance Concern (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.3"/>
+							<!-- Conformité FR-Liste-des-allergies-et-hypersensibilites (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.40"/>
+							<id root="1269c206-4d59-4a9d-aa2d-aa0c4622d525"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor="NA"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							
+							<!-- Entrée FR-Allergie-ou-hypersensibilite -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Alert observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.18"/>
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28"/>
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5"/>
+									<!-- Conformité Allergies And Intolerances Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.6"/>
+									<!-- Conformité FR-Allergie-ou-hypersensibilite (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.41"/>
+									<id root="c64c6013-c8af-4938-ad10-1b7d26dee2a0"/>
+									<!-- Type d'allergie / intolérance -->
+									<code code="DALG" displayName="Allergie médicamenteuse"
+										codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+									<text><reference value="#NO-ALL"/></text>
+									<statusCode code="completed"/>
+									<!-- Date de l'allergie / intolérance -->
+									<effectiveTime xsi:type="IVL_TS">
+										<low nullFlavor="UNK"/>
+									</effectiveTime>
+									<!-- Pas d'allergie / hypersensibilité connue -->
+									<value xsi:type="CD" code="no-known-allergies" 
+										displayName="Pas d'allergie/hypersensibilité connue"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">										
+										<originalText><reference value="#NO-ALL"/></originalText>
+									</value>
+								</observation>
+							</entryRelationship>
+						</act>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Allergies-et-hypersensibilites : Pas d’information  -->
+			<component>
+				<section>
+					<!-- Conformité Alerts Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.2"/>
+					<!-- Conformité Allergies and Other Adverse Reactions Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.13"/>
+					<!-- Conformité FR-Allergies-et-hypersensibilites (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.137"/>
+					<id root="7649c5fa-a444-49a6-91e9-78d2e5880c67"/>
+					<code code="48765-2" displayName="Allergies et hypersensibilités"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Allergies et hypersensibilités</title>
+					<!-- Partie narrative de la section -->
+					<text ID="ALL-UNK">Pas d’information sur les allergies / hypersensibilités</text>
+					
+					<!-- Entrée FR-Liste-des-allergies-et-hypersensibilites -->
+					<entry>
+						<act classCode="ACT" moodCode="EVN">
+							<!-- Conformité Problem Act (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.27"/>
+							<!-- Conformité Concern Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.1"/>
+							<!-- Conformité Allergy and Intolerance Concern (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5.3"/>
+							<!-- Conformité FR-Liste-des-allergies-et-hypersensibilites (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.40"/>
+							<id root="1269c206-4d59-4a9d-aa2d-aa0c4622d525"/>
+							<code nullFlavor="NA"/>
+							<statusCode code="completed"/>
+							<effectiveTime>
+								<low nullFlavor="UNK"/>
+								<high nullFlavor="UNK"/>
+							</effectiveTime>
+							
+							<!-- Entrée FR-Allergie-ou-hypersensibilite -->
+							<entryRelationship typeCode="SUBJ" inversionInd="false">
+								<observation classCode="OBS" moodCode="EVN" negationInd="false">
+									<!-- Conformité Alert observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.18"/>
+									<!-- Conformité Problem observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.28"/>
+									<!-- Conformité Problem Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5"/>
+									<!-- Conformité Allergies And Intolerances Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.6"/>
+									<!-- Conformité FR-Allergie-ou-hypersensibilite (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.41"/>
+									<id root="c64c6013-c8af-4938-ad10-1b7d26dee2a0"/>
+									<!-- Type d'allergie / intolérance -->
+									<code code="DALG" displayName="Allergie médicamenteuse"
+										codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+									<text><reference value="#ALL-UNK"/></text>
+									<statusCode code="completed"/>
+									<!-- Date de l'allergie / intolérance -->
+									<effectiveTime xsi:type="IVL_TS">
+										<low nullFlavor="UNK"/>
+									</effectiveTime>
+									<!-- Pas d’information sur les allergies / hypersensibilités -->
+									<value xsi:type="CD" code="no-allergy-info" 
+										displayName="Pas d’information sur les allergies/hypersensibilités"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">
+										<originalText><reference value="#ALL-UNK"/></originalText>
+									</value>									
+								</observation>
+							</entryRelationship>
+						</act>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Habitus-mode-de-vie -->
+			<component>
+				<section>
+					<!-- Conformité Social History Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.15" />
+					<!-- Conformité Social History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.16" />
+					<!-- Conformité Coded Social History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.16.1" />
+					<!-- Conformité FR-Habitus-mode-de-vie (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.141" />
+					<id root="D99F46A4-C196-44CC-9F77-CB034DF6D1AF"/>
+					<code code="29762-2" displayName="Habitus, Mode de vie"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Habitus, Mode de vie</title>
+					<!-- Partie narrative de la section -->
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Type</th>
+									<th>Observation</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<content ID="tabac-statut">Statut tabagique</content>
+									</td>
+									<td>Fumeur quotidien</td>
+								</tr>
+								<tr>
+									<td>
+										<content ID="tabac-conso">Consommation tabagique</content>
+									</td>
+									<td>25 PA</td>
+								</tr>
+								<tr>
+									<td>
+										<content ID="alcool">Consommation d'alcool</content>
+									</td>
+									<td>5 verres / jour</td>
+								</tr>
+								<tr>
+									<td>
+										<content ID="drogue">Consommation de drogue</content>
+									</td>
+									<td><content ID="drogue-type">Cannabis</content></td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					
+					<!-- [1..*] Entrée FR-Habitus-Mode-de-vie (Statut tabagique) -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Social history observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.33" />
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Social history observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.4" />
+							<!-- Conformité FR-Habitus-Mode-de-vie (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.52" />
+							<id root="CF5B21BC-387A-44AD-9FE9-D6582A6CF332" />              
+							<!-- valeur issue du JDV_SocialHistoryCodes-CISIS (1.2.250.1.213.1.1.4.2.283.4) -->
+							<code code="72166-2" displayName="Statut tabagique" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+							<text><reference value="#tabac-statut"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<!-- valeur issue du JDV_StatutTabagique-CISIS (1.2.250.1.213.1.1.5.667) -->
+							<value xsi:type="CD" code="LA18976-3" displayName="Fumeur quotidien" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+						</observation>
+					</entry> 
+					<!-- [1..*] Entrée FR-Habitus-Mode-de-vie (Consommation tabagique) -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Social history observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.33" />
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Social history observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.4" />
+							<!-- Conformité FR-Habitus-Mode-de-vie (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.52" />
+							<id root="CF5B21BC-387A-44AD-9FE9-D6582A6CF332" />              
+							<!-- valeur issue du JDV_SocialHistoryCodes-CISIS (1.2.250.1.213.1.1.4.2.283.4) -->
+							<code code="74011-8" displayName="Consommation tabagique"
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#tabac-conso"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<value xsi:type="PQ" value="25" unit="{pack}/a"/>
+						</observation>
+					</entry>
+					<!-- [1..*] Entrée FR-Habitus-Mode-de-vie (Alcool) -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Social history observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.33" />
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Social history observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.4" />
+							<!-- Conformité FR-Habitus-Mode-de-vie (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.52" />
+							<id root="CF5B21BC-387A-44AD-9FE9-D6582A6CF332" />
+							<!-- valeur issue du JDV_SocialHistoryCodes-CISIS (1.2.250.1.213.1.1.4.2.283.4) -->
+							<code code="74013-4" displayName="Consommation d'alcool"
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#alcool"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<value xsi:type="PQ" value="5" unit="{drink}/d" />
+						</observation>
+					</entry>
+					<!-- [1..*] Entrée FR-Habitus-Mode-de-vie (Consommation de drogue) -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Social history observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.33" />
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Social history observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.4" />
+							<!-- Conformité FR-Habitus-Mode-de-vie (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.52" />
+							<id root="8378F25F-7EC2-4CEE-A9A5-168030827D07" />
+							<!-- valeur issue du JDV_SocialHistoryCodes-CISIS (1.2.250.1.213.1.1.4.2.283.4) -->
+							<code code="42831-8" displayName="Consommation de drogue"
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#drogue"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<value xsi:type="CD" code="8063-14-7" displayName="Cannabis" codeSystem="1.2.250.1.213.2.72" codeSystemName="ChemIDPlus">
+								<originalText><reference value="#drogue-type"/></originalText>
+							</value>
+						</observation>
+					</entry>					
+				</section>
+			</component>
+
+			<!-- [1..1] Section FR-Traitements -->
+	      	<component>
+	        	<section>         
+		          <!-- Conformité Medications Section (CCD) -->
+		          <templateId root="2.16.840.1.113883.10.20.1.8" />      
+		          <!-- Conformité Medications (IHE PCC) -->
+		          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.19" />    
+		          <!-- Conformité FR-Traitements (FR CI-SIS) -->
+		          <templateId root="1.2.250.1.213.1.1.2.143" />
+		          <code code="10160-0" displayName="Historique de la prise médicamenteuse" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		          <title>Traitements</title>
+		          <text>
+		            <table border="0">
+		              <thead>
+		                <tr>
+		                  <th>Date de début</th>
+		                  <th>Date de fin</th>
+		                  <th>Médicament</th>
+		                  <th>Dose prescrite</th>
+		                  <th>Fréquence</th>
+		                  <th>Voie d'administration</th>
+		                  <th>Motif</th>
+		                </tr>
+		              </thead>
+		              <tbody>
+		                <tr>
+		                  <td>11/02/2022</td>
+		                  <td>-</td>
+		                  <td><content ID="med-01">PLAVIX 75mg, comprimé pelliculé</content></td>
+		                  <td><content ID="med-01-doseMin-1">1 cp</content></td>
+		                  <td><content ID="med-01-frequence">1 fois/j</content></td>
+		                  <td><content ID="med-01-voie">Voie orale</content></td>
+		                  <td><content ID="med-01-motif">Angine de poitrine instable</content></td>
+		                </tr>
+		                <tr>
+		                  <td>11/02/2022</td>
+		                  <td>-</td>
+		                  <td><content ID="med-02">COUMADINE 5mg, comprimé sécable </content></td>                  
+		                  <td><content ID="med-02-doseMin-1">1 cp</content></td>
+		                  <td><content ID="med-02-frequence">4 fois/j</content></td>
+		                  <td><content ID="med-02-voie">Voie orale</content></td>
+		                  <td><content ID="med-02-motif">Accident Ischémique Cérébral Transitoire</content></td>
+		                </tr>
+		                <tr>
+		                  <td>01/12/2021</td>
+		                  <td>06/12/2021</td>
+		                  <td>
+		                    <content ID="med-03">PARACETAMOL MYLAN 500 mg, comprimé</content>
+		                  </td>
+		                  <td>
+		                    <content ID="med-03-doseMin-1">1 cp</content> à <content ID="med-03-doseMax-1">2 cp</content><br/><br/><br/>
+		                    <content ID="med-03-doseMin-2">1 cp</content> à <content ID="med-03-doseMax-2">2 cp</content>
+		                  </td>
+		                  <td>
+		                    <content ID="med-03-frequence-1">3 fois/j à partir du 01/12/2021 pendant 2 jours</content>
+		                    <br/>
+		                    <br/>
+		                    <content ID="med-03-frequence-2">2 fois/j à partir du 03/12/2021 pendant 4 jours</content>
+		                  </td> 
+		                  <td><content ID="med-03-voie">Voie orale</content></td>                    
+		                  <td>-</td>
+		                </tr>
+		              </tbody>
+		            </table>
+		          </text>
+		          <!-- [1..*] Entrée FR-Traitement (Plavix pour Angine de poitrine) -->
+		          <entry typeCode="DRIV">
+		            <substanceAdministration classCode="SBADM" moodCode="EVN">              
+		              <!-- Conformité Medication Activity (CCD) -->
+		              <templateId root="2.16.840.1.113883.10.20.1.24" />
+		              <!-- Conformité Medications Entry (IHE PCC) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7" />
+		              <!-- Conformité FR-Traitement (FR CI-SIS) -->
+		              <templateId root="1.2.250.1.213.1.1.3.42" />
+		              <!-- Conformité Mode d'administration (normal) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.1" />
+		              <id root="AADC9C14-F1CA-4177-B2C8-A5178D5B3CA0" />
+		              <code code="DRUG" displayName="Médicament" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+		              <text><reference value="#med-01"></reference></text>
+		              <statusCode code="completed" />
+		              <!-- Durée du traitement -->
+		              <effectiveTime xsi:type="IVL_TS">
+		                <low value="20220211" />
+		                <high nullFlavor="UNK" />
+		              </effectiveTime>
+		              <!-- Fréquence du traitement -->
+		              <effectiveTime xsi:type="PIVL_TS" operator="A">
+		                <period value="1" unit="d">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-01-frequence"/>
+		                    </originalText>
+		                  </translation>
+		                </period>
+		              </effectiveTime>
+		              <!-- Voie d'administration -->
+		              <routeCode code="20053000" displayName="Voie orale" codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM">
+		                <originalText><reference value="#med-001-voie"></reference></originalText>
+		              </routeCode>              
+		              <!-- Dose à administrer -->
+		              <doseQuantity>
+		                <low value="1" unit="{tablet}">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-01-doseMin-1"/>
+		                    </originalText>
+		                  </translation>
+		                </low>
+		                <high value="1" unit="{tablet}">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-01-doseMax-1"/>
+		                    </originalText>
+		                  </translation>
+		                </high>
+		              </doseQuantity>
+		              <!-- Rythme d'administration -->
+		              <rateQuantity nullFlavor="NAV" />
+		              <!-- Dose maximale -->
+		              <maxDoseQuantity>
+		                <numerator />
+		                <denominator />
+		              </maxDoseQuantity>
+		              <!-- [1..1] Entrée FR-Produit-de-sante -->
+		              <consumable>
+		                <manufacturedProduct classCode="MANU">
+		                  <!-- Conformité Product (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.53"/>
+		                  <!-- Conformité Product Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+		                  <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.43"/>
+		                  <manufacturedMaterial>                    
+		                    <!-- Code CIS du produit -->
+		                    <code code="63564053" displayName="PLAVIX 75 mg, comprimé pelliculé" codeSystem="1.2.250.1.213.2.3.1" codeSystemName="CIS">
+		                      <originalText>
+		                        <reference value="#med-01" />
+		                      </originalText>                      
+		                      <!-- Code CIP du produit -->
+		                      <translation code="3400938022209" displayName="PLAVIX 75 mg, comprimé pelliculé, plaquette(s) thermoformée(s) PVC PVDC aluminium de 30 comprimé(s)" codeSystem="1.2.250.1.213.2.3.2" codeSystemName="CIP">
+		                        <originalText>
+		                          <reference value="#med-01" />
+		                        </originalText>
+		                      </translation>
+		                    </code>
+		                    <name>PLAVIX 75 mg</name>
+		                    <lotNumberText />
+		                  </manufacturedMaterial>
+		                </manufacturedProduct>
+		              </consumable>
+		              <!-- Entrée FR-Traitement-subordonne  
+									<entryRelationship typeCode="COMP">										
+										... non utilisé pour dosage normal
+									</entryRelationship> -->
+		              <!-- Entrée FR-Reference-interne : Motif du traitement -->
+		              <entryRelationship typeCode="RSON">
+		                <act classCode="ACT" moodCode="EVN">                  
+		                  <!-- Conformité Internal References (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.4.1" />
+		                  <!-- Conformité FR-Reference-interne (FR CI-SISI) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.36" />
+		                  <id root="CDBD5B08-6CDE-11DB-9FE1-0800200C9A66" />
+		                  <code code="I20.0" displayName="Angine de poitrine instable" codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM-10">
+		                    <originalText mediaType="text/xml">
+		                      <reference value="#med-01-motif" />
+		                    </originalText>
+		                  </code>
+		                  <statusCode code="completed" />
+		                  <effectiveTime xsi:type="IVL_TS">
+		                    <low value="20220211" />
+		                  </effectiveTime>
+		                </act>
+		              </entryRelationship>
+		            </substanceAdministration>
+		          </entry>
+		          
+		          <!-- [1..*] Entrée FR-Traitement (Coumadine pour AIT) -->
+		          <entry typeCode="DRIV">
+		            <substanceAdministration classCode="SBADM" moodCode="EVN">
+		              <!-- Conformité Medication Activity (CCD) -->
+		              <templateId root="2.16.840.1.113883.10.20.1.24" />
+		              <!-- Conformité Medications Entry (IHE PCC) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7" />
+		              <!-- Conformité FR-Traitement (FR CI-SIS) -->
+		              <templateId root="1.2.250.1.213.1.1.3.42" />
+		              <!-- Conformité Mode d'administration (normal) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.1" />
+		              <id root="8609F763-4F75-4FB5-A1A3-A6A269D15F4A" />
+		              <code code="DRUG" displayName="Médicament" codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>              
+		              <text><reference value="#med-02"></reference></text>
+		              <statusCode code="completed" />
+		              <!-- Durée du traitement -->
+		              <effectiveTime xsi:type="IVL_TS">
+		                <low value="20220211" />
+		                <high nullFlavor="UNK" />
+		              </effectiveTime>
+		              <!-- Fréquence du traitement -->
+		              <effectiveTime xsi:type="PIVL_TS" operator="A">
+		                <period value="6" unit="h">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-02-frequence"/>
+		                    </originalText>
+		                  </translation>
+		                </period>
+		              </effectiveTime>
+		              <!-- Voie d'administration -->
+		              <routeCode code="20053000" displayName="Voie orale" codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM">
+		                <originalText><reference value="#med-002-voie"></reference></originalText>
+		              </routeCode>
+		              <!-- Dose à administrer -->
+		              <doseQuantity>
+		                <low value="1" unit="{tablet}">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-02-doseMin-1"/>
+		                    </originalText>
+		                  </translation>
+		                </low>
+		                <high value="1" unit="{tablet}">
+		                  <translation>
+		                    <originalText>
+		                      <reference value="#med-02-doseMax-1"/>
+		                    </originalText>
+		                  </translation>
+		                </high>
+		              </doseQuantity>
+		              <!-- Rythme d'administration -->
+		              <rateQuantity nullFlavor="NAV" />
+		              <!-- [1..1] Entrée FR-Produit-de-sante -->
+		              <consumable>
+		                <manufacturedProduct classCode="MANU">
+		                  <!-- Conformité Product (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.53"/>
+		                  <!-- Conformité Product Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+		                  <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.43"/>
+		                  <manufacturedMaterial>
+		                    <!-- Code CIS du produit -->
+		                    <code code="63245753" displayName="COUMADINE 5mg, comprimé sécable" codeSystem="1.2.250.1.213.2.3.1" codeSystemName="CIS">
+		                      <originalText mediaType="text/xml">
+		                        <reference value="#med-02" />
+		                      </originalText>
+		                      <!-- Code CIP du produit -->
+		                      <translation code="3400935693099" displayName="COUMADINE 5mg, comprimé sécable, plaquette(s) thermoformée(s) PVC-aluminium de 30 comprimé(s)" codeSystem="1.2.250.1.213.2.3.2" codeSystemName="CIP">
+		                        <originalText mediaType="text/xml">
+		                          <reference value="#med-02" />
+		                        </originalText>
+		                      </translation>
+		                    </code>
+		                    <name>COUMADINE 5mg</name>                    
+		                  </manufacturedMaterial>
+		                </manufacturedProduct>
+		              </consumable>
+		              <!-- Entrée FR-Traitement-subordonne  
+									<entryRelationship typeCode="COMP">										
+										... non utilisé pour dosage normal
+									</entryRelationship> -->
+		              <!-- Entrée FR-Reference-interne : Motif du traitement -->
+		              <entryRelationship typeCode="RSON">
+		                <act classCode="ACT" moodCode="EVN">
+		                  <!-- Conformité Internal References (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.4.1" />
+		                  <!-- Conformité FR-Reference-interne (FR CI-SISI) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.36" />
+		                  <id root="12DA3A06-18E7-40B7-9397-1FA5B1552472" />
+		                  <code code="G45.9" displayName="Accident Ischémique Cérébral Transitoire" codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM-10">
+		                    <originalText mediaType="text/xml">
+		                      <reference value="#med-02-motif" />
+		                    </originalText>
+		                  </code>
+		                  <statusCode code="completed" />
+		                  <effectiveTime xsi:type="IVL_TS">
+		                    <low value="20220211" />
+		                  </effectiveTime>
+		                </act>
+		              </entryRelationship>
+		            </substanceAdministration>
+		          </entry>
+		          
+		          <!-- [1..*] Entrée FR-Traitement (paracétamol) -->
+		          <entry>
+		            <substanceAdministration classCode="SBADM" moodCode="INT">     
+		              <!-- Conformité Medication Activity (CCD) -->
+		              <templateId root="2.16.840.1.113883.10.20.1.24" />
+		              <!-- Conformité Medications Entry (IHE PCC) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7" />
+		              <!-- Conformité FR-Traitement (FR CI-SIS) -->
+		              <templateId root="1.2.250.1.213.1.1.3.42" />
+		              <!-- [0..1] Conformité Posologie structurée : uniquement si posologie structurée -->
+		              <templateId root="1.3.6.1.4.1.19376.1.9.1.3.6"/>
+		              <!-- [0..1] Conformité Mode d'administration : Doses progressives (avec FR-Traitement-prescrit-subordonnee) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.8"/>
+		              <id root="AADC9C14-F1CA-4177-B2C8-A5178D5B3CA0"/>
+		              <code code="DRUG" codeSystem="2.16.840.1.113883.5.4" displayName="Médicament"
+		                codeSystemName="HL7:ActCode"/>
+		              <text><reference value="#med-03"/></text>
+		              <statusCode code="completed"/>
+		              <!-- [0..1] Durée du traitement -->
+		              <effectiveTime xsi:type="IVL_TS">
+		                <low value="20211201"/>
+		                <high value="20211206"/>
+		              </effectiveTime>
+		              
+		              <!-- [0..1] Fréquence d'administration : uniquement si posologie structurée -->
+		              <!-- non renseigné ici car doses progressives décrites dans des <substanceAdministration> subordonnés -->
+		              <!-- <effectiveTime xsi:type="PIVL_TS" operator="A"> -->
+		              
+		              <!-- [0..1] Voie d'administration : uniquement si posologie structurée -->
+		              <!-- valeur issue de la terminologie EDQM (0.4.0.127.0.16.1.1.2.1) -->
+		              <routeCode code="20053000" displayName="Voie orale" codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM">
+		                <originalText><reference value="#med-03-voie"/></originalText>
+		              </routeCode>
+		              
+		              <!-- [0..1] Région anatomique d'administration : uniquement si posologie structurée -->
+		              <!-- valeur issue du JDV_HL7_HumanSubstanceAdministrationSite-CISIS (2.16.840.1.113883.1.11.19724) -->
+		              <!-- <approachSiteCode> </approachSiteCode> -->
+		              
+		              <!-- [0..1] Dose à administrer : uniquement si posologie structurée -->
+		              <!-- non renseigné ici car doses progressives décrites dans des <substanceAdministration> subordonnés -->
+		              <!-- <doseQuantity>  </doseQuantity> -->
+		              
+		              <!-- [0..1] Rythme d'administration : uniquement si posologie structurée -->
+		              <!-- <rateQuantity>  </rateQuantity> -->
+		              
+		              <!-- [0..*] Dose maximale d'administration : uniquement si posologie structurée -->
+		              <maxDoseQuantity>
+		                <numerator value="4"/>
+		                <denominator value="1" unit="d"/>
+		              </maxDoseQuantity>
+		              
+		              <!-- [1..1] Entrée FR-Produit-de-sante -->
+		              <consumable>
+		                <manufacturedProduct classCode="MANU">
+		                  <!-- Conformité Product (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.53"/>
+		                  <!-- Conformité Product Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+		                  <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.43"/>
+		                  <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+		                    <!-- Code CIS du médicament -->
+		                    <code code="63107752" displayName="PARACETAMOL MYLAN 500 mg, comprimé"
+		                      codeSystem="1.2.250.1.213.2.3.1" codeSystemName="CIS">
+		                      <originalText><reference value="#med-001"/></originalText>
+		                      <!-- Code MV Médicabase du médicament -->
+		                      <translation code="MV00002306" displayName="Paracétamol 500 mg comprimé" 
+		                        codeSystem="1.2.250.1.213.2.59" codeSystemName="MV"></translation>                      
+		                      <!-- Code CIP du médicament -->
+		                      <translation code="3400933516390" 
+		                        displayName="PARACETAMOL MYLAN 500 mg, comprimé, plaquette(s) thermoformée(s) PVC-aluminium de 16 comprimé(s)"
+		                        codeSystem="1.2.250.1.213.2.3.2" codeSystemName="CIP"></translation>
+		                    </code>
+		                    <!-- Nom de la marque -->
+		                    <name>PARACETAMOL MYLAN 500 mg, comprimé</name>
+		                    <!-- Forme galénique : EDQM (0.4.0.127.0.16.1.1.2.1) Pharmaceutical Dose Forms -->
+		                    <pharm:formCode code="10219000" displayName="Comprimé" codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM"/>                    
+		                    <!-- [0..1] Équivalent générique -->
+		                    <pharm:asSpecializedKind classCode="GRIC">
+		                      <pharm:generalizedMedicineClass classCode="MMAT">
+		                        <pharm:code code="N02BE01" displayName="paracetamol" codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+		                        <pharm:name>paracetamol</pharm:name>
+		                      </pharm:generalizedMedicineClass>
+		                    </pharm:asSpecializedKind>
+		                    <!-- [0..*] Substances actives -->
+		                    <pharm:ingredient classCode="ACTI">
+		                      <pharm:quantity>
+		                        <pharm:numerator xsi:type="pharm:PQ" value="500" unit="mg"/>
+		                        <pharm:denominator xsi:type="pharm:PQ" value="1"/>
+		                      </pharm:quantity>                    
+		                      <pharm:ingredient classCode="MMAT" determinerCode="KIND">
+		                        <pharm:code code="N02BE01" displayName="paracetamol" codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+		                        <pharm:name>paracetamol</pharm:name>
+		                      </pharm:ingredient>
+		                    </pharm:ingredient>
+		                  </manufacturedMaterial>
+		                </manufacturedProduct>
+		              </consumable>              
+		
+		              <!-- [0..*] Entrée FR-Traitement-subordonnee (pour indiquer les changements de fréquence et/ou de dose) -->
+		              <!-- si doses progressives (tapered dose), fractionnées (split dose) et conditionnelles (conditional dose)-->
+		              <entryRelationship typeCode="COMP">
+		                <sequenceNumber value="1"/>
+		                <substanceAdministration classCode="SBADM" moodCode="INT">        
+		                  <!-- Conformité FR-Traitement-subordonne (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.42.1"/>
+		                  <!-- Conformité Modalité : Doses progressives (IHE PCC)-->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.8"/>
+		                  <id root="C93DE620-3722-11EC-8D3D-0242AC130003"/>
+		                  <text>
+		                    <reference value="#med-03-ModeAdminProg-1"/>
+		                  </text>
+		                  <statusCode code="completed"/>
+		                  <!-- Fréquence d'administration : toutes les 8h (3 fois/j) à partir du 01/12/2021 pendant 2 jours -->
+		                  <effectiveTime xsi:type="SXPR_TS">
+		                    <comp xsi:type="IVL_TS" operator="A">
+		                      <low value="20211201"/>
+		                      <width value="2" unit="d"/>
+		                    </comp>
+		                    <comp xsi:type="PIVL_TS" operator="A">
+		                      <period value="8" unit="h">
+		                        <translation>
+		                          <originalText>
+		                            <reference value="#med-03-frequence-1"/>
+		                          </originalText>
+		                        </translation>
+		                      </period>
+		                    </comp>
+		                  </effectiveTime>
+		                  <!-- Dose à administrer : 1 cp -->
+		                  <doseQuantity>
+		                    <low value="1" unit="{tablet}">
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-doseMin-1"/>
+		                        </originalText>
+		                      </translation>
+		                    </low>
+		                    <high value="1" unit="{tablet}">
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-doseMax-1"/>
+		                        </originalText>
+		                      </translation>
+		                    </high>
+		                  </doseQuantity>
+		                  <!-- [0..1] Rythme d'administration : uniquement si posologie structurée -->
+		                  <rateQuantity>
+		                    <low value="1500" unit='mg/d'>
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-rateMin-1"/>
+		                        </originalText>
+		                      </translation>
+		                    </low>
+		                    <high value="3000" unit='mg/d'>
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-rateMax-1"/>
+		                        </originalText>
+		                      </translation>
+		                    </high>
+		                  </rateQuantity>
+		                  
+		                  <!-- Produit de santé à nullFlavor="NA" -->
+		                  <consumable>
+		                    <manufacturedProduct classCode="MANU">
+		                      <!-- Conformité Product (CCD) -->
+		                      <templateId root="2.16.840.1.113883.10.20.1.53"/>
+		                      <!-- Conformité Product Entry (IHE PCC) -->
+		                      <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+		                      <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                      <templateId root="1.2.250.1.213.1.1.3.43"/>
+		                      <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+		                        <!-- Code du médicament -->
+		                        <code nullFlavor="NA"/>
+		                        <!-- Nom de la marque -->
+		                        <name nullFlavor="NA"/>
+		                      </manufacturedMaterial>
+		                    </manufacturedProduct>
+		                  </consumable>                  
+		                </substanceAdministration>
+		              </entryRelationship>
+		              
+		              <!-- [0..*] Entrée FR-Traitement-subordonnee (pour indiquer les changements de fréquence et/ou de dose) -->
+		              <!-- si doses progressives (tapered dose), fractionnées (split dose) et conditionnelles (conditional dose)-->
+		              <entryRelationship typeCode="COMP">
+		                <sequenceNumber value="2"/>
+		                <substanceAdministration classCode="SBADM" moodCode="INT">     
+		                  <!-- Conformité FR-Traitement-subordonne (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.42.1"/>
+		                  <!-- Conformité Modalité : Doses progressives (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.8"/>
+		                  <id root="3FDCAA46-3723-11EC-8D3D-0242AC130003"/>
+		                  <text>
+		                    <reference value="#med-03-ModeAdminProg-2"/>
+		                  </text>
+		                  <statusCode code="completed"/>              
+		                  <!-- Fréquence d'administration : toutes les 12h (2 fois/j) à partir du 03/12/2021 pendant 4 jours -->
+		                  <effectiveTime xsi:type="SXPR_TS">
+		                    <comp xsi:type="IVL_TS" operator="A">
+		                      <low value="20211203"/>
+		                      <width value="4" unit="d"/>
+		                    </comp>
+		                    <comp xsi:type="PIVL_TS" operator="A">
+		                      <period value="12" unit="h">
+		                        <translation>
+		                          <originalText>
+		                            <reference value="#med-03-frequence-2"/>
+		                          </originalText>
+		                        </translation>
+		                      </period>
+		                    </comp>
+		                  </effectiveTime>
+		                  <!-- Dose à administrer : 1 comprimé -->
+		                  <doseQuantity>
+		                    <low value="1" unit="{tablet}">
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-doseMin-2"/>
+		                        </originalText>
+		                      </translation>
+		                    </low>
+		                    <high value="1" unit="{tablet}">
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-doseMax-2"/>
+		                        </originalText>
+		                      </translation>
+		                    </high>
+		                  </doseQuantity>
+		                  <!-- [0..1] Rythme d'administration : uniquement si posologie structurée -->
+		                  <rateQuantity>
+		                    <low value="1000" unit='mg/d'>
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-rateMin-2"/>
+		                        </originalText>
+		                      </translation>
+		                    </low>
+		                    <high value="2000" unit='mg/d'>
+		                      <translation>
+		                        <originalText>
+		                          <reference value="#med-03-rateMax-2"/>
+		                        </originalText>
+		                      </translation>
+		                    </high>
+		                  </rateQuantity>
+		                  <!-- Produit de santé à nullFlavor="NA" -->
+		                  <consumable>
+		                    <manufacturedProduct classCode="MANU">
+		                      <!-- Conformité Product (CCD) -->
+		                      <templateId root="2.16.840.1.113883.10.20.1.53"/>
+		                      <!-- Conformité Product Entry (IHE PCC) -->
+		                      <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+		                      <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                      <templateId root="1.2.250.1.213.1.1.3.43"/>
+		                      <manufacturedMaterial classCode="MMAT" determinerCode="KIND">
+		                        <!-- Code du médicament -->
+		                        <code nullFlavor="NA"/>
+		                        <!-- Nom de la marque -->
+		                        <name nullFlavor="NA"/>                        
+		                      </manufacturedMaterial>
+		                    </manufacturedProduct>
+		                  </consumable>                  
+		                </substanceAdministration>
+		              </entryRelationship>
+		            </substanceAdministration>
+		          </entry>
+		        
+		        </section>
+	      	</component>    
+			
+			<!-- Section FR-Traitements : Pas d'information -->
+			<component>
+				<section>
+					<!-- Conformité Medications Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.8"/>
+					<!-- Conformité Medications (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.19"/>
+					<!-- Conformité FR-Traitement (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.143"/>
+					<code code="10160-0" displayName="Traitements"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Traitements</title>
+					<text ID="TREATMENT-UNK">Pas d'information sur les traitements du patient</text>
+
+					<!-- Entrée FR-Traitement -->
+					<entry typeCode="DRIV">
+						<substanceAdministration classCode="SBADM" moodCode="EVN" nullFlavor="UNK">
+							<!-- Conformité Medication Activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.24" />
+							<!-- Conformité Medications Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7" />
+							<!-- Conformité FR-Traitement (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.42" />
+							<!-- Conformité Mode d'administration (normal) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.1" />
+							<id root="8609F763-4F75-4FB5-A1A3-A6A269D15F4A"/>
+							<code code="no-medication-info" displayName="Pas d'information sur les traitements médicamenteux" 
+								codeSystem="2.16.840.1.113883.5.1150.1" codeSystemName="IPS CodeSystem - Absent and Unknown Data">
+								<originalText><reference value="#TREATMENT-UNK"/></originalText>
+							</code>							
+							<text><reference/></text>
+							<statusCode code="completed"/>
+							<!-- Durée du traitement -->
+							<effectiveTime xsi:type="IVL_TS">
+								<low nullFlavor="NA"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>							
+							<!-- FR-Produit-de-sante -->
+							<consumable>
+								<manufacturedProduct nullFlavor="UNK">
+									<!-- Conformité CCD -->
+									<templateId root="2.16.840.1.113883.10.20.1.53"/>
+									<!-- Conformité IHE PCC -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+									<!-- Conformité CI-SIS -->
+									<templateId root="1.2.250.1.213.1.1.3.43"/>
+									<manufacturedMaterial nullFlavor="UNK">
+										<code nullFlavor="NA"/>
+									</manufacturedMaterial>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Traitements : Aucun traitement -->
+			<component>
+				<section>
+					<!-- Conformité Medications Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.8"/>
+					<!-- Conformité Medications (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.19"/>
+					<!-- Conformité FR-Traitement (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.143"/>
+					<code code="10160-0" displayName="Traitements"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Traitements</title>
+					<text ID="NO-TREATMENT">Aucun traitement</text>
+					
+					<!-- Entrée FR-Traitement -->
+					<entry typeCode="DRIV">
+						<substanceAdministration classCode="SBADM" moodCode="EVN">
+							<!-- Conformité Medication Activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.24" />
+							<!-- Conformité Medications Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7" />
+							<!-- Conformité FR-Traitement (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.42" />
+							<!-- Conformité Mode d'administration (normal) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.1" />
+							<id root="2ED5EF29-8305-4383-8945-C13F2A988D5E"/>
+							<!-- Pas de traitement médicamenteux connu -->
+							<code code="no-known-medications" displayName="Pas de traitement médicamenteux connu" 
+								codeSystem="2.16.840.1.113883.5.1150.1">
+								<originalText><reference value="#NO-TREATMENT"/></originalText>
+							</code>							
+							<text><reference></reference></text>
+							<statusCode code="completed"/>
+							<effectiveTime xsi:type="IVL_TS">
+								<low nullFlavor="NA"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- FR-Produit-de-sante -->
+							<consumable>
+								<manufacturedProduct>
+									<!-- Conformité CCD -->
+									<templateId root="2.16.840.1.113883.10.20.1.53"/>
+									<!-- Conformité IHE PCC -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2"/>
+									<!-- Conformité CI-SIS -->
+									<templateId root="1.2.250.1.213.1.1.3.43"/>
+									<manufacturedMaterial>
+										<code nullFlavor="NA"/>
+									</manufacturedMaterial>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Dispositifs-medicaux -->
+			<component>
+				<section>
+					<!-- Conformité Medical Equipment Section (CCD) -->
+					<templateId root="2.16.840.1.11383.10.20.1.7" />
+					<!-- Conformité Medical Devices Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.5" />
+					<!-- Conformité FR-Dispositifs-medicaux (FR-CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.1"/>
+					<id root="1493F01B-236C-4828-BDFD-08C632F3665D"/>
+					<code code="46264-8" displayName="Dispositifs médicaux" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Dispositifs médicaux</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Type de DM</th>
+									<th>Identifiant unique du DM</th>
+									<th>Prescripteur</th>
+									<th>Dispensateur</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>01/12/2019</td>
+									<td><content ID="DM001-categorie">STIMULATEUR CARDIAQUE IMPLANTABLE TRIPLE CHAMBRE</content></td>
+									<td>[2.16.840.1.113883.3.3719] {01}00844588003288{17}141120{10}7654321D{21}10987654d321</td>
+									<td>DR Laure MARIGNY (CENTRE DE SANTE SAINT MARTIN)</td>
+									<td>PHARMACIE COMPAIN</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- [1..*] Entrée Dispositif médical -->
+					<entry>
+						<supply classCode="SPLY" moodCode="EVN">
+							<!-- Conformité Supply Activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.34" />
+							<!-- Conformité FR-Dispositif-medical (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.20" />
+							<!-- Identifiant de la fourniture du DM -->
+							<id nullFlavor="UNK"/>
+							<!-- Date d'utilisation du DM -->
+							<effectiveTime value="20191201"/>
+							<!-- Dispensateur -->
+							<performer typeCode="PRF">
+								<!-- Date de délivrance -->
+								<time value="20190711"/>
+								<assignedEntity>
+									<!--Identifiant du PS exécutant-->
+									<id nullFlavor="UNK"/>
+									<!-- Délivré par -->
+									<representedOrganization>
+										<id root="1.2.250.1.71.4.2.2" extension="1750017212"/>
+										<name>PHARMACIE COMPAIN</name>
+									</representedOrganization>
+								</assignedEntity>
+							</performer>      
+							<!-- Prescripteur -->
+							<author>
+								<time value="20190711"/>
+								<assignedAuthor>
+									<!-- Identifiant du prescripteur -->
+									<id root="1.2.250.1.71.4.2.1" extension="10100997245"/>
+									<!-- Profession / Spécialité du prescripteur -->
+									<code code="G15_10/SM54" displayName="Médecin - Médecine Générale (SM)" 
+										codeSystem="1.2.250.1.213.1.1.4.5"/>
+									<!-- Nom et prénom prescripteur -->
+									<assignedPerson>
+										<name>
+											<prefix>M</prefix>
+											<suffix>DR</suffix>
+											<given>Laure</given>
+											<family>MARIGNY</family>
+										</name>
+									</assignedPerson>
+									<!-- Etablissement du prescripteur -->
+									<representedOrganization>
+										<id root="1.2.250.1.71.4.2.2" extension="1750058190"/>
+										<name>CENTRE DE SANTE SAINT MARTIN</name>   
+									</representedOrganization>
+								</assignedAuthor>
+							</author>
+							<!-- Description du dispositif médical -->
+							<participant typeCode="DEV">
+								<participantRole classCode="MANU">
+									<!-- UID du DM -->
+									<id root="2.16.840.1.113883.3.3719" extension="{01}00844588003288{17}141120{10}7654321D{21}10987654d321"/>									
+									<!-- Catégorie de DM -->
+									<playingDevice classCode="DEV" determinerCode="INSTANCE">
+										<code code="J010104" displayName="STIMULATEUR CARDIAQUE IMPLANTABLE TRIPLE CHAMBRE" 
+											codeSystem="1.2.250.1.213.2.68" codeSystemName="EMDN"> 											
+											<originalText><reference value="#DM001-categorie"/></originalText>
+											<translation code="C50FA05" displayName="STIMULATEUR CARDIAQUE IMPLANTABLE TRIPLE CHAMBRE" 
+												codeSystem="1.2.250.1.213.2.65" codeSystemName="CLADIMED"/>											            
+											<translation code="3408693" displayName="STIMULATEUR CARDIAQUE DE RE-SYNCHRO VENTRICULAIRE, BIOTRONIK, EDORA 8 HF-T." 
+												codeSystem="1.2.250.1.215.200.2.1" codeSystemName="LPP"/>											
+										</code>
+									</playingDevice>
+								</participantRole>
+							</participant>
+						</supply>
+					</entry>
+
+				</section>
+			</component>
+
+			<!-- Section FR-Dispositifs-medicaux : Aucun DM -->
+			<component>
+				<section>
+					<!-- Conformité Medical Equipment Section (CCD) -->
+					<templateId root="2.16.840.1.11383.10.20.1.7" />
+					<!-- Conformité Medical Devices Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.5" />
+					<!-- Conformité FR-Dispositifs-medicaux (FR-CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.1"/>
+					<id root="4A402640-1CF6-4153-B5BA-D56B623004C8"/>
+					<code code="46264-8" displayName="Dispositifs médicaux" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Dispositifs médicaux</title>
+					<text>Aucun DM</text>
+					<!-- [1..*] Entrée Dispositif médical -->
+					<entry>
+						<supply classCode="SPLY" moodCode="EVN">
+							<!-- Conformité Supply Activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.34" />
+							<!-- Conformité FR-Dispositif-medical (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.20" />
+							<!-- Identifiant de la fourniture du DM -->
+							<id nullFlavor="NA"/>
+							<!-- Référence vers la partie narrative de la section DM -->
+							<text><reference value="#NO-DM"/></text>
+							<!-- Date d'utilisation du DM -->
+							<effectiveTime nullFlavor="NA"/>
+							<!-- Description du dispositif médical -->
+							<participant typeCode="DEV">
+								<participantRole classCode="MANU">
+									<!-- Aucun DM -->
+									<playingDevice classCode="DEV" determinerCode="INSTANCE">
+										<code code="no-known-devices"
+											displayName="Pas de dispositif médical connu"
+											codeSystem="2.16.840.1.113883.5.1150.1"
+											codeSystemName="IPS CodeSystem - Absent and Unknown Data"/>										
+									</playingDevice>
+								</participantRole>
+							</participant>
+						</supply>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Vaccinations -->
+			<component>
+		        <section>
+		          <!-- Conformité Immunization section (CCD) --> 
+		          <templateId root="2.16.840.1.113883.10.20.1.6" />
+		          <!-- Conformité Immunization section (IHE PCC) --> 
+		          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.23" />
+		          <!-- Conformité FR-Vaccinations (CI-SIS) --> 
+		          <templateId root="1.2.250.1.213.1.1.2.147" />
+		          <id root="12DA3A06-18E9-40B7-4352-1FA5B1552475" />
+		          <code code="11369-6" displayName="Historique des vaccinations" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		          <title>Vaccinations</title>
+		          <text>
+		            <table border="0">
+		              <thead>
+		                <tr>
+		                  <th>Date</th>
+		                  <th>Type de vaccin</th>
+		                  <th>Vaccin</th>
+		                  <th>Lot n°</th>
+		                  <th>Rang</th>
+		                  <th>Voie</th>
+		                  <th>Réaction observée</th>
+		                  <th>Région d'administration</th>
+		                  <th>Référence prescription</th>
+		                  <th>Dose à administrer</th>
+		                  <th>Vaccinateur</th>
+		                  <th>Commentaire</th>
+		                </tr>
+		              </thead>
+		              <tbody>
+		                <tr>
+		                  <td>25/08/2009</td>
+		                  <td><content ID="tetanos1">Vaccin diphtérie-polyomielite-tétanos</content></td>
+		                  <td>REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig</td>
+		                  <td>4456668</td>
+		                  <td>1</td>
+		                  <td>injection intramusculaire</td>
+		                  <td>
+		                    <content ID="tetanos1-reac">Fièvre due à des médicaments</content>
+		                  </td>
+		                  <td>Deltoïde gauche</td>
+		                  <td ID="tetanos1-prescription">-</td>
+		                  <td>1</td>
+		                  <td>Dr Charles MULLER</td>
+		                  <td ID="tetanos1-comment">-</td>
+		                </tr>
+		                <tr>
+		                  <td>28/09/2009</td>
+		                  <td><content ID="tetanos2">Vaccin diphtérie-polyomielite-tétanos</content></td>
+		                  <td>REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig</td>
+		                  <td>4456672</td>
+		                  <td>2</td>
+		                  <td>injection intramusculaire</td>
+		                  <td>
+		                    <content ID="tetanos2-reac">Fièvre due à des médicaments</content>
+		                  </td>
+		                  <td>Deltoïde gauche</td>
+		                  <td ID="tetanos2-prescription">-</td>
+		                  <td>1</td>                  
+		                  <td>Dr Charles MULLER</td>
+		                  <td ID="tetanos2-comment">Prise récente et ponctuelle de solupred (60mg) en une prise pendant 2 jours</td>
+		                </tr>
+		              </tbody>
+		            </table>
+		          </text>
+		          <!-- [1..*] Entrée FR-Vaccination : Vaccination tétanos (1er injection) -->
+		          <entry>
+		            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+		              <!-- Conformité Medication activity (CCD) -->
+		              <templateId root="2.16.840.1.113883.10.20.1.24" />
+		              <!-- Conformité Immunizations (IHE PCC) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.12" />
+		              <!-- Conformité FR-Vaccination (CI-SIS) -->
+		              <templateId root="1.2.250.1.213.1.1.3.45" />
+		              <id root="41DAC707-7C96-47B7-B600-AC63D8002142" />
+		              <code code="INITIMMUNIZ" displayName="1ère série vaccinante" 
+		                    codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActSubstanceAdministrationImmunizationCode" />
+		              <text><reference value="#tetanos1"/></text>
+		              <statusCode code="completed" />
+		              <effectiveTime value="20090928094914+0100" />
+		              <!-- Voie d'administration -->  
+		              <!-- valeur issue du JDV_ImmunizationRouteCodes-CISIS (1.2.250.1.213.1.1.5.676)  -->
+		              <routeCode code="20035000" displayName="Voie intramusculaire"
+		                         codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM"/>
+		              <!-- Région d'administration -->
+		              <!-- valeur issue du JDV_ImmunizationApproachSiteCode-CISIS (1.2.250.1.213.1.1.5.621)  -->
+		              <approachSiteCode code="16217701000119102" displayName="Deltoïde gauche" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+		                <originalText>
+		                  <reference value="#" />
+		                </originalText>
+		              </approachSiteCode>
+		              <!--Dose à administrer-->
+		              <doseQuantity value="1" />
+		              <!-- Entrée FR-Produit-de-sante -->
+		              <consumable typeCode="CSM">
+		                <manufacturedProduct>
+		                  <!-- Conformité Product (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.53" />
+		                  <!-- Conformité Product Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2" />
+		                  <!-- Conformité FR-Produit-de-sante (CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.43" />
+		                  <manufacturedMaterial>
+		                    <code code="3400936876293" displayName="REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig"
+		                      codeSystem="1.2.250.1.213.2.3.1" codeSystemName="CIS">
+		                      <originalText><reference value="#tetanos1"/></originalText>
+		                      <translation code="J07CA01" displayName="Vaccin diphtérie-polyomielite-tétanos"
+		                                   codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+		                    </code>
+		                    <name>REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig</name>
+		                    <lotNumberText>4456668</lotNumberText>
+		                  </manufacturedMaterial>
+		                </manufacturedProduct>
+		              </consumable>
+		              <!-- Exécutant -->
+		              <performer typeCode="PRF">
+		                <assignedEntity>
+		                  <id root="1.2.250.1.71.4.2.1" extension="801234567897" />
+		                  <code code="G15_10/SM26" displayName="Médecin - Qualifié en Médecine Générale (SM)" codeSystem="1.2.250.1.213.1.1.4.5" />
+		                  <addr nullFlavor="MSK" />
+		                  <telecom nullFlavor="MSK" />
+		                  <assignedPerson>
+		                    <name>
+		                      <family>MULLER</family>
+		                      <given>Charles</given>
+		                      <suffix>DR</suffix>
+		                    </name>
+		                  </assignedPerson>
+		                  <representedOrganization>
+		                    <id root="1.2.250.1.71.4.2.2" extension="101238887" />
+		                    <name>Cabinet médical du Dr MULLER</name>
+		                    <!-- JDV_J04-XdsPracticeSettingCode-CISIS (1.2.250.1.213.1.1.5.467) -->
+		                    <standardIndustryClassCode code="AMBULATOIRE" displayName="Ambulatoire" codeSystem="1.2.250.1.213.1.1.4.9" />
+		                  </representedOrganization>
+		                </assignedEntity>
+		              </performer>
+		              <!-- Entrée FR-Rang-de-la-vaccination -->
+		              <entryRelationship typeCode="SUBJ">
+		                <observation classCode="OBS" moodCode="EVN">
+		                  <!-- Conformité Medication series number observation (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.46" />
+		                  <!-- Conformité FR-Rang-de-la-vaccination (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.82" />
+		                  <code code="30973-2" displayName="Rang de la vaccination" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		                  <statusCode code="completed" />
+		                  <value xsi:type="INT" value="1" />
+		                </observation>
+		              </entryRelationship>
+		              <!-- Entrée FR-Probleme : Réaction observée-->
+		              <entryRelationship typeCode="CAUS" inversionInd="false">
+		                <observation classCode="OBS" moodCode="EVN">
+		                  <!-- Conformité Problem observation (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.28" />
+		                  <!-- Conformité Problem Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+		                  <!-- Conformité Reaction (IHE PCC) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.54" />
+		                  <!-- Conformité FR-Probleme (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.37" />
+		                  <id root="3374F9E9-6175-442E-929A-73B07F3D2484" />
+		                  <code code="418799008" displayName="symptôme rapporté par le patient ou le répondant" 
+		                        codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+		                  <text><reference value="#tetanos1-reac"/></text>
+		                  <statusCode code="completed" />
+		                  <effectiveTime>
+		                    <low value="20090825" />
+		                  </effectiveTime>
+		                  <value xsi:type="CD" code="R50.2" displayName="Fièvre due à des médicaments" codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM-10">
+		                    <originalText>
+		                      <reference value="#tetanos1-reac" />
+		                    </originalText>
+		                  </value>
+		                </observation>
+		              </entryRelationship>
+		              <!-- Entrée FR-Commentaire-ER -->
+		              <entryRelationship typeCode="SUBJ">
+		                <act classCode="ACT" moodCode="EVN">
+		                  <!-- Conformité Comment (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.40" />
+		                  <!-- Conformité Comment Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+		                  <!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.32" />
+		                  <code code="48767-8" displayName="Commentaire" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		                  <text>
+		                    <reference value="#tetanos1-comment" />
+		                  </text>
+		                  <statusCode code="completed" />
+		                </act>
+		              </entryRelationship>
+		            </substanceAdministration>
+		          </entry>
+		          
+		          <!-- [1..*] Entrée Entrée FR-Vaccination : Vaccination tétanos (2ème injection) -->
+		          <entry>
+		            <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+		              <!-- Conformité Medication activity (CCD) -->
+		              <templateId root="2.16.840.1.113883.10.20.1.24" />
+		              <!-- Conformité Immunizations (IHE PCC) -->
+		              <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.12" />
+		              <!-- Conformité FR-Vaccination (CI-SIS) -->
+		              <templateId root="1.2.250.1.213.1.1.3.45" />
+		              <id root="41DAC707-7C96-47B7-B600-AC63D8002142" />
+		              <code code="INITIMMUNIZ" displayName="1ère série vaccinante" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActSubstanceAdministrationImmunizationCode" />
+		              <text><reference value="#tetanos2"/></text>
+		              <statusCode code="completed" />
+		              <effectiveTime value="20090928094914+0100" />
+		              <!-- Voie d'administration -->              
+		              <!-- valeur issue du JDV_ImmunizationRouteCodes-CISIS (1.2.250.1.213.1.1.5.676)  -->
+		              <routeCode code="20035000" displayName="Voie intramusculaire"
+		                codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM"/>
+		              <!-- Région d'administration -->
+		              <!-- valeur issue du JDV_ImmunizationApproachSiteCode-CISIS (1.2.250.1.213.1.1.5.621)  -->              
+		              <approachSiteCode code="16217701000119102" displayName="Deltoïde gauche" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+		                <originalText>
+		                  <reference value="#" />
+		                </originalText>
+		              </approachSiteCode>
+		              <!--Dose à administrer-->
+		              <doseQuantity value="1" />
+		              <!-- Entrée FR-Produit-de-sante -->
+		              <consumable typeCode="CSM">
+		                <manufacturedProduct>
+		                  <!-- Conformité Product (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.53" />
+		                  <!-- Conformité Product Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2" />
+		                  <!-- Conformité FR-Produit-de-sante (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.43" />
+		                  <manufacturedMaterial>
+		                    <code code="3400936876293" displayName="REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig"
+		                      codeSystem="1.2.250.1.213.2.3.1" codeSystemName="CIS">
+		                      <originalText>
+		                        <reference value="#tetanos2" />
+		                      </originalText>
+		                      <translation code="J07CA01" displayName="Vaccin diphtérie-polyomielite-tétanos"
+		                        codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+		                    </code>
+		                    <name>REVAXIS Susp inj en seringue préremplie Ser/0,5ml+2Aig</name>
+		                    <lotNumberText>4456672</lotNumberText>
+		                  </manufacturedMaterial>
+		                </manufacturedProduct>
+		              </consumable>
+		              <!-- Exécutant -->
+		              <performer typeCode="PRF">
+		                <assignedEntity>
+		                  <id root="1.2.250.1.71.4.2.1" extension="801234567897" />
+		                  <code code="G15_10/SM26" displayName="Médecin - Qualifié en Médecine Générale (SM)" codeSystem="1.2.250.1.213.1.1.4.5" />
+		                  <addr nullFlavor="NASK" />
+		                  <telecom nullFlavor="NASK" />
+		                  <assignedPerson>
+		                    <name>
+		                      <family>MULLER</family>
+		                      <given>Charles</given>
+		                      <suffix>DR</suffix>
+		                    </name>
+		                  </assignedPerson>
+		                  <representedOrganization>
+		                    <id root="1.2.250.1.71.4.2.2" extension="101238887" />
+		                    <name>Cabinet médical du Dr MULLER</name>
+		                    <!-- JDV_J04-XdsPracticeSettingCode-CISIS (1.2.250.1.213.1.1.5.467) -->
+		                    <standardIndustryClassCode code="AMBULATOIRE" displayName="Ambulatoire" codeSystem="1.2.250.1.213.1.1.4.9" />
+		                  </representedOrganization>
+		                </assignedEntity>
+		              </performer>
+		              <!-- Entrée FR-Rang-de-la-vaccination -->
+		              <entryRelationship typeCode="SUBJ">
+		                <observation classCode="OBS" moodCode="EVN">
+		                  <!-- Conformité Medication series number observation (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.46" />
+		                  <!-- Conformité FR-Rang-de-la-vaccination (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.82" />
+		                  <code code="30973-2" displayName="Rang de la vaccination" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		                  <statusCode code="completed" />
+		                  <value xsi:type="INT" value="2" />
+		                </observation>
+		              </entryRelationship>
+		              <!-- Entrée FR-Probleme : Réaction observée-->
+		              <entryRelationship typeCode="CAUS" inversionInd="false">
+		                <observation classCode="OBS" moodCode="EVN">
+		                  <!-- Conformité Problem observation (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.28" />
+		                  <!-- Conformité Problem Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.5" />
+		                  <!-- Conformité Reaction (IHE PCC) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.54" />
+		                  <!-- Conformité FR-Probleme (FR CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.37" />
+		                  <id root="F9E020E2-D219-43D4-8BF8-6B275E1F726D" />
+		                  <code code="418799008" displayName="symptôme rapporté par le patient ou le répondant" 
+		                        codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+		                  <text><reference value="#tetanos2-reac"/></text>
+		                  <statusCode code="completed" />
+		                  <effectiveTime>
+		                    <low value="20090928" />
+		                  </effectiveTime>
+		                  <value xsi:type="CD" code="R50.2" displayName="Fièvre due à des médicaments" codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM-10" >
+		                    <originalText>
+		                      <reference value="#tetanos2-reac" />
+		                    </originalText>
+		                  </value>
+		                </observation>
+		              </entryRelationship>
+		              <!-- Entrée FR-Commentaire-ER -->
+		              <entryRelationship typeCode="SUBJ">
+		                <act classCode="ACT" moodCode="EVN">
+		                  <!-- Conformité Comment (CCD) -->
+		                  <templateId root="2.16.840.1.113883.10.20.1.40" />
+		                  <!-- Conformité Comment Entry (IHE PCC) -->
+		                  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.2" />
+		                  <!-- Conformité FR-Commentaire-ER (CI-SIS) -->
+		                  <templateId root="1.2.250.1.213.1.1.3.32" />
+		                  <code code="48767-8" displayName="Commentaire" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+		                  <text><reference value="#tetanos2-comment"/></text>
+		                  <statusCode code="completed" />
+		                </act>
+		              </entryRelationship>
+		            </substanceAdministration>
+		          </entry>
+		        
+		        </section>
+		    </component>
+
+			<!-- Section FR-Vaccins-recommandes -->
+			<component>
+				<section>
+					<!-- Conformité Immunization Recommendations (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.18.3.1"/>
+					<!-- Conformité FR-Vaccins-recommandes (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.120"/>
+					<code code="18776-5" displayName="Plan de soins"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Vaccin recommandé</title>
+					<text><content ID="vaccin-recommande-1">Vaccin antituberculeux</content></text>
+					
+					<!-- Entrée FR-Vaccin-recommande -->
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="INT" negationInd="false">
+							<!-- Conformité Plan of care activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.25"/>
+							<!-- Conformité Immunization Recommandation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.12.2"/>
+							<!-- Conformité FR-Vaccin-recommande (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.47"/>
+							<id root="41DAC707-8A98-47B7-B600-AC63D8002142"/>
+							<!-- Type de vaccination : 1ère série vaccinante ou Rappel ou Sans précision -->
+							<code code="IMMUNIZ" displayName="Vaccination sans autre précision"
+								codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+							<!-- Elément narratif de l'entrée -->
+							<text><reference value="vaccin-recommande-1"></reference></text>
+							<statusCode code="active"/>
+							<!-- Période de vaccination -->
+							<effectiveTime xsi:type="IVL_TS">
+								<low value="20231201"/>
+								<high value="20231231"/>
+							</effectiveTime>
+							<!-- Voie d'administration : valeur issue du JDV_ImmunizationRouteCodes-CISIS (1.2.250.1.213.1.1.5.676)  -->
+							<routeCode code="20035000" displayName="Voie intramusculaire"
+								codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM"/> 	
+							<!-- Dose administrée -->
+							<doseQuantity value="1"/>
+							<!-- Vaccin -->
+							<consumable typeCode="CSM">
+								<manufacturedProduct>
+									<!-- Conformité Product (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.53" />
+									<!-- Conformité Product Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2" />
+									<!-- Conformité FR-Produit-de-sante (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.43" />
+									<manufacturedMaterial>
+										<code>
+											<originalText><reference value="#vaccin-recommande-1"/></originalText>
+											<translation code="J07AN" displayName="Vaccin antituberculeux" codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+										</code>										
+									</manufacturedMaterial>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Historique-des-grossesses -->
+			<component>
+				<section>
+					<!-- Conformité Pregnancy History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.4" />
+					<!-- Conformité FR-Historique-des-grossesses (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.77" />
+					<id root="9612432A-A79C-44BC-BEC8-E323142C3A1B" />
+					<code code="10162-6" displayName="Historique des grossesses" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+					<title>Historique des grossesses</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Observation</th>
+									<th>Précision</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td><content ID="grossesse-statut">Statut de grossesse</content></td>
+									<td><content ID="grossesse-statut-value">patiente actuellement enceinte</content></td>
+								</tr>
+								<tr>
+									<td><content ID="date-accouchement">Date prévisionnelle d'accouchement</content></td>
+									<td>03/07/2022</td>
+								</tr>
+								<tr>
+									<td><content ID="age-premiere-grossesse">Âge à la première grossesse</content></td>
+									<td>30 ans</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Entrée FR-Observation-sur-la-grossesse : statut de grossesses -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Pregnancy Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.5" />
+							<!-- Conformité FR-Observation-sur-la-grossesse (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.53" />
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<code code="11449-6" displayName="Statut de grossesse" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+							<text><reference value="#grossesse-statut"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<!-- valeur issue du JDV_StatutGrossesse-CISIS (1.2.250.1.213.1.1.5.671) -->
+							<value xsi:type="CD" code="77386006" displayName="patiente actuellement enceinte" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+								<originalText><reference value="#grossesse-statut-value"/></originalText>
+							</value>              
+						</observation>
+					</entry>
+					<!-- Entrée FR-Observation-sur-la-grossesse : Date prévisionnelle d'accouchement -->
+					<entry typeCode="COMP">
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Pregnancy Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.5" />
+							<!-- Conformité FR-Observation-sur-la-grossesse (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.53" />
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C32" />
+							<code code="11778-8" displayName="Date prévisionnelle d'accouchement" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+							<text><reference value="#date-accouchement"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<value xsi:type="IVL_TS" value="20220703"/>              
+						</observation>
+					</entry>
+					<!-- Entrée FR-Observation-sur-la-grossesse : Âge à la première grossesse -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+							<!-- Conformité Pregnancy Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.5" />
+							<!-- Conformité FR-Observation-sur-la-grossesse (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.53" />
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C65" />
+							<code code="42797-1" displayName="Âge à la première grossesse" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+							<text><reference value="#age-premiere-grossesse"/></text>
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<value xsi:type="PQ" value="30" unit="a"/>              
+						</observation>
+					</entry>
+				</section>
+			</component>      
+
+			<!-- Section FR-Signes-vitaux -->
+			<component>
+				<section>
+					<!-- Conformité Vital Signs Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.16" />
+					<!-- Conformité Vital Signs Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.25" />
+					<!-- Conformité Coded Vital Signs Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.2" />
+					<!-- Conformité FR-Signes-vitaux (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.75" />
+					<id root="B70D20AA-0438-4092-AD2F-E376173C00D9" />
+					<code code="8716-3" displayName="Signes vitaux" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+					<title>Signes vitaux</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Signe vital</th>
+									<th>Valeur</th>
+									<th>Date de la mesure</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td ID="poids">Poids</td>
+									<td>58 kg</td>
+									<td>12/03/2022</td>
+								</tr>
+								<tr>
+									<td ID="taille">Taille</td>
+									<td>1,60 m</td>
+									<td>12/03/2022</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Entrée FR-Signes-vitaux -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Conformité Result organizer (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.32" />
+							<!-- Conformité Vital signs organizer (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.35" />
+							<!-- Conformité Vital Signs Organizer (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.1" />
+							<!-- Conformité FR-Signes-vitaux (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.49" />
+							<id root="A251A0D1-3C96-4209-B67E-F2F8F125BFDA" />              
+							<code code="85353-1" displayName="Signes vitaux" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+							<statusCode code="completed" />
+							<effectiveTime nullFlavor="NA" />
+							<!-- Entrée FR-Signe-vital-observe : Poids(kg) -->
+							<component typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Result observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.31" />
+									<!-- Conformité Simple Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+									<!-- Conformité Vital Signs Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.2" />
+									<!-- Conformité FR-Signe-vital-observé (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.50" />
+									<id root="8D40D39D-3574-496A-91EA-B7BE236ABD1A" />
+									<!-- valeur issue du JDV_SignesVitaux-CISIS (1.2.250.1.213.1.1.5.171) -->
+									<code code="29463-7" displayName="Poids" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+									<text><reference value="#poids"/></text>
+									<statusCode code="completed" />
+									<effectiveTime value="20220312"/>
+									<value xsi:type="PQ" value="58" unit="kg" />
+								</observation>
+							</component>
+							<!-- Entrée FR-Signe-vital-observe : Taille(cm) -->
+							<component typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Result observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.31" />
+									<!-- Conformité Simple Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13" />
+									<!-- Conformité Vital Signs Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.2" />
+									<!-- Conformité FR-Signe-vital-observé (FR CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.50" />
+									<id root="04CBA750-7FBD-482C-ABDF-D06275C3FC4A" />
+									<!-- valeur issue du JDV_SignesVitaux-CISIS (1.2.250.1.213.1.1.5.171) -->
+									<code code="8302-2" displayName="Taille" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+									<text><reference value="#taille"/></text>
+									<statusCode code="completed" />
+									<effectiveTime value="20220312"/>
+									<value xsi:type="PQ" value="1.60" unit="m" />
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Historique-prises-en-charge-medicales -->
+			<component>
+				<section>
+					<!-- Conformité Encounters section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.3"/>
+					<!-- Conformité Encounter Histories Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.3"/>
+					<!-- Conformité FR-Historique-prises-en-charge-medicales (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.76"/>
+					<id root="b70d20aa-0438-4092-ad2f-e376173c00R5"/>
+					<code code="46240-8" displayName="Historique des rencontres"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Historique des prises en charges médicales</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Type</th>
+									<th>Exécutant</th>
+									<th>Lieu</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>24/02/2023</td>
+									<td>Ambulatoire (hors établissement)</td>
+									<td>PR Jacques PETITJEAN (Hôpital Lariboisière)</td>
+									<td>Hôpital Lariboisière / Service hématologie (tel:0158453200)</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Entrée Rencontre -->
+					<entry>
+						<encounter classCode="ENC" moodCode="EVN">
+							<!-- Conformité Encounter activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.21"/>
+							<!-- Conformité Encounter (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.14"/>
+							<!-- Conformité FR-Rencontre (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.58"/>
+							<id root="4AA6dcfc-6628-42e7-8d6f-68621568f584"/>
+							<!-- Type de Rencontre -->
+							<code code="AMB" displayName="Ambulatoire (hors établissement)"
+								codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActEncounterCode"/>
+							<text><reference value="#Consult"/></text>
+							<!-- Date de Rencontre -->
+							<effectiveTime value="20230224"/>
+							<!-- Exécutant -->
+							<performer typeCode="PRF">
+								<assignedEntity>
+									<id nullFlavor="UNK"/>
+									<addr nullFlavor="NAV"/>
+									<telecom nullFlavor="NAV"/>
+									<assignedPerson>
+										<name>
+											<prefix>M</prefix>
+											<given>Jacques</given>
+											<family>PETITJEAN</family>											
+											<suffix>PR</suffix>
+										</name>
+									</assignedPerson>
+									<representedOrganization>
+										<name>Hôpital Lariboisière</name>
+										<addr nullFlavor="NAV"/>
+									</representedOrganization>
+								</assignedEntity>
+							</performer>
+							<!-- Lieu de la Rencontre -->
+							<participant typeCode="LOC">
+								<participantRole classCode="SDLOC">
+									<id/>
+									<code/>
+									<addr nullFlavor="NAV"/>
+									<telecom value="tel:0158453200" use="WP"/>
+									<playingEntity classCode="PLC" determinerCode="INSTANCE">
+										<name>Hôpital Lariboisière / Service hématologie</name>
+									</playingEntity>
+								</participantRole>
+							</participant>
+						</encounter>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Historique-prises-en-charge-medicales : Aucune rencontre -->
+			<component>
+				<section>
+					<!-- Conformité Encounters section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.3"/>
+					<!-- Conformité Encounter Histories Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.5.3.3"/>
+					<!-- Conformité FR-Historique-prises-en-charge-medicales (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.76"/>
+					<id root="b70d20aa-0438-4092-ad2f-e376173c00R5"/>
+					<code code="46240-8" displayName="Historique des rencontres"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Historique des prises en charges médicales</title>
+					<text ID="NO-ENCOUNTER">Aucune rencontre</text>
+					<!-- Entrée Rencontre [1..*] -->
+					<entry>
+						<encounter classCode="ENC" moodCode="EVN" nullFlavor="NA">
+							<!-- Conformité Encounter activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.21"/>
+							<!-- Conformité Encounter (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.14"/>
+							<!-- Conformité FR-Rencontre (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.58"/>
+							<id nullFlavor="NA"/>              
+							<code code="02276797" displayName="Aucun"
+								codeSystem="1.2.250.1.213.2.63" codeSystemName="Wolf"/>
+							<!-- Référence vers la partie narrative de la section DM -->
+							<text><reference value="#NO-ENCOUNTER"/></text>
+							<effectiveTime nullFlavor="NA"/>
+						</encounter>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Plan-de-soins -->
+			<component>
+				<section>
+					<!-- Conformité Care Plan Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.10" />
+					<!-- Conformité Plan of care Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.36" />
+					<!-- Conformité FR-Plan-de-soins (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.158" />
+					<id root="12DA3A06-18E7-40B7-9397-1FA5B1555692" />
+					<code code="18776-5" displayName="Plan de soins" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+					<title>Plan de soins</title>
+					<text>            
+						<paragraph><content styleCode="BoldItalics">Demandes d'examens ou de suivis : </content></paragraph>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date envisagée</th>
+									<th>Demande</th>
+									<th>Valeur</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>01/12/2022</td>
+									<td><content ID="plan-obs-request-01-code">Poids</content></td>
+									<td>65 kg</td>
+								</tr> 
+								<tr>
+									<td>01/12/2022</td>
+									<td><content ID="plan-obs-request-02-code">Autre examen (texte libre)</content></td>
+									<td>-</td>
+								</tr> 
+							</tbody>
+						</table>
+						<br/>
+						<paragraph><content styleCode="BoldItalics">Actes : </content></paragraph>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date envisagée</th>
+									<th>Acte</th>
+									<th>Statut</th>
+									<th>Priorité</th>
+								</tr>
+							</thead>
+							<tbody>                
+								<tr>
+									<td>01/12/2022</td>
+									<td><content ID="plan-acte-02-code">Pose d'une prothèse auditive implantable dans l'oreille moyenne</content></td> 
+									<td>en cours ou à venir</td>             
+									<td>Bénéfique pour le patient mais pas essentiel pour sa survie</td>                     
+								</tr>   
+							</tbody>
+						</table>
+						<br/>
+						<paragraph><content styleCode="BoldItalics">Rencontres : </content></paragraph>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date envisagée</th>
+									<th>Type de rencontre</th>
+									<th>Professionnel</th>
+									<th>Lieu</th>
+								</tr>
+							</thead>
+							<tbody>                
+								<tr>
+									<td>01/12/2022</td>
+									<td><content ID="plan-rencontre-03-code">Ambulatoire (hors établissement)</content></td>    
+									<td>PR Jacques PETITJEAN (Médecin - Oncologie, opt Onco-hématologie (SM))</td> 
+									<td>Hôpital Lariboisière (Service hématologie)</td>                    
+								</tr>   
+							</tbody>
+						</table>
+						<br/>
+						<paragraph><content styleCode="BoldItalics">Vaccins recommandés :</content></paragraph>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date envisagée</th>
+									<th>Vaccin</th>
+									<th>Rang</th>
+								</tr>
+							</thead>
+							<tbody>                
+								<tr>
+									<td>du 01/12/2023 au 31/12/2023</td>
+									<td><content ID="plan-vaccin-04-code">Vaccin antituberculeux</content></td>    
+									<td>1</td> 
+								</tr>   
+							</tbody>
+						</table>            
+					</text>          
+					
+					<!-- [0..*] Entrée FR-Demande-d-examen-ou-de-suivi (codé) -->
+					<entry>
+						<observation classCode="OBS" moodCode="GOL">    
+							<!-- Conformité Plan of care activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.25"/>
+							<!-- Conformité Observation Request (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.20.3.1"/>
+							<!-- Conformité FR-Demande-d-examen-ou-de-suivi (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.27"/>
+							<id root="f83d3db2-c511-4cfa-b216-773f6deadb4d"/>
+							<!-- Type d’examen -->
+							<code code="29463-7" displayName="Poids" 
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#plan-obs-request-01-code"/></text>
+							<statusCode code="active"/>
+							<!-- Date de l’examen -->
+							<effectiveTime value="20221201"/>
+							<!-- Résultat -->
+							<value xsi:type="PQ" value="65" unit="kg"/>                
+						</observation>
+					</entry>
+					
+					<!-- [0..*] Entrée FR-Demande-d-examen-ou-de-suivi (texte libre) -->
+					<entry>
+						<observation classCode="OBS" moodCode="GOL">    
+							<!-- Conformité Plan of care activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.25"/>
+							<!-- Conformité Observation Request (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.20.3.1"/>
+							<!-- Conformité FR-Demande-d-examen-ou-de-suivi (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.27"/>
+							<id root="f83d3db2-c511-4cfa-b216-773f6deadb4E"/>
+							<!-- Type d’examen -->
+							<code code="GEN-092.04.20" displayName="Autre demande d’examen ou de suivi" codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA_ASIP">
+								<originalText><reference value="#plan-obs-request-02-code"></reference></originalText>
+							</code>
+							<text><reference value="#plan-obs-request-02-code"/></text>
+							<statusCode code="active"/>
+							<!-- Date de l’examen -->
+							<effectiveTime value="20221201"/>             
+						</observation>
+					</entry>
+					
+					<!-- [0..*] Entrée FR-Acte -->
+					<entry>
+						<procedure classCode="PROC" moodCode="EVN">
+							<!-- Conformité Procedure Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.19" />
+							<!-- Conformité Procedure activity (CCD) = acte réalisé -->
+							<templateId root="2.16.840.1.113883.10.20.1.29" />
+							<!-- Conformité FR-Acte (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.62" />
+							<id root="A6BC7FD2-EC3F-4E01-B567-854B087D1D9B" />
+							<!-- Code de l'acte -->
+							<code code="CBLA001" displayName="Pose d'une prothèse auditive implantable dans l'oreille moyenne" 
+								codeSystem="1.2.250.1.213.2.5" codeSystemName="CCAM" />
+							<text>
+								<reference value="#plan-acte-02-code" />
+							</text>
+							<!-- valeur issue du JDV_HL7_ActStatus-CISIS (2.16.840.1.113883.1.11.15933) -->
+							<statusCode code="active" />
+							<!-- Date de l'acte -->
+							<effectiveTime value="20221201" />
+							<!-- valeur issue du JDV_HL7_ActPriority-CISIS (2.16.840.1.113883.5.7) -->
+							<priorityCode code="EL" displayName="Bénéfique pour le patient mais pas essentiel pour sa survie"
+								codeSystem="2.16.840.1.113883.5.7" codeSystemName="HL7:ActPriority"/>            
+						</procedure>
+					</entry>
+					
+					<!-- [0..*] Entrée FR-Rencontre -->
+					<entry>
+						<encounter classCode="ENC" moodCode="ARQ">
+							<!-- Conformité Plan of care activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.25"/>
+							<!-- Conformité Encounter (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.14"/>
+							<!-- Conformité FR-Rencontre (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.58"/>
+							<id root="4AA6dcfc-6628-42e7-8d6f-68621568f584"/>
+							<!-- Type de Rencontre -->
+							<code code="AMB" displayName="Ambulatoire (hors établissement)"
+								codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActEncounterCode"/>
+							<text><reference value="#plan-rencontre-03-code"/></text>
+							<!-- Date de Rencontre -->
+							<effectiveTime value="20221201"/>
+							<!-- valeur issue du JDV_HL7_ActPriority-CISIS (2.16.840.1.113883.5.7) -->
+							<priorityCode code="CS" displayName="recontacter pour fixer RDV"
+								codeSystem="2.16.840.1.113883.5.7" codeSystemName="ActPriority"/>              
+							<!-- Exécutant -->
+							<performer typeCode="PRF">
+								<assignedEntity>
+									<!--<id nullFlavor="UNK"/>-->
+									<id root="1.2.250.1.71.4.2.1" extension="801234567897"/>
+									<code code="G15_10/SM35" codeSystem="1.2.250.1.213.1.1.4.5" displayName="Médecin - Oncologie, opt Onco-hématologie (SM)"/>
+									<addr nullFlavor="NAV"/>
+									<telecom nullFlavor="NAV"/>
+									<assignedPerson>
+										<name>
+											<prefix>PR</prefix>
+											<given>Jacques</given>
+											<family>PETITJEAN</family>
+										</name>
+									</assignedPerson>
+									<representedOrganization>
+										<name>Hôpital Lariboisière</name>
+										<addr nullFlavor="NAV"/>
+									</representedOrganization>
+								</assignedEntity>
+							</performer>
+							
+							<!-- Lieu de la Rencontre -->
+							<participant typeCode="LOC">
+								<participantRole classCode="SDLOC">
+									<id/>
+									<code/>
+									<addr nullFlavor="NAV"/>
+									<telecom value="tel:0158453200" use="WP"/>
+									<playingEntity classCode="PLC" determinerCode="INSTANCE">
+										<name>Hôpital Lariboisière (Service hématologie)</name>
+									</playingEntity>
+								</participantRole>
+							</participant>
+						</encounter>
+					</entry>
+					
+					<!-- [0..*] Entrée FR-Vaccin-recommande -->
+					<entry>
+						<substanceAdministration classCode="SBADM" moodCode="INT" negationInd="false">
+							<!-- Conformité Plan of care activity (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.25"/>
+							<!-- Conformité Immunization Recommandation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.12.2"/>
+							<!-- Conformité FR-Vaccin-recommande (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.47"/>
+							<id root="41DAC707-8A98-47B7-B600-AC63D8002142"/>
+							<!-- Type de vaccination : 1ère série vaccinante ou Rappel ou Sans précision -->
+							<code code="IMMUNIZ" displayName="Vaccination sans autre précision"
+								codeSystem="2.16.840.1.113883.5.4" codeSystemName="HL7:ActCode"/>
+							<!-- Elément narratif de l'entrée -->
+							<text><reference value="plan-vaccin-04-code"></reference></text>
+							<statusCode code="active"/>
+							<!-- Période de vaccination -->
+							<effectiveTime xsi:type="IVL_TS">
+								<low value="20231201"/>
+								<high value="20231231"/>
+							</effectiveTime>
+							<!-- Voie d'administration : valeur issue du JDV_ImmunizationRouteCodes-CISIS (1.2.250.1.213.1.1.5.676)  -->
+							<routeCode code="20035000" displayName="Voie intramusculaire"
+								codeSystem="0.4.0.127.0.16.1.1.2.1" codeSystemName="EDQM"/> 	
+							<!-- Dose administrée -->
+							<doseQuantity value="1"/>
+							<!-- Vaccin -->
+							<consumable typeCode="CSM">
+								<manufacturedProduct>
+									<!-- Conformité Product (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.53" />
+									<!-- Conformité Product Entry (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.7.2" />
+									<!-- Conformité FR-Produit-de-sante (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.43" />
+									<manufacturedMaterial>
+										<code>
+											<originalText><reference value="#plan-vaccin-04-code"/></originalText>
+											<translation code="J07AN" displayName="Vaccin antituberculeux" codeSystem="2.16.840.1.113883.6.73" codeSystemName="ATC"/>
+										</code>
+									</manufacturedMaterial>
+								</manufacturedProduct>
+							</consumable>
+						</substanceAdministration>
+					</entry>
+					
+				</section>
+			</component>      
+			
+			<!-- Section FR-Antecedents-familiaux -->
+			<component>
+				<section>
+					<!-- Conformité Family History Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.4"/>
+					<!-- Conformité Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.14"/>
+					<!-- Conformité Coded Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.15"/>
+					<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.139"/>
+					<id root="b70d20aa-0438-4092-ad2f-e376173c56P9"/>
+					<code code="10157-6" displayName="Historique des pathologies familiales"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents familiaux</title>
+					<text>            
+						<paragraph><content styleCode="BoldItalics">Père</content></paragraph>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Date</th>
+									<th>Problème</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>2000</td>
+									<td><content ID="ant-fam-pere-01">Accident Ischémique Transitoire</content></td>
+								</tr> 								
+							</tbody>
+						</table>						
+					</text>          
+					<!-- [1..*] Entrée FR-Antecedents-familiaux -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Conformité Family history organizer (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.23"/>
+							<!-- Conformité Family History Organizer (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15"/>
+							<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.59"/>
+							<statusCode code="completed"/>
+							<subject typeCode="SBJ">
+								<!-- Conformité Subject participation (IHE PCC) -->
+								<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15.2"/>
+								<!-- Conformité FR-Sujet (CI-SIS) -->
+								<templateId root="1.2.250.1.213.1.1.3.60"/>
+								<relatedSubject classCode="PRS">
+									<!-- Lien de parenté : JDV_HL7_PersonalRelationshipRoleType-CISIS (2.16.840.1.113883.1.11.19563) -->
+									<code code="FTH" displayName="Père" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7:RoleCode"/>
+									<subject>
+										<administrativeGenderCode code="M" displayName="Masculin"
+											codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7:AdministrativeGender"/>
+										<birthTime value="19570103"/>										
+									</subject>
+								</relatedSubject>
+							</subject>
+							<!-- [1..*] Entrée FR-Antecedent-familial-observe -->
+							<component typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Family history observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.22"/>
+									<!-- Conformité Simple Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+									<!-- Conformité Family History Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.3"/>
+									<!-- Conformité FR-Antecedent-familial-observe (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.51"/>
+									<id root="f83d3db2-c511-4cfa-b216-773f6deadc9e"/>
+									<code code="282291009" displayName="interprétation diagnostique" 
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+									<text><reference value=""/></text>
+									<statusCode code="completed"/>
+									<effectiveTime value="2000"/>
+									<value xsi:type="CE" code="G45.9"
+										displayName="Accident Ischémique Transitoire"
+										codeSystem="2.16.840.1.113883.6.3" codeSystemName="CIM10">
+										<originalText><reference value="#ant-fam-pere-01"/></originalText>
+									</value>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+				</section>
+			</component>
+
+			<!-- Section FR-Antecedents-familiaux : Pas d'information-->
+			<component>
+				<section>
+					<!-- Conformité Family History Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.4"/>
+					<!-- Conformité Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.14"/>
+					<!-- Conformité Coded Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.15"/>
+					<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.139"/>
+					<id root="b70d20aa-0438-4092-ad2f-e376173c56P9"/>
+					<code code="10157-6" displayName="Historique des pathologies familiales"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents familiaux</title>
+					<text ID="ANT-FAM-UNK">Pas d'information </text>
+					<!-- [1..*] Entrée FR-Antecedents-familiaux -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Conformité Family history organizer (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.23"/>
+							<!-- Conformité Family History Organizer (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15"/>
+							<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.59"/>
+							<statusCode code="completed"/>
+							<subject typeCode="SBJ">
+								<!-- Conformité Subject participation (IHE PCC) -->
+								<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15.2"/>
+								<!-- Conformité FR-Sujet (CI-SIS) -->
+								<templateId root="1.2.250.1.213.1.1.3.60"/>
+								<relatedSubject classCode="PRS">
+									<code nullFlavor="UNK"/>
+								</relatedSubject> 
+							</subject> 
+							<!-- [1..*] Entrée FR-Antecedent-familial-observe -->
+							<component typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Family history observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.22"/>
+									<!-- Conformité Simple Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+									<!-- Conformité Family History Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.3"/>
+									<!-- Conformité FR-Antecedent-familial-observe (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.51"/>
+									<id root="f83d3db2-c511-4cfa-b216-773f6deadc9e"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#FAM-HIST-UNK"/></text>
+									<statusCode code="completed"/>
+									<effectiveTime nullFlavor ="UNK"/>
+									<value xsi:type="CD" code="no-problem-info" 
+										displayName="Pas d'information sur les problèmes"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">										
+										<originalText><reference value="#ANT-FAM-UNK"></reference></originalText>
+									</value>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Antecedents-familiaux : Aucun antécédent familial -->
+			<component>
+				<section>
+					<!-- Conformité Family History Section (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.4"/>
+					<!-- Conformité Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.14"/>
+					<!-- Conformité Coded Family Medical History Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.15"/>
+					<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.139"/>
+					<id root="b70d20aa-0438-4092-ad2f-e376173c56P9"/>
+					<code code="10157-6" displayName="Historique des pathologies familiales"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Antécédents familiaux</title>
+					<text ID="NO-ANT-FAM">Aucun antécédent familial</text>
+					<!-- [1..*] Entrée FR-Antecedents-familiaux -->
+					<entry>
+						<organizer classCode="CLUSTER" moodCode="EVN">
+							<!-- Conformité Family history organizer (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.23"/>
+							<!-- Conformité Family History Organizer (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15"/>
+							<!-- Conformité FR-Antecedents-familiaux (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.59"/>
+							<statusCode code="completed"/>
+							<subject typeCode="SBJ">
+								<!-- Conformité Subject participation (IHE PCC) -->
+								<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.15.2"/>
+								<!-- Conformité FR-Sujet (CI-SIS) -->
+								<templateId root="1.2.250.1.213.1.1.3.60"/>
+								<relatedSubject classCode="PRS">
+									<code nullFlavor ="UNK"/>
+								</relatedSubject> 
+							</subject> 
+							<!-- [1..*] Entrée FR-Antecedent-familial-observe -->
+							<component typeCode="COMP">
+								<observation classCode="OBS" moodCode="EVN">
+									<!-- Conformité Family history observation (CCD) -->
+									<templateId root="2.16.840.1.113883.10.20.1.22"/>
+									<!-- Conformité Simple Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+									<!-- Conformité Family History Observation (IHE PCC) -->
+									<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.3"/>
+									<!-- Conformité FR-Antecedent-familial-observe (CI-SIS) -->
+									<templateId root="1.2.250.1.213.1.1.3.51"/>
+									<id root="f83d3db2-c511-4cfa-b216-773f6deadc9e"/>
+									<code code="55607006" displayName="problème"
+										codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+									<text><reference value="#NO-FAM-HIST"/></text>
+									<statusCode code="completed"/>
+									<effectiveTime nullFlavor ="NA"/>
+									<value xsi:type="CD" code="no-known-problems" displayName="Pas de problème connu"
+										codeSystem="2.16.840.1.113883.5.1150.1" 
+										codeSystemName="IPS CodeSystem - Absent and Unknown Data">										
+										<originalText><reference value="#NO-ANT-FAM"></reference></originalText>
+									</value>
+								</observation>
+							</component>
+						</organizer>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Actes-et-interventions : Aucun acte -->
+			<component>
+				<section>
+					<!-- Conformité Procedures and Interventions (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.11"/>
+					<!-- Conformité FR-Actes-et-interventions (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.118"/>
+					<id root="4A402640-1CF6-4153-B5BA-D56B623004C8"/>
+					<code code="29554-3" displayName="Actes" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>						
+					<title>Actes et interventions</title>     
+					<text ID="NO-ACT">Pas d'acte ou intervention connu</text>
+					
+					<!-- Entrée FR-Acte -->
+					<entry>
+						<procedure classCode="PROC" moodCode="EVN" negationInd="true">
+							<!-- Conformité Procedure Entry (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.19"/>
+							<!-- Conformité Procedure activity (CCD) : acte réalisée -->
+							<templateId root="2.16.840.1.113883.10.20.1.29"/>
+							<!-- Conformité FR-Acte (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.62"/>
+							<id nullFlavor="NA"/>
+							<code code="no-known-procedures" 
+								displayName="Pas d'acte ou intervention connu"
+								codeSystem="2.16.840.1.113883.5.1150.1" 
+								codeSystemName="IPS CodeSystem - Absent and Unknown Data">
+								<originalText><reference value="#NO-ACT"/></originalText>
+							</code>							
+							<text><reference value="#NO-ACT"/></text>
+							<statusCode code="completed"/>
+							<effectiveTime nullFlavor="NA"/>
+						</procedure>
+					</entry>
+				</section>
+			</component>
+			
+			<!-- Section FR-Dispositions -->
+			<component>
+				<section>
+					<!-- Conformité ED Disposition (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.10"/>
+					<!-- Conformité FR-Dispositions (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.172"/>
+					<id root="df6b5534-b28e-499B-968e-2ccac9b54789"/>
+					<code code="11302-7" displayName="Dispositions"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Dispositions pour le patient</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Disposition</th>
+									<th>Exécutant</th>
+									<th>Destination</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Etablissement de santé de préférence</td>
+									<td>-</td>
+									<td>Maison de retraite du Boulevard Saint Paul</td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- [1..*] Entrée FR-Disposition -->
+					<entry>
+						<act classCode="ACT" moodCode="INT">
+							<!-- Conformité Encounter Disposition (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.10.4.2"/>
+							<!-- Conformité FR-Disposition (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.97"/>
+							<id root="df6b5534-b28e-499B-968e-2ccac9b56709"/>
+							<code code="11302-7" displayName="Etablissement de santé de préférence" 
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#ES-destination"/></text>
+							<statusCode code="normal"/>
+							<effectiveTime value="20200702"/>						
+							<!-- Destinataire -->
+							<participant typeCode="RCV">							
+								<participantRole classCode="ROL">
+									<!-- Identifiant de l'établissement -->
+									<id root="1.2.250.1.71.4.2.2" extension="455454"/>
+									<!-- Type de l'établissement -->
+									<code code="SA17" displayName="Etablissement Personnes Agées"
+										codeSystem="1.2.250.1.71.4.2.4" codeSystemName="R02"/>
+									<!-- Adresse de l'établissement -->
+									<addr use="WP">
+										<streetAddressLine>21 Boulevard Saint Paul</streetAddressLine>
+										<streetAddressLine>75012 PARIS</streetAddressLine>
+									</addr>
+									<!-- Coordonnées télécom de l'établissement -->
+									<telecom value="tel:0517540000" use="WP"/>
+									<!-- Nom de l'établissement -->
+									<playingEntity classCode="ENT">
+										<name>Maison de retraite du Boulevard Saint Paul</name>
+									</playingEntity>
+								</participantRole>
+							</participant>						
+						</act>
+					</entry>
+					
+				</section>
+			</component>
+			
+			<!-- Section FR-Fonctions-physiques -->
+			<component>
+				<section>
+					<!-- Conformité Physical Function Section (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.12.2.5"/>
+					<!-- Conformité FR-Fonctions-physiques (CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.115"/>
+					<id root="df6b5534-b28e-499B-968e-2ccac9b98914"/>
+					<code code="46006-3"
+						displayName="Problèmes physiques fonctionnels et structurels"
+						codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+					<title>Problèmes physiques fonctionnels et structurels</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Type d'évaluation</th>
+									<th>Date</th>
+									<th>Valeur</th>
+									<th>Interprétation</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Echelle de performance OMS</td>
+									<td>28/05/2010</td>
+									<td><content ID="echelle-performance-OMS">Stade 1</content></td>
+									<td>Capable d'une activité identique à celle précédant la maladie sans aucune restriction</td>
+								</tr>
+								<tr>
+									<td>Marcher</td>
+									<td>14/01/2018</td>
+									<td><content ID="statut-fonctionnel">Restriction modérée de la performance de marche sur de courtes distances</content></td>
+									<td></td>
+								</tr>
+							</tbody>
+						</table>
+					</text>
+					<!-- Entrée FR-Evaluation : Echelle de performance OMS -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Simple Observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.31"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Survey Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.12.3.6"/>
+							<!-- Conformité FR-Evaluation (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.25"/>
+							<id root="8BD1C820-95A6-44ED-80C3-4399F97E5D37"/>
+							<!-- Type d'évaluation -->
+							<code code="42800-3" displayName="Echelle de performance OMS" 
+								codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>							
+							<text><reference value="#echelle-performance-OMS"/></text>
+							<statusCode code="completed"/>
+							<effectiveTime value="20100528"/>
+							<!-- Valeur de l'évaluation -->
+							<value xsi:type="CD" code="MED-264" displayName="Stade 1"
+								codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA_ASIP">
+								<originalText>
+									<reference value="#echelle-performance-OMS"/>
+								</originalText>
+							</value>
+							<interpretationCode code="MED-241" displayName="Capable d'une activité identique 
+								à celle précédant la maladie sans aucune restriction"
+								codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA_ASIP"/>
+						</observation>
+					</entry>	
+					<!-- Entrée FR-Evaluation : marcher -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN" negationInd="false">
+							<!-- Conformité Simple Observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.31"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Survey Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.12.3.6"/>
+							<!-- Conformité FR-Evaluation (CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.25"/>
+							<id root="FC21DC59-43D5-4BB0-ACC7-3601784DLSM5" />
+							<!-- Type d'évaluation -->
+							<code code="d450" displayName="Marcher"
+								codeSystem="2.16.840.1.113883.6.254" codeSystemName="ICF"/>
+							<text><reference value="#statut-fonctionnel"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180114" />
+							</effectiveTime>
+							<!-- Valeur de l'évaluation -->
+							<value xsi:type="CD" code="d4500.3" 
+								displayName="Restriction modérée de la performance de marche sur de courtes distances"
+								codeSystem="2.16.840.1.113883.6.254" codeSystemName="ICF">
+								<originalText>
+									<reference value="#statut-fonctionnel"/>
+								</originalText>
+							</value>
+						</observation>
+					</entry>					
+				</section>
+			</component>
+			
+			<!-- Section FR-Directives-anticipees -->
+			<component>
+				<section>    
+					<!-- Conformité Advanced directives (CCD) -->
+					<templateId root="2.16.840.1.113883.10.20.1.1" />             
+					<!-- Conformité Advanced directives (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.34" />          
+					<!-- Conformité coded Advanced directives (IHE PCC) -->
+					<templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.35" />    
+					<!-- Conformité FR-Directives-anticipees (FR CI-SIS) -->
+					<templateId root="1.2.250.1.213.1.1.2.157" />
+					<id root="12DA3A06-18E7-40B7-9397-1FA5B1555690" />
+					<code code="42348-3" displayName="Directives anticipées" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+					<title>Directives anticipées</title>
+					<text>
+						<table border="0">
+							<thead>
+								<tr>
+									<th>Directive</th>
+									<th>Précision</th>
+									<th>Date de la directive</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td><content ID="maintien-artificiel-en-vie">Maintient artificiel en vie</content></td>
+									<td>Non autorisé</td>
+									<td>01/01/2018</td>
+								</tr>
+								<tr>
+									<td><content ID="assistance-respiratoire">Assistance respiratoire</content></td>
+									<td>Non autorisé</td>
+									<td>01/01/2018</td>
+								</tr>
+								<tr>
+									<td><content ID="alimentation-hydratation-artificielles">Alimentation et hydratation artificielles</content></td>
+									<td>Non autorisé</td>
+									<td>01/01/2018</td>
+								</tr>
+								<tr>
+									<td><content ID="dialyse-renale">Dialyse rénale</content></td>
+									<td>Autorisé</td>
+									<td>01/01/2018</td>
+								</tr>
+								<tr>
+									<td><content ID="reanimation-cardiaque-respiratoire">Réanimation cardiaque et respiratoire</content></td>
+									<td>Non autorisé</td>
+									<td>01/01/2018</td>
+								</tr>   
+								<tr>
+									<td><content ID="intervention-chirurgicale">Intervention chirurgicale</content></td>
+									<td>Autorisé</td>
+									<td>01/01/2018</td>
+								</tr>     
+								<tr>
+									<td><content ID="sedation-profonde">Sédation profonde et continue associée à un traitement de la douleur</content></td>
+									<td>Autorisé</td>
+									<td>01/01/2018</td>
+								</tr>            
+							</tbody>
+						</table>
+					</text>
+					<!-- Entrée FR-Directive-Anticipee : Maintient artificiel en vie -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="75789-8" displayName="Maintient artificiel en vie" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#maintien-artificiel-en-vie"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="false"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Assistance respiratoire -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="75787-2" displayName="Assistance respiratoire" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#assistance-respiratoire"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="false"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Alimentation et hydratation artificielles -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="77352-3" displayName="Alimentation et hydratation artificielles" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#alimentation-hydratation-artificielles"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="false"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Dialyse rénale -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="MED-295" displayName="Dialyse rénale" codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA-ASIP"/>
+							<text><reference value="#dialyse-renale"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="true"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Réanimation cardiaque et respiratoire -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="75779-9" displayName="Réanimation cardiaque et respiratoire" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+							<text><reference value="#reanimation-cardiaque-respiratoire"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="false"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Intervention chirurgicale -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="MED-293" displayName="Intervention chirurgicale" codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA_ASIP"/>
+							<text><reference value="#intervention-chirurgicale"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="true"/>       
+						</observation>
+					</entry>
+					<!-- Entrée FR-Directive-Anticipee : Sédation profonde et continue associée à un traitement de la douleur -->
+					<entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<!-- Conformité Advance directive observation (CCD) -->
+							<templateId root="2.16.840.1.113883.10.20.1.17"/>
+							<!-- Conformité Simple Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13"/>
+							<!-- Conformité Advance Directive Observation (IHE PCC) -->
+							<templateId root="1.3.6.1.4.1.19376.1.5.3.1.4.13.7"/>
+							<!-- Conformité FR-Directive-Anticipee (FR CI-SIS) -->
+							<templateId root="1.2.250.1.213.1.1.3.54"/>
+							<id root="4FD525FD-8712-40F9-BF31-EF9A25069C25" />
+							<!-- valeur issue du JDV_TypeDirectiveAnticipee-CISIS (1.2.250.1.213.1.1.5.136) -->
+							<code code="MED-298" displayName="Sédation profonde et continue associée à un traitement de la douleur" codeSystem="1.2.250.1.213.1.1.4.322" codeSystemName="TA_ASIP"/>
+							<text><reference value="#sedation-profonde"/></text>
+							<statusCode code="completed" />
+							<effectiveTime>
+								<low value="20180101"/>
+								<high nullFlavor="NA"/>
+							</effectiveTime>
+							<!-- autorisé (true) / non autorisé (false) -->
+							<value xsi:type="BL" value="true"/>       
+						</observation>
+					</entry>
+					
+				</section>
+			</component>
+			
+		</structuredBody>
+	</component>
+</ClinicalDocument>

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -1,58 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
-    xmlns:hl7="urn:hl7-org:v3"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:sdtc="urn:hl7-org:sdtc"
-    xmlns="http://www.w3.org/1999/xhtml"
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:hl7="urn:hl7-org:v3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns:sdtc="urn:hl7-org:sdtc" xmlns="http://www.w3.org/1999/xhtml"
     exclude-result-prefixes="xd hl7 xsi xhtml sdtc">
     <xd:doc scope="stylesheet">
         <xd:desc>
             <xd:p><xd:b>Title:</xd:b> CDA R2 StyleSheet</xd:p>
             <xd:p><xd:b>Version:</xd:b> 4.1.0-alpha2</xd:p>
-            <xd:p><xd:b>Maintained by:</xd:b> HL7 <xd:a href="https://confluence.hl7.org/display/SD/Structured+Documents">Structured Documents Work Group</xd:a></xd:p>
-            <xd:p><xd:b>Purpose:</xd:b> Provides general purpose display of CDA release 2.0 and 2.1 (Specification: ANSI/HL7 CDAR2) and CDA release 3 (Specification was pulled after ballot) documents. It may also be a starting point for people interested in extending the display. This stylesheet displays all section content, but does not try to render each and every header attribute. For header attributes it tries to be smart in displaying essentials, which is still a lot.</xd:p>
-            <xd:p><xd:b>License:</xd:b> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a></xd:p>
-            <xd:p><xd:b>Warranty</xd:b> The CDA XSL is a sample rendering and should be used in that fashion without warranty or guarantees of suitability for a particular purpose. The stylesheet should be tested locally by implementers before production usage.</xd:p>
-            <xd:p><xd:b>Project Link:</xd:b> <xd:a href="https://github.com/HL7/cda-core-xsl">https://github.com/HL7/cda-core-xsl</xd:a>. Including downloads of releases, documentation, issue tracker and more.</xd:p>
-            <xd:p><xd:b>History:</xd:b> This stylesheet stands on the shoulders of giants. The stylesheet is the cumulative work of several developers; the most significant prior milestones were the foundation work from HL7 Germany and Finland (Tyylitiedosto) and HL7 US (Calvin Beebe), and the presentation approach from Tony Schaller, medshare GmbH provided at IHIC 2009. The stylesheet has subsequently been maintained/updated by Lantana Group (US) and Nictiz (NL).</xd:p>
-            <xd:p><xd:b>Revisions:</xd:b> The release notes previously contained in the stylesheet, have moved to the <xd:a href="https://github.com/HL7/cda-core-xsl/wiki/Revisions">GitHub</xd:a> where the project is maintained.</xd:p>
+            <xd:p><xd:b>Maintained by:</xd:b> HL7 <xd:a
+                    href="https://confluence.hl7.org/display/SD/Structured+Documents">Structured
+                    Documents Work Group</xd:a></xd:p>
+            <xd:p><xd:b>Purpose:</xd:b> Provides general purpose display of CDA release 2.0 and 2.1
+                (Specification: ANSI/HL7 CDAR2) and CDA release 3 (Specification was pulled after
+                ballot) documents. It may also be a starting point for people interested in
+                extending the display. This stylesheet displays all section content, but does not
+                try to render each and every header attribute. For header attributes it tries to be
+                smart in displaying essentials, which is still a lot.</xd:p>
+            <xd:p><xd:b>License:</xd:b> Licensed under the Apache License, Version 2.0 (the
+                "License"); you may not use this file except in compliance with the License. You may
+                obtain a copy of the License at <a href="http://www.apache.org/licenses/LICENSE-2.0"
+                    >http://www.apache.org/licenses/LICENSE-2.0</a></xd:p>
+            <xd:p><xd:b>Warranty</xd:b> The CDA XSL is a sample rendering and should be used in that
+                fashion without warranty or guarantees of suitability for a particular purpose. The
+                stylesheet should be tested locally by implementers before production usage.</xd:p>
+            <xd:p><xd:b>Project Link:</xd:b>
+                <xd:a href="https://github.com/HL7/cda-core-xsl"
+                    >https://github.com/HL7/cda-core-xsl</xd:a>. Including downloads of releases,
+                documentation, issue tracker and more.</xd:p>
+            <xd:p><xd:b>History:</xd:b> This stylesheet stands on the shoulders of giants. The
+                stylesheet is the cumulative work of several developers; the most significant prior
+                milestones were the foundation work from HL7 Germany and Finland (Tyylitiedosto) and
+                HL7 US (Calvin Beebe), and the presentation approach from Tony Schaller, medshare
+                GmbH provided at IHIC 2009. The stylesheet has subsequently been maintained/updated
+                by Lantana Group (US) and Nictiz (NL).</xd:p>
+            <xd:p><xd:b>Revisions:</xd:b> The release notes previously contained in the stylesheet,
+                have moved to the <xd:a href="https://github.com/HL7/cda-core-xsl/wiki/Revisions"
+                    >GitHub</xd:a> where the project is maintained.</xd:p>
         </xd:desc>
     </xd:doc>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>XSLT 1.0 does not have date function, so we need something to compare against e.g. to get someones age</xd:p>
+            <xd:p>XSLT 1.0 does not have date function, so we need something to compare against e.g.
+                to get someones age</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="currentDate" select="(/hl7:ClinicalDocument/hl7:effectiveTime/@value)[1]"/>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Vocabulary file containing language dependant strings such as labels</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="vocFile" select="'cda_l10n.xml'"/>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Cache language dependant strings</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:variable name="vocMessages" select="document($vocFile)"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Default language for retrieval of language dependant strings such as labels, e.g. 'en-US'. This is the fallback language in case the string is not available in the actual language. See also <xd:ref name="textLang" type="parameter">textLang</xd:ref>.</xd:p>
+            <xd:p>Default language for retrieval of language dependant strings such as labels, e.g.
+                'en-US'. This is the fallback language in case the string is not available in the
+                actual language. See also <xd:ref name="textLang" type="parameter"
+                >textLang</xd:ref>.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="textlangDefault" select="'en-US'"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Actual language for retrieval of language dependant strings such as labels, e.g. 'en-US'. Unless supplied, this is taken from the ClinicalDocument/language/@code attribute, or in case that is not present from <xd:ref name="textlangDefault" type="parameter">textlangDefault</xd:ref>.</xd:p>
+            <xd:p>Actual language for retrieval of language dependant strings such as labels, e.g.
+                'en-US'. Unless supplied, this is taken from the ClinicalDocument/language/@code
+                attribute, or in case that is not present from <xd:ref name="textlangDefault"
+                    type="parameter">textlangDefault</xd:ref>.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="textLang">
@@ -68,42 +93,52 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Currently unused. Unsupported by Internet Explorer. Text encoding to render the output in. Defaults to UTF-8 which is fine for most environments. Could change into more localized encodings such as cp-1252 (Windows Latin 1), iso-8859-1 (Latin 1), or shift-jis (Japanese Kanji table))</xd:p>
+            <xd:p>Currently unused. Unsupported by Internet Explorer. Text encoding to render the
+                output in. Defaults to UTF-8 which is fine for most environments. Could change into
+                more localized encodings such as cp-1252 (Windows Latin 1), iso-8859-1 (Latin 1), or
+                shift-jis (Japanese Kanji table))</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="textEncoding" select="'utf-8'"/>
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Boolean value for whether the result document may contain JavaScript. Some environments forbid the use of JavaScript. Without JavaScript, certain more dynamic features may not work.</xd:p>
+            <xd:p>Boolean value for whether the result document may contain JavaScript. Some
+                environments forbid the use of JavaScript. Without JavaScript, certain more dynamic
+                features may not work.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="useJavascript" select="'true'"/>
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Absolute or relative URI to an external Cascading Stylesheet (CSS) file that contains style attributes for custom markup, e.g. in the @styleCode attribute in Section.text</xd:p>
+            <xd:p>Absolute or relative URI to an external Cascading Stylesheet (CSS) file that
+                contains style attributes for custom markup, e.g. in the @styleCode attribute in
+                Section.text</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="externalCss"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font family for the whole document unless overruled somewhere</xd:p>
+            <xd:p>Determines the font family for the whole document unless overruled
+                somewhere</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-family" select="'Verdana, Tahoma, sans-serif'"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for all text unless otherwise specified, and is the base value for other font sizes</xd:p>
+            <xd:p>Determines the font size for all text unless otherwise specified, and is the base
+                value for other font sizes</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-main" select="'9pt'"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h1 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref> + 3</xd:p>
+            <xd:p>Determines the font size for text in the h1 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref> + 3</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h1">
@@ -111,10 +146,11 @@
             <xsl:with-param name="with" select="3"/>
         </xsl:call-template>
     </xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h2 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref> + 2</xd:p>
+            <xd:p>Determines the font size for text in the h2 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref> + 2</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h2">
@@ -122,10 +158,11 @@
             <xsl:with-param name="with" select="2"/>
         </xsl:call-template>
     </xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h3 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref> + 1</xd:p>
+            <xd:p>Determines the font size for text in the h3 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref> + 1</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h3">
@@ -133,31 +170,35 @@
             <xsl:with-param name="with" select="1"/>
         </xsl:call-template>
     </xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h4 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
+            <xd:p>Determines the font size for text in the h4 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h4" select="$font-size-main"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h5 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
+            <xd:p>Determines the font size for text in the h5 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h5" select="$font-size-main"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for text in the h6 tag, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
+            <xd:p>Determines the font size for text in the h6 tag, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref></xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-h6" select="$font-size-main"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the font size for footnote text, defaults to <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref> - 1</xd:p>
+            <xd:p>Determines the font size for footnote text, defaults to <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref> - 1</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="font-size-footnote">
@@ -165,78 +206,120 @@
             <xsl:with-param name="with" select="-1"/>
         </xsl:call-template>
     </xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the background-color, as any legal hex, rgb or named color, for header like table elements, e.g. th tags, defaults to "LightGrey".</xd:p>
+            <xd:p>Determines the background-color, as any legal hex, rgb or named color, for header
+                like table elements, e.g. th tags, defaults to "LightGrey".</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="bgcolor-th">LightGrey</xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines the background-color, as any legal hex, rgb or named color, for body like table elements, e.g. td tags, defaults to "#f2f2f2".</xd:p>
+            <xd:p>Determines the background-color, as any legal hex, rgb or named color, for body
+                like table elements, e.g. td tags, defaults to "#f2f2f2".</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="bgcolor-td">#f2f2f2</xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines if the document title and top level summary of header information (patient/guardian/author/encounter/documentationOf, inFulfillmentOf) should be rendered. Defaults to "true", any other value is interpreted as "do not render". Some systems may have a context around the rendering of the document that would make rendering the header superfluous. Note that the footer, which may be switched off separately contains everything that the header does and more.</xd:p>
+            <xd:p>Determines if the document title and top level summary of header information
+                (patient/guardian/author/encounter/documentationOf, inFulfillmentOf) should be
+                rendered. Defaults to "true", any other value is interpreted as "do not render".
+                Some systems may have a context around the rendering of the document that would make
+                rendering the header superfluous. Note that the footer, which may be switched off
+                separately contains everything that the header does and more.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="dohtmlheader">true</xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Determines if the document footer containing a listing of everything in the CDA Header should be rendered. Defaults to "true", any other value is interpreted as "do not render". Some systems may have a context around the rendering of the document that would make rendering the footer superfluous, or just want to concentrate on document contents.</xd:p>
+            <xd:p>Determines if the document footer containing a listing of everything in the CDA
+                Header should be rendered. Defaults to "true", any other value is interpreted as "do
+                not render". Some systems may have a context around the rendering of the document
+                that would make rendering the footer superfluous, or just want to concentrate on
+                document contents.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="dohtmlfooter">true</xsl:param>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Security parameter. May contain a vertical bar separated list of URI prefixes, such as "http://www.example.com|https://www.example.com". See parameter <xd:ref name="limit-external-images" type="parameter">limit-external-images</xd:ref> for more detail.</xd:p>
+            <xd:p>Security parameter. May contain a vertical bar separated list of URI prefixes,
+                such as "http://www.example.com|https://www.example.com". See parameter <xd:ref
+                    name="limit-external-images" type="parameter">limit-external-images</xd:ref> for
+                more detail.</xd:p>
         </xd:desc>
-    </xd:doc> 
+    </xd:doc>
     <xsl:param name="external-image-whitelist"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Security parameter. When set to 'yes' limits the URIs to images (if any) to locally attached images and/or images that are on the <xd:ref name="external-image-whitelist" type="parameter">external-image-whitelist</xd:ref>. When set to anything other than 'yes' also allows for arbitrary external images (e.g. through http:// or https://). Default value is 'yes' which is considered defensive against potential security risks that could stem from resources loaded from arbitrary source.</xd:p>
+            <xd:p>Security parameter. When set to 'yes' limits the URIs to images (if any) to
+                locally attached images and/or images that are on the <xd:ref
+                    name="external-image-whitelist" type="parameter"
+                    >external-image-whitelist</xd:ref>. When set to anything other than 'yes' also
+                allows for arbitrary external images (e.g. through http:// or https://). Default
+                value is 'yes' which is considered defensive against potential security risks that
+                could stem from resources loaded from arbitrary source.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="limit-external-images" select="'yes'"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Security parameter. When set to 'yes' <xd:a href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-plugins-browsing-context-flag">sandboxes the iframe for pdfs</xd:a>. Sandboxed iframe disallow plug-ins, including the plug-in needed to render pdf. Effectively this setting thus prohibits pdf rendering. When set to anything other than 'yes', pdf carrying iframes are not sandboxed and pdf rendering is possible. Default value is 'yes' which is considered defensive against potential security risks that could stem from resources loaded from arbitrary source.</xd:p>
+            <xd:p>Security parameter. When set to 'yes' <xd:a
+                    href="https://html.spec.whatwg.org/multipage/origin.html#sandboxed-plugins-browsing-context-flag"
+                    >sandboxes the iframe for pdfs</xd:a>. Sandboxed iframe disallow plug-ins,
+                including the plug-in needed to render pdf. Effectively this setting thus prohibits
+                pdf rendering. When set to anything other than 'yes', pdf carrying iframes are not
+                sandboxed and pdf rendering is possible. Default value is 'yes' which is considered
+                defensive against potential security risks that could stem from resources loaded
+                from arbitrary source.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:param name="limit-pdf" select="'yes'"/>
-    
+
     <xd:doc>
-        <xd:desc>Determines depth of menu at the top of the document. Default is 1, which means just head section. Max is 3 which is head section + 2 levels (if any)</xd:desc>
+        <xd:desc>Determines depth of menu at the top of the document. Default is 1, which means just
+            head section. Max is 3 which is head section + 2 levels (if any)</xd:desc>
     </xd:doc>
     <xsl:param name="menu-depth" select="3"/>
-    
+
     <xd:doc>
-        <xd:desc>Privacy parameter. Accepts a comma separated list of patient ID root values (normally OID's). When a patient ID is encountered with a root value in this list, then the rendering of the extension will be xxx-xxx-xxx regardless of what the actual value is. This is useful to prevent public display of for example the US SSN. Default is to render any ID as it occurs in the document. Note that this setting only affects human rendering and that it does not affect automated processing of the underlying document. If the same value also occurs in the <xd:ref name="skip-ids" type="parameter">skip-ids</xd:ref> list, then that takes precedence.</xd:desc>
+        <xd:desc>Privacy parameter. Accepts a comma separated list of patient ID root values
+            (normally OID's). When a patient ID is encountered with a root value in this list, then
+            the rendering of the extension will be xxx-xxx-xxx regardless of what the actual value
+            is. This is useful to prevent public display of for example the US SSN. Default is to
+            render any ID as it occurs in the document. Note that this setting only affects human
+            rendering and that it does not affect automated processing of the underlying document.
+            If the same value also occurs in the <xd:ref name="skip-ids" type="parameter"
+                >skip-ids</xd:ref> list, then that takes precedence.</xd:desc>
     </xd:doc>
     <xsl:param name="skip-ids"/>
-    <xsl:variable name="skip-ids-var" select="concat(',',$skip-ids,',')"/>
-    
+    <xsl:variable name="skip-ids-var" select="concat(',', $skip-ids, ',')"/>
+
     <xd:doc>
-        <xd:desc>Privacy parameter. Accepts a comma separated list of patient ID root values (normally OID's). When a patient ID is encountered with a root value in this list, then the rendering of this ID will be skipped. This is useful to prevent public display of for example the US SSN. Default is to render any ID as it occurs in the document. Note that this setting only affects human rendering and that it does not affect automated processing of the underlying document.</xd:desc>
+        <xd:desc>Privacy parameter. Accepts a comma separated list of patient ID root values
+            (normally OID's). When a patient ID is encountered with a root value in this list, then
+            the rendering of this ID will be skipped. This is useful to prevent public display of
+            for example the US SSN. Default is to render any ID as it occurs in the document. Note
+            that this setting only affects human rendering and that it does not affect automated
+            processing of the underlying document.</xd:desc>
     </xd:doc>
     <xsl:param name="mask-ids"/>
-    <xsl:variable name="mask-ids-var" select="concat(',',$mask-ids,',')"/>
-    
+    <xsl:variable name="mask-ids-var" select="concat(',', $mask-ids, ',')"/>
+
     <xd:doc>
-        <xd:desc>Determines if sections will receive numbering according to ClinicalDocument order. Value 'true' activates numbering. Top level sections are 1, 2, 3, 4, sub level sections are 1.1, 1.2, 1.2.1, 1.2.2 etc.</xd:desc>
+        <xd:desc>Determines if sections will receive numbering according to ClinicalDocument order.
+            Value 'true' activates numbering. Top level sections are 1, 2, 3, 4, sub level sections
+            are 1.1, 1.2, 1.2.1, 1.2.2 etc.</xd:desc>
     </xd:doc>
     <xsl:param name="dosectionnumbering" select="'false'"/>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Do lowercase compare of language+region</xd:p>
@@ -247,14 +330,14 @@
             <xsl:with-param name="data" select="$textLang"/>
         </xsl:call-template>
     </xsl:variable>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Do lowercase compare of language (assume alpha2 not alpha3)</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="textLangPartLowerCase" select="substring($textLangLowerCase,1,2)"/>
-    
+    <xsl:variable name="textLangPartLowerCase" select="substring($textLangLowerCase, 1, 2)"/>
+
     <xd:doc>
         <xd:desc>
             <xd:p>Do lowercase compare of default language+region</xd:p>
@@ -265,48 +348,54 @@
             <xsl:with-param name="data" select="$textlangDefault"/>
         </xsl:call-template>
     </xsl:variable>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Do lowercase compare of default language (assume alpha2 not alpha3)</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="textLangDefaultPartLowerCase" select="substring($textLangDefaultLowerCase,1,2)"/>
-    
+    <xsl:variable name="textLangDefaultPartLowerCase"
+        select="substring($textLangDefaultLowerCase, 1, 2)"/>
+
     <xd:doc>
         <xd:desc>
             <xd:p>String processing variable. Lower-case alphabet</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="lc" select="'abcdefghijklmnopqrstuvwxyz'" />
-    
+    <xsl:variable name="lc" select="'abcdefghijklmnopqrstuvwxyz'"/>
+
     <xd:doc>
         <xd:desc>
             <xd:p>String processing variable. Upper-case alphabet</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="uc" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
-    
+    <xsl:variable name="uc" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
     <xd:doc>
         <xd:desc>
-            <xd:p>String processing variable. Removes the following characters, in addition to line breaks "':;?`{}“”„‚’</xd:p>
+            <xd:p>String processing variable. Removes the following characters, in addition to line
+                breaks "':;?`{}“”„‚’</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="simple-sanitizer-match"><xsl:text>&#10;&#13;&#34;&#39;&#58;&#59;&#63;&#96;&#123;&#125;&#8220;&#8221;&#8222;&#8218;&#8217;</xsl:text></xsl:variable>
-    
+    <xsl:variable name="simple-sanitizer-match">
+        <xsl:text>&#10;&#13;&#34;&#39;&#58;&#59;&#63;&#96;&#123;&#125;&#8220;&#8221;&#8222;&#8218;&#8217;</xsl:text>
+    </xsl:variable>
+
     <xd:doc>
         <xd:desc>
             <xd:p>String processing variable.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:variable name="simple-sanitizer-replace" select="'***************'"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Use XHTML 1.0 Strict with UTF-8 encoding. CDAr3 specifies an XHTML subset of tags in Section.text so that makes mapping easier.</xd:p>
+            <xd:p>Use XHTML 1.0 Strict with UTF-8 encoding. CDAr3 specifies an XHTML subset of tags
+                in Section.text so that makes mapping easier.</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:output indent="yes" encoding="utf-8" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+    <xsl:output indent="yes" encoding="utf-8" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"
+        doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
 
     <xd:doc>
         <xd:desc>
@@ -489,57 +578,57 @@
                 </style>
                 <xsl:comment> Stylecode CSS </xsl:comment>
                 <style type="text/css" media="all">
-                    .Bold{
+                    .Bold {
                         font-weight: bold;
                     }
-                    .Italics{
+                    .Italics {
                         font-style: italic;
                     }
-                    .Underline{
+                    .Underline {
                         text-decoration: underline;
                     }
-                    .Emphasis{
+                    .Emphasis {
                         font-weight: bold;
                         font-style: italic;
                     }
-                    .Lrule{
+                    .Lrule {
                         border-left-width: 2px;
                         border-left-style: solid;
                     }
-                    .Rrule{
+                    .Rrule {
                         border-right-width: 2px;
                         border-right-style: solid;
                     }
-                    .Toprule{
+                    .Toprule {
                         border-top-width: 2px;
                         border-top-style: solid;
                     }
-                    .Botrule{
+                    .Botrule {
                         border-bottom-width: 2px;
                         border-bottom-style: solid;
                     }
-                    .Arabic{
+                    .Arabic {
                         list-style: arabic;
                     }
-                    .LittleRoman{
+                    .LittleRoman {
                         list-style: lower-roman;
                     }
-                    .BigRoman{
+                    .BigRoman {
                         list-style: upper-roman;
                     }
-                    .LittleAlpha{
+                    .LittleAlpha {
                         list-style: lower-alpha;
                     }
-                    .BigAlpha{
+                    .BigAlpha {
                         list-style: upper-alpha
                     }
-                    .Disc{
+                    .Disc {
                         list-style: disc;
                     }
-                    .Circle{
+                    .Circle {
                         list-style: circle;
                     }
-                    .Square{
+                    .Square {
                         list-style: square;
                     }</style>
                 <!--<xsl:comment> Stylecode CSS IHE PCC MCV, Revision 1.2, Trial Implementation, November 2, 2018</xsl:comment>
@@ -632,11 +721,10 @@
                         float: left;
                         margin-right: 10px;
                         cursor: pointer;
-                    }
-                </style>
+                    }</style>
                 <xsl:comment> Revision Toggle CSS </xsl:comment>
                 <style type="text/css" media="print">
-                    button, 
+                    button,
                     div.button,
                     #buttontable {
                         display: none;
@@ -648,8 +736,7 @@
                         display: block;
                         float: none;
                         margin-right: 0;
-                    }
-                </style>
+                    }</style>
                 <xsl:comment> Table of Contents CSS </xsl:comment>
                 <style type="text/css" media="screen">
                     <xsl:text disable-output-escaping="yes">
@@ -735,12 +822,12 @@
                     }
                     /* End IE only hack */
                 </style>
-                <xsl:if test="string-length($externalCss)>0">
+                <xsl:if test="string-length($externalCss) > 0">
                     <xsl:comment> External CSS </xsl:comment>
                     <link type="text/css" rel="stylesheet" href="{$externalCss}"/>
                 </xsl:if>
-                
-                <xsl:if test="string($useJavascript)='true'">
+
+                <xsl:if test="string($useJavascript) = 'true'">
                     <xsl:comment> Javascript for Revisions switch </xsl:comment>
                     <script type="text/javascript">
                         <xsl:text>var gStringCollapse = "</xsl:text>
@@ -832,19 +919,18 @@
                     </script>
                     <xsl:comment> Javascript for Table of Contents menu </xsl:comment>
                     <script type="text/javascript">
-                        sfHover = function() {
+                        sfHover = function () {
                             var sfEls = document.getElementById("nav").getElementsByTagName("li");
                             for (i in sfEls) {
-                                sfEls[i].onmouseover=function() {
-                                    this.className+=" ie_does_hover";
+                                sfEls[i].onmouseover = function () {
+                                    this.className += " ie_does_hover";
                                 }
-                                sfEls[i].onmouseout=function() {
-                                    this.className=this.className.replace(new RegExp(" ie_does_hover"), "");
+                                sfEls[i].onmouseout = function () {
+                                    this.className = this.className.replace(new RegExp(" ie_does_hover"), "");
                                 }
                             }
                         }
-                        if (window.attachEvent) window.attachEvent("onload", sfHover);
-                    </script>
+                        if (window.attachEvent) window.attachEvent("onload", sfHover);</script>
                 </xsl:if>
             </head>
             <body>
@@ -857,8 +943,9 @@
                         <xsl:call-template name="show-header"/>
                     </xsl:if>
                     <!-- START TOC and Revision toggle -->
-                    <xsl:if test="string($useJavascript)='true'">
-                        <xsl:if test="//hl7:content[@revised] or count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 1">
+                    <xsl:if test="string($useJavascript) = 'true'">
+                        <xsl:if
+                            test="//hl7:content[@revised] or count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 1">
                             <div id="buttontable">
                                 <table border="0" cellpadding="0" cellspacing="0">
                                     <tbody>
@@ -875,7 +962,8 @@
                     <!-- END TOC and Revision toggle -->
                 </div>
                 <div id="documentbody">
-                    <xsl:apply-templates select="hl7:component/hl7:structuredBody | hl7:component/hl7:nonXMLBody"/>
+                    <xsl:apply-templates
+                        select="hl7:component/hl7:structuredBody | hl7:component/hl7:nonXMLBody"/>
                 </div>
                 <xsl:if test="$dohtmlfooter = 'true'">
                     <div id="documentfooter">
@@ -899,6 +987,7 @@
                         <xsl:call-template name="informationRecipient"/>
                         <xsl:call-template name="authenticator"/>
                         <xsl:call-template name="legalAuthenticator"/>
+                        <div class="separator">&#160;</div>
                     </div>
                 </xsl:if>
             </body>
@@ -943,13 +1032,16 @@
                 </xsl:call-template>
             </xsl:variable>
             <xsl:if test="hl7:id">
-                <xsl:value-of select="concat($i18nid, ' = ',hl7:id[1]/@root, ' ', hl7:id[1]/@extension)"/>
+                <xsl:value-of
+                    select="concat($i18nid, ' = ', hl7:id[1]/@root, ' ', hl7:id[1]/@extension)"/>
             </xsl:if>
         </xsl:variable>
-        <xsl:variable name="renderElement" select="self::hl7:nonXMLBody/hl7:text | self::hl7:observationMedia/hl7:value"/>
+        <xsl:variable name="renderElement"
+            select="self::hl7:nonXMLBody/hl7:text | self::hl7:observationMedia/hl7:value"/>
         <xsl:choose>
             <!-- Minimal mitigation for security risk based on malicious input -->
-            <xsl:when test="$renderElement/hl7:reference[starts-with(translate(normalize-space(@value),'JAVASCRIPT','javascript'),'javascript')]">
+            <xsl:when
+                test="$renderElement/hl7:reference[starts-with(translate(normalize-space(@value), 'JAVASCRIPT', 'javascript'), 'javascript')]">
                 <pre title="{$renderAltText}">
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="key" select="'securityRiskURLLabel'"/>
@@ -960,11 +1052,14 @@
             <!-- if there is a reference, use that in an iframe -->
             <xsl:when test="$renderElement/hl7:reference">
                 <xsl:variable name="source" select="string($renderElement/hl7:reference/@value)"/>
-                <xsl:variable name="lcSource" select="translate($source, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
-                <xsl:variable name="scrubbedSource" select="translate($source, $simple-sanitizer-match, $simple-sanitizer-replace)"/>
-                <xsl:message><xsl:value-of select="$source"/>, <xsl:value-of select="$lcSource"/></xsl:message>
+                <xsl:variable name="lcSource"
+                    select="translate($source, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+                <xsl:variable name="scrubbedSource"
+                    select="translate($source, $simple-sanitizer-match, $simple-sanitizer-replace)"/>
+                <xsl:message><xsl:value-of select="$source"/>, <xsl:value-of select="$lcSource"
+                    /></xsl:message>
                 <xsl:choose>
-                    <xsl:when test="contains($lcSource,'javascript')">
+                    <xsl:when test="contains($lcSource, 'javascript')">
                         <p>
                             <xsl:call-template name="getLocalizedString">
                                 <xsl:with-param name="key" select="'javascript-injection-warning'"/>
@@ -1005,16 +1100,20 @@
                         &lt;![endif]</xsl:comment>
                         <xsl:comment>[if gt IE 9]&gt;</xsl:comment>
                         <xsl:choose>
-                            <xsl:when test="$renderElement/@mediaType = 'application/pdf' and $limit-pdf = 'yes'">
+                            <xsl:when
+                                test="$renderElement/@mediaType = 'application/pdf' and $limit-pdf = 'yes'">
                                 <div style="font-style: italic;">
                                     <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'iframe-warning-sandboxed-pdf'"/>
+                                        <xsl:with-param name="key"
+                                            select="'iframe-warning-sandboxed-pdf'"/>
                                     </xsl:call-template>
                                 </div>
                             </xsl:when>
                             <xsl:otherwise>
-                                <iframe name="{$renderID}" id="{$renderID}" width="100%" height="600" title="{$renderAltText}">
-                                    <xsl:if test="$renderElement/@mediaType != 'application/pdf' or $limit-pdf = 'yes'">
+                                <iframe name="{$renderID}" id="{$renderID}" width="100%"
+                                    height="600" title="{$renderAltText}">
+                                    <xsl:if
+                                        test="$renderElement/@mediaType != 'application/pdf' or $limit-pdf = 'yes'">
                                         <xsl:attribute name="sandbox"/>
                                     </xsl:if>
                                     <xsl:attribute name="src">
@@ -1028,7 +1127,7 @@
                 </xsl:choose>
             </xsl:when>
             <!-- This is an image of some sort -->
-            <xsl:when test="$renderElement[starts-with(@mediaType,'image/')]">
+            <xsl:when test="$renderElement[starts-with(@mediaType, 'image/')]">
                 <img alt="{$renderAltText}" title="{$renderAltText}">
                     <xsl:if test="string-length($usemap) &gt; 0">
                         <xsl:attribute name="usemap">
@@ -1036,7 +1135,9 @@
                         </xsl:attribute>
                     </xsl:if>
                     <xsl:attribute name="src">
-                        <xsl:value-of select="concat('data:',$renderElement/@mediaType,';base64,',$renderElement/text())"/>
+                        <xsl:value-of
+                            select="concat('data:', $renderElement/@mediaType, ';base64,', $renderElement/text())"
+                        />
                     </xsl:attribute>
                 </img>
             </xsl:when>
@@ -1053,10 +1154,13 @@
                 <xsl:comment>[if gt IE 9]&gt;</xsl:comment>
                 <xsl:call-template name="getLocalizedString">
                     <xsl:with-param name="pre" select="' '"/>
-                    <xsl:with-param name="key" select="'If the contents are not displayed here, it may be offered as a download.'"/>
+                    <xsl:with-param name="key"
+                        select="'If the contents are not displayed here, it may be offered as a download.'"
+                    />
                 </xsl:call-template>
                 <xsl:choose>
-                    <xsl:when test="$renderElement/@mediaType = 'application/pdf' and $limit-pdf = 'yes'">
+                    <xsl:when
+                        test="$renderElement/@mediaType = 'application/pdf' and $limit-pdf = 'yes'">
                         <div style="font-style: italic;">
                             <xsl:call-template name="getLocalizedString">
                                 <xsl:with-param name="key" select="'iframe-warning-sandboxed-pdf'"/>
@@ -1064,12 +1168,16 @@
                         </div>
                     </xsl:when>
                     <xsl:otherwise>
-                        <iframe name="{$renderID}" id="{$renderID}" width="100%" height="600" title="{$renderAltText}">
-                            <xsl:if test="$renderElement/@mediaType != 'application/pdf' or $limit-pdf = 'yes'">
+                        <iframe name="{$renderID}" id="{$renderID}" width="100%" height="600"
+                            title="{$renderAltText}">
+                            <xsl:if
+                                test="$renderElement/@mediaType != 'application/pdf' or $limit-pdf = 'yes'">
                                 <xsl:attribute name="sandbox"/>
                             </xsl:if>
                             <xsl:attribute name="src">
-                                <xsl:value-of select="concat('data:', $renderElement/@mediaType, ';base64,', $renderElement/text())"/>
+                                <xsl:value-of
+                                    select="concat('data:', $renderElement/@mediaType, ';base64,', $renderElement/text())"
+                                />
                             </xsl:attribute>
                         </iframe>
                     </xsl:otherwise>
@@ -1077,7 +1185,7 @@
                 <xsl:comment>&lt;![endif]</xsl:comment>
             </xsl:when>
             <!-- This is plain text -->
-            <xsl:when test="$renderElement[not(@mediaType) or @mediaType='text/plain']">
+            <xsl:when test="$renderElement[not(@mediaType) or @mediaType = 'text/plain']">
                 <pre title="{$renderAltText}">
                     <xsl:value-of select="$renderElement/text()"/>
                 </pre>
@@ -1094,7 +1202,8 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>component/section: display title and text, and process any nested component/sections increasing margin-left as we go deeper</xd:p>
+            <xd:p>component/section: display title and text, and process any nested
+                component/sections increasing margin-left as we go deeper</xd:p>
         </xd:desc>
         <xd:param name="level">Header level element to call, e.g. h1, h2 or h3</xd:param>
         <xd:param name="margin">Margin defined in em</xd:param>
@@ -1102,10 +1211,10 @@
     <xsl:template name="section">
         <xsl:param name="level" select="3"/>
         <xsl:param name="margin" select="0"/>
-        
+
         <div style="margin-left: {$margin}em;" class="section">
             <div class="section-title">
-                <xsl:if test="string($useJavascript)='true'">
+                <xsl:if test="string($useJavascript) = 'true'">
                     <div class="button expandCollapse" onclick="collapseSection(this)">
                         <xsl:attribute name="title">
                             <xsl:call-template name="getLocalizedString">
@@ -1146,7 +1255,9 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Produces a section title with at least an anchor based on relative position in the document (for the Table of Contents), and a second anchor if the section has the @ID tag</xd:p>
+            <xd:p>Produces a section title with at least an anchor based on relative position in the
+                document (for the Table of Contents), and a second anchor if the section has the @ID
+                tag</xd:p>
         </xd:desc>
         <xd:param name="level">Header level element to call, e.g. h1, h2 or h3</xd:param>
     </xd:doc>
@@ -1176,7 +1287,8 @@
                 </xsl:attribute>
             </xsl:if>
             <xsl:choose>
-                <xsl:when test="count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 1">
+                <xsl:when
+                    test="count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 1">
                     <!-- Add link to go back to top if the document has more than one section, otherwise superfluous -->
                     <a href="#_toc">
                         <xsl:apply-templates select="." mode="getTitleName"/>
@@ -1188,10 +1300,11 @@
             </xsl:choose>
         </xsl:element>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Produces a legal style of numbering for a section. E.g. 1.1, 1.2.1, 1.2.2 etc.</xd:p>
+            <xd:p>Produces a legal style of numbering for a section. E.g. 1.1, 1.2.1, 1.2.2
+                etc.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:section" mode="getNumbering">
@@ -1202,7 +1315,7 @@
             </xsl:if>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Produces an anchor name suitable for the HTML &lt;a/&gt; tag</xd:p>
@@ -1212,10 +1325,11 @@
         <xsl:value-of select="'section_'"/>
         <xsl:apply-templates select="." mode="getNumbering"/>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Produces a human readable section title based on its title, or code as fallback</xd:p>
+            <xd:p>Produces a human readable section title based on its title, or code as
+                fallback</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:section" mode="getTitleName">
@@ -1271,29 +1385,43 @@
                                 <xsl:choose>
                                     <xsl:when test="hl7:assignedAuthor/hl7:assignedPerson">
                                         <xsl:call-template name="show-name-set">
-                                            <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:assignedPerson/hl7:name"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedAuthor/hl7:assignedPerson/hl7:name"
+                                            />
                                         </xsl:call-template>
-                                        <xsl:if test="hl7:assignedAuthor/hl7:assignedPerson/hl7:desc">
+                                        <xsl:if
+                                            test="hl7:assignedAuthor/hl7:assignedPerson/hl7:desc">
                                             <div>
-                                                <xsl:value-of select="hl7:assignedAuthor/hl7:assignedPerson/hl7:desc"/>
+                                                <xsl:value-of
+                                                  select="hl7:assignedAuthor/hl7:assignedPerson/hl7:desc"
+                                                />
                                             </div>
                                         </xsl:if>
-                                        <xsl:if test="hl7:assignedAuthor/hl7:assignedPerson/hl7:birthTime">
+                                        <xsl:if
+                                            test="hl7:assignedAuthor/hl7:assignedPerson/hl7:birthTime">
                                             <xsl:text> </xsl:text>
                                             <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'birthTimeLong'"/>
+                                                <xsl:with-param name="key" select="'birthTimeLong'"
+                                                />
                                             </xsl:call-template>
                                             <xsl:text> </xsl:text>
                                             <xsl:call-template name="show-timestamp">
-                                                <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:assignedPerson/hl7:birthTime"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:assignedAuthor/hl7:assignedPerson/hl7:birthTime"
+                                                />
                                             </xsl:call-template>
                                         </xsl:if>
                                     </xsl:when>
                                     <xsl:when test="hl7:assignedAuthor/hl7:assignedAuthoringDevice">
-                                        <xsl:value-of select="hl7:assignedAuthor/hl7:assignedAuthoringDevice/hl7:softwareName"/>
+                                        <xsl:value-of
+                                            select="hl7:assignedAuthor/hl7:assignedAuthoringDevice/hl7:softwareName"
+                                        />
                                     </xsl:when>
-                                    <xsl:when test="hl7:assignedAuthor/hl7:assignedDevice/hl7:softwareName">
-                                        <xsl:value-of select="hl7:assignedAuthor/hl7:assignedDevice/hl7:softwareName/@value"/>
+                                    <xsl:when
+                                        test="hl7:assignedAuthor/hl7:assignedDevice/hl7:softwareName">
+                                        <xsl:value-of
+                                            select="hl7:assignedAuthor/hl7:assignedDevice/hl7:softwareName/@value"
+                                        />
                                     </xsl:when>
                                     <xsl:when test="hl7:assignedAuthor/hl7:id">
                                         <xsl:call-template name="getLocalizedString">
@@ -1301,7 +1429,8 @@
                                             <xsl:with-param name="post" select="': '"/>
                                         </xsl:call-template>
                                         <xsl:call-template name="show-id-set">
-                                            <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:id"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedAuthor/hl7:id"/>
                                         </xsl:call-template>
                                     </xsl:when>
                                 </xsl:choose>
@@ -1312,35 +1441,43 @@
                                         <xsl:with-param name="post" select="': '"/>
                                     </xsl:call-template>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:code"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:assignedAuthor/hl7:code"/>
                                     </xsl:call-template>
                                 </xsl:if>
                                 <xsl:choose>
-                                    <xsl:when test="hl7:assignedAuthor/hl7:representedOrganization/hl7:name">
+                                    <xsl:when
+                                        test="hl7:assignedAuthor/hl7:representedOrganization/hl7:name">
                                         <xsl:text>, </xsl:text>
                                         <xsl:call-template name="getLocalizedString">
                                             <xsl:with-param name="key" select="'organization'"/>
                                             <xsl:with-param name="post" select="': '"/>
                                         </xsl:call-template>
                                         <xsl:call-template name="show-name-set">
-                                            <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:representedOrganization/hl7:name"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedAuthor/hl7:representedOrganization/hl7:name"
+                                            />
                                         </xsl:call-template>
                                     </xsl:when>
-                                    <xsl:when test="hl7:assignedAuthor/hl7:representedOrganization/hl7:id">
+                                    <xsl:when
+                                        test="hl7:assignedAuthor/hl7:representedOrganization/hl7:id">
                                         <xsl:text>, </xsl:text>
                                         <xsl:call-template name="getLocalizedString">
                                             <xsl:with-param name="key" select="'organization'"/>
                                             <xsl:with-param name="post" select="': '"/>
                                         </xsl:call-template>
                                         <xsl:call-template name="show-id-set">
-                                            <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:representedOrganization/hl7:id"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedAuthor/hl7:representedOrganization/hl7:id"
+                                            />
                                         </xsl:call-template>
                                     </xsl:when>
                                 </xsl:choose>
                                 <xsl:if test="hl7:assignedAuthor/hl7:telecom">
                                     <br/>
                                     <xsl:call-template name="show-telecom-set">
-                                        <xsl:with-param name="in" select="hl7:assignedAuthor/hl7:telecom"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:assignedAuthor/hl7:telecom"/>
                                     </xsl:call-template>
                                 </xsl:if>
                             </li>
@@ -1353,7 +1490,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle  section informant </xd:p>
+            <xd:p>Handle section informant </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template name="section-informant">
@@ -1375,96 +1512,125 @@
                                             <xsl:when test="hl7:relatedEntity/hl7:code">
                                                 <xsl:text>(</xsl:text>
                                                 <xsl:call-template name="show-code-set">
-                                                    <xsl:with-param name="in" select="hl7:relatedEntity/hl7:code"/>
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:relatedEntity/hl7:code"/>
                                                 </xsl:call-template>
                                                 <xsl:text>) </xsl:text>
                                             </xsl:when>
                                             <xsl:otherwise>
                                                 <xsl:text>(</xsl:text>
                                                 <xsl:call-template name="getLocalizedString">
-                                                    <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.110-',hl7:relatedEntity/@classCode)"/>
+                                                  <xsl:with-param name="key"
+                                                  select="concat('2.16.840.1.113883.5.110-', hl7:relatedEntity/@classCode)"
+                                                  />
                                                 </xsl:call-template>
                                                 <xsl:text>) </xsl:text>
                                             </xsl:otherwise>
                                         </xsl:choose>
                                         <xsl:call-template name="show-name-set">
-                                            <xsl:with-param name="in" select="hl7:relatedEntity/hl7:relatedPerson/hl7:name"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:relatedEntity/hl7:relatedPerson/hl7:name"
+                                            />
                                         </xsl:call-template>
                                         <xsl:if test="hl7:relatedEntity/hl7:relatedPerson/hl7:desc">
                                             <div>
-                                                <xsl:value-of select="hl7:relatedEntity/hl7:relatedPerson/hl7:desc"/>
+                                                <xsl:value-of
+                                                  select="hl7:relatedEntity/hl7:relatedPerson/hl7:desc"
+                                                />
                                             </div>
                                         </xsl:if>
-                                        <xsl:if test="hl7:relatedEntity/hl7:relatedPerson/hl7:birthTime">
+                                        <xsl:if
+                                            test="hl7:relatedEntity/hl7:relatedPerson/hl7:birthTime">
                                             <xsl:text> </xsl:text>
                                             <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'birthTimeLong'"/>
+                                                <xsl:with-param name="key" select="'birthTimeLong'"
+                                                />
                                             </xsl:call-template>
                                             <xsl:text> </xsl:text>
                                             <xsl:call-template name="show-timestamp">
-                                                <xsl:with-param name="in" select="hl7:relatedEntity/hl7:relatedPerson/hl7:birthTime"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:relatedEntity/hl7:relatedPerson/hl7:birthTime"
+                                                />
                                             </xsl:call-template>
                                         </xsl:if>
                                     </xsl:when>
                                     <xsl:when test="hl7:assignedEntity">
                                         <xsl:choose>
-                                            <xsl:when test="hl7:assignedEntity/hl7:assignedPerson/hl7:name">
+                                            <xsl:when
+                                                test="hl7:assignedEntity/hl7:assignedPerson/hl7:name">
                                                 <xsl:call-template name="show-name-set">
-                                                    <xsl:with-param name="in" select="hl7:assignedEntity/hl7:assignedPerson/hl7:name"/>
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:assignedEntity/hl7:assignedPerson/hl7:name"
+                                                  />
                                                 </xsl:call-template>
-                                                <xsl:if test="hl7:assignedEntity/hl7:assignedPerson/hl7:desc">
-                                                    <div>
-                                                        <xsl:value-of select="hl7:assignedEntity/hl7:assignedPerson/hl7:desc"/>
-                                                    </div>
+                                                <xsl:if
+                                                  test="hl7:assignedEntity/hl7:assignedPerson/hl7:desc">
+                                                  <div>
+                                                  <xsl:value-of
+                                                  select="hl7:assignedEntity/hl7:assignedPerson/hl7:desc"
+                                                  />
+                                                  </div>
                                                 </xsl:if>
-                                                <xsl:if test="hl7:assignedEntity/hl7:assignedPerson/hl7:birthTime">
-                                                    <xsl:text> </xsl:text>
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="key" select="'birthTimeLong'"/>
-                                                    </xsl:call-template>
-                                                    <xsl:text> </xsl:text>
-                                                    <xsl:call-template name="show-timestamp">
-                                                        <xsl:with-param name="in" select="hl7:assignedEntity/hl7:assignedPerson/hl7:birthTime"/>
-                                                    </xsl:call-template>
+                                                <xsl:if
+                                                  test="hl7:assignedEntity/hl7:assignedPerson/hl7:birthTime">
+                                                  <xsl:text> </xsl:text>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'birthTimeLong'"/>
+                                                  </xsl:call-template>
+                                                  <xsl:text> </xsl:text>
+                                                  <xsl:call-template name="show-timestamp">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:assignedEntity/hl7:assignedPerson/hl7:birthTime"
+                                                  />
+                                                  </xsl:call-template>
                                                 </xsl:if>
                                             </xsl:when>
                                             <xsl:when test="hl7:assignedEntity/hl7:id">
                                                 <xsl:call-template name="getLocalizedString">
-                                                    <xsl:with-param name="key" select="'id'"/>
-                                                    <xsl:with-param name="post" select="': '"/>
+                                                  <xsl:with-param name="key" select="'id'"/>
+                                                  <xsl:with-param name="post" select="': '"/>
                                                 </xsl:call-template>
                                                 <xsl:call-template name="show-id-set">
-                                                    <xsl:with-param name="in" select="hl7:assignedEntity/hl7:id"/>
-                                                    <xsl:with-param name="sep" select="', '"/>
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:assignedEntity/hl7:id"/>
+                                                  <xsl:with-param name="sep" select="', '"/>
                                                 </xsl:call-template>
                                             </xsl:when>
                                         </xsl:choose>
 
-                                        <xsl:if test="hl7:assignedEntity/hl7:representedOrganization">
+                                        <xsl:if
+                                            test="hl7:assignedEntity/hl7:representedOrganization">
                                             <xsl:text>, </xsl:text>
                                             <xsl:call-template name="getLocalizedString">
                                                 <xsl:with-param name="key" select="'organization'"/>
                                                 <xsl:with-param name="post" select="': '"/>
                                             </xsl:call-template>
                                             <xsl:call-template name="show-name-set">
-                                                <xsl:with-param name="in" select="hl7:assignedEntity/hl7:representedOrganization/hl7:name"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:assignedEntity/hl7:representedOrganization/hl7:name"/>
                                                 <xsl:with-param name="sep" select="', '"/>
                                             </xsl:call-template>
                                         </xsl:if>
-                                        <xsl:if test="hl7:assignedEntity/hl7:representedOrganization/hl7:telecom">
+                                        <xsl:if
+                                            test="hl7:assignedEntity/hl7:representedOrganization/hl7:telecom">
                                             <xsl:text>, </xsl:text>
                                             <xsl:call-template name="show-telecom-set">
-                                                <xsl:with-param name="in" select="hl7:assignedEntity/hl7:representedOrganization/hl7:telecom"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:assignedEntity/hl7:representedOrganization/hl7:telecom"/>
                                                 <xsl:with-param name="sep" select="', '"/>
                                             </xsl:call-template>
                                         </xsl:if>
                                     </xsl:when>
                                 </xsl:choose>
 
-                                <xsl:if test="hl7:relatedEntity/hl7:telecom | hl7:assignedEntity/hl7:telecom">
+                                <xsl:if
+                                    test="hl7:relatedEntity/hl7:telecom | hl7:assignedEntity/hl7:telecom">
                                     <br/>
                                     <xsl:call-template name="show-telecom-set">
-                                        <xsl:with-param name="in" select="hl7:relatedEntity/hl7:telecom | hl7:assignedEntity/hl7:telecom"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedEntity/hl7:telecom | hl7:assignedEntity/hl7:telecom"
+                                        />
                                     </xsl:call-template>
                                 </xsl:if>
                             </li>
@@ -1477,7 +1643,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle  section subject </xd:p>
+            <xd:p>Handle section subject </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template name="section-subject">
@@ -1495,7 +1661,8 @@
                             <li>
                                 <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:name">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:name"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:subject/hl7:name"/>
                                     </xsl:call-template>
                                 </xsl:if>
                                 <xsl:if test="hl7:relatedSubject/hl7:code">
@@ -1505,52 +1672,68 @@
                                         <xsl:with-param name="post" select="': '"/>
                                     </xsl:call-template>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:code"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:code"/>
                                     </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject[*[local-name() = 'birthTime'] | *[local-name() = 'deceasedInd'] | *[local-name() = 'birthdeceasedTime'] | *[local-name() = 'multipleBirthInd'] | *[local-name() = 'multipleBirthOrderNumber']]">
+                                <xsl:if
+                                    test="hl7:relatedSubject/hl7:subject[*[local-name() = 'birthTime'] | *[local-name() = 'deceasedInd'] | *[local-name() = 'birthdeceasedTime'] | *[local-name() = 'multipleBirthInd'] | *[local-name() = 'multipleBirthOrderNumber']]">
                                     <xsl:text>, </xsl:text>
                                     <xsl:call-template name="show-birthDeathTime-multipleBirth">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject"/>
-                                        <xsl:with-param name="clinicalDocumentEffectiveTime" select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:subject"/>
+                                        <xsl:with-param name="clinicalDocumentEffectiveTime"
+                                            select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"
+                                        />
                                     </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:administrativeGenderCode">
+                                <xsl:if
+                                    test="hl7:relatedSubject/hl7:subject/hl7:administrativeGenderCode">
                                     <xsl:text>, </xsl:text>
                                     <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'administrativeGenderCode'"/>
+                                        <xsl:with-param name="key"
+                                            select="'administrativeGenderCode'"/>
                                         <xsl:with-param name="post" select="': '"/>
                                     </xsl:call-template>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:administrativeGenderCode"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:subject/hl7:administrativeGenderCode"
+                                        />
                                     </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:raceCode |
-                                              hl7:relatedSubject/hl7:subject/sdtc:raceCode">
+                                <xsl:if test="
+                                        hl7:relatedSubject/hl7:subject/hl7:raceCode |
+                                        hl7:relatedSubject/hl7:subject/sdtc:raceCode">
                                     <xsl:text>, </xsl:text>
-                                            <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'Race'"/>
-                                                <xsl:with-param name="post" select="': '"/>
-                                            </xsl:call-template>
-                                            <xsl:call-template name="show-code-set">
-                                                <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:raceCode | hl7:relatedSubject/hl7:subject/sdtc:raceCode"/>
-                                            </xsl:call-template>
+                                    <xsl:call-template name="getLocalizedString">
+                                        <xsl:with-param name="key" select="'Race'"/>
+                                        <xsl:with-param name="post" select="': '"/>
+                                    </xsl:call-template>
+                                    <xsl:call-template name="show-code-set">
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:subject/hl7:raceCode | hl7:relatedSubject/hl7:subject/sdtc:raceCode"
+                                        />
+                                    </xsl:call-template>
                                 </xsl:if>
-                                <xsl:if test="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode |
-                                              hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode">
+                                <xsl:if test="
+                                        hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode |
+                                        hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode">
                                     <xsl:text>, </xsl:text>
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Ethnicity'"/>
                                         <xsl:with-param name="post" select="': '"/>
                                     </xsl:call-template>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode | hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:relatedSubject/hl7:subject/hl7:ethnicGroupCode | hl7:relatedSubject/hl7:subject/sdtc:ethnicGroupCode"
+                                        />
                                     </xsl:call-template>
                                 </xsl:if>
                                 <xsl:if test="hl7:relatedSubject/hl7:telecom">
                                     <div>
                                         <xsl:call-template name="show-telecom-set">
-                                            <xsl:with-param name="in" select="hl7:relatedSubject/hl7:telecom"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:relatedSubject/hl7:telecom"/>
                                         </xsl:call-template>
                                     </div>
                                 </xsl:if>
@@ -1575,7 +1758,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle    paragraph  </xd:p>
+            <xd:p>Handle paragraph </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:paragraph">
@@ -1590,7 +1773,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle    linkHtml  </xd:p>
+            <xd:p>Handle linkHtml </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:linkHtml">
@@ -1645,7 +1828,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle list  </xd:p>
+            <xd:p>Handle list </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:list">
@@ -1657,7 +1840,7 @@
         </xsl:if>
         <!-- item -->
         <xsl:choose>
-            <xsl:when test="@listType='ordered'">
+            <xsl:when test="@listType = 'ordered'">
                 <ol>
                     <xsl:apply-templates select="." mode="handleSectionTextAttributes"/>
                     <!--<xsl:if test="@ID">
@@ -1697,7 +1880,7 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle caption  </xd:p>
+            <xd:p>Handle caption </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:caption">
@@ -1750,9 +1933,10 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle footnoteRef. Produces a superscript [n] where n is the occurence number of this ref in the
-                whole document. Also adds a title with the first 50 characters of th footnote on the number so you 
-                don't have to navigate to the footnote and just continue to read.</xd:p>
+            <xd:p>Handle footnoteRef. Produces a superscript [n] where n is the occurence number of
+                this ref in the whole document. Also adds a title with the first 50 characters of th
+                footnote on the number so you don't have to navigate to the footnote and just
+                continue to read.</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:footnoteRef">
@@ -1797,13 +1981,14 @@
         
         <xsl:apply-templates select="ancestor::hl7:ClinicalDocument//hl7:observationMedia[@ID = $idrefs]"/>
     </xsl:template>-->
-    
+
     <xsl:variable name="table-elem-attrs" select="document('cda_narrativeblock.xml')/tableElems"/>
-    
+
     <xd:doc>
         <xd:desc>Handle table and constituents of table</xd:desc>
     </xd:doc>
-    <xsl:template match="hl7:table | hl7:thead | hl7:tfoot | hl7:tbody | hl7:colgroup | hl7:col | hl7:tr | hl7:th | hl7:td">
+    <xsl:template
+        match="hl7:table | hl7:thead | hl7:tfoot | hl7:tbody | hl7:colgroup | hl7:col | hl7:tr | hl7:th | hl7:td">
         <xsl:element name="{local-name()}">
             <xsl:apply-templates select="." mode="handleSectionTextAttributes"/>
             <!--<xsl:if test="@ID">
@@ -1953,7 +2138,7 @@
             <xsl:apply-templates/>
         </td>
     </xsl:template>-->
-    
+
     <xd:doc>
         <xd:desc>Security measure. Only process images on the image whitelist</xd:desc>
         <xd:param name="current-whitelist"/>
@@ -1968,8 +2153,8 @@
             <xsl:when test="string-length($current-whitelist) &gt; 0">
                 <xsl:variable name="whitelist-item">
                     <xsl:choose>
-                        <xsl:when test="contains($current-whitelist,'|')">
-                            <xsl:value-of select="substring-before($current-whitelist,'|')"/>
+                        <xsl:when test="contains($current-whitelist, '|')">
+                            <xsl:value-of select="substring-before($current-whitelist, '|')"/>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="$current-whitelist"/>
@@ -1977,7 +2162,7 @@
                     </xsl:choose>
                 </xsl:variable>
                 <xsl:choose>
-                    <xsl:when test="starts-with($image-uri,$whitelist-item)">
+                    <xsl:when test="starts-with($image-uri, $whitelist-item)">
                         <br clear="all"/>
                         <img src="{$image-uri}" alt="{$altTitleText}" title="{$altTitleText}"/>
                         <xsl:message>
@@ -1989,13 +2174,14 @@
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:call-template name="check-external-image-whitelist">
-                            <xsl:with-param name="current-whitelist" select="substring-after($current-whitelist,'|')"/>
+                            <xsl:with-param name="current-whitelist"
+                                select="substring-after($current-whitelist, '|')"/>
                             <xsl:with-param name="image-uri" select="$image-uri"/>
                             <xsl:with-param name="altTitleText" select="$altTitleText"/>
                         </xsl:call-template>
                     </xsl:otherwise>
                 </xsl:choose>
-                
+
             </xsl:when>
             <xsl:otherwise>
                 <p>
@@ -2019,12 +2205,13 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle RenderMultiMedia. This currently only handles GIF's and JPEG's. It could, however, be extended 
-                by including other image MIME types in the predicate and/or by generating &lt;object&gt; or &lt;applet&gt; 
-                tag with the correct params depending on the media type @ID =$imageRef referencedObject </xd:p>
+            <xd:p>Handle RenderMultiMedia. This currently only handles GIF's and JPEG's. It could,
+                however, be extended by including other image MIME types in the predicate and/or by
+                generating &lt;object&gt; or &lt;applet&gt; tag with the correct params depending on
+                the media type @ID =$imageRef referencedObject </xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template match="hl7:renderMultiMedia">
@@ -2035,7 +2222,8 @@
                 <xsl:with-param name="delimiters" select="' '"/>
             </xsl:call-template>
         </xsl:variable>-->
-        <xsl:variable name="referencedObjects" select="ancestor::hl7:ClinicalDocument//hl7:regionOfInterest[@ID = $imageRefs] | ancestor::hl7:ClinicalDocument//hl7:observationMedia[@ID = $imageRefs]"/>
+        <xsl:variable name="referencedObjects"
+            select="ancestor::hl7:ClinicalDocument//hl7:regionOfInterest[@ID = $imageRefs] | ancestor::hl7:ClinicalDocument//hl7:observationMedia[@ID = $imageRefs]"/>
         <div>
             <xsl:apply-templates select="hl7:caption"/>
             <xsl:for-each select="$referencedObjects">
@@ -2095,7 +2283,7 @@
             </xsl:for-each>
         </div>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle superscript</xd:p>
@@ -2110,7 +2298,7 @@
             <xsl:apply-templates/>
         </sup>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle subscript</xd:p>
@@ -2125,12 +2313,13 @@
             <xsl:apply-templates/>
         </sub>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Attribute processing for CDAr2 and CDAr3</xd:p>
         </xd:desc>
-        <xd:param name="class">If valued then this gets added to potential other class codes</xd:param>
+        <xd:param name="class">If valued then this gets added to potential other class
+            codes</xd:param>
     </xd:doc>
     <xsl:template match="*" mode="handleSectionTextAttributes">
         <xsl:param name="class">
@@ -2140,7 +2329,7 @@
                 <xsl:when test="local-name() = 'th'">narr_th</xsl:when>
             </xsl:choose>
         </xsl:param>
-        
+
         <xsl:variable name="classes">
             <xsl:if test="string-length($class)">
                 <xsl:value-of select="$class"/>
@@ -2160,11 +2349,11 @@
                 <xsl:value-of select="@class"/>
             </xsl:if>
         </xsl:variable>
-        
+
         <xsl:variable name="elem-name" select="local-name(.)"/>
-        
+
         <!-- Write @class attribute if there's data for it -->
-        <xsl:if test="string-length(normalize-space($classes))>0">
+        <xsl:if test="string-length(normalize-space($classes)) > 0">
             <xsl:attribute name="class">
                 <xsl:value-of select="normalize-space($classes)"/>
             </xsl:attribute>
@@ -2172,7 +2361,7 @@
         <!-- Write title with @revised (CDAr1 / CDAr2) prefixing to @title if one exists already -->
         <xsl:if test="@revised">
             <xsl:attribute name="title">
-                <xsl:value-of select="normalize-space(concat(@revised,' ',@title))"/>
+                <xsl:value-of select="normalize-space(concat(@revised, ' ', @title))"/>
             </xsl:attribute>
         </xsl:if>
         <!-- Write default table cellspacing / cellpadding -->
@@ -2188,15 +2377,17 @@
                 </xsl:attribute>
             </xsl:if>
         </xsl:if>
-        
+
         <xsl:for-each select="@*">
             <xsl:sort select="local-name()" order="descending"/>
             <xsl:variable name="attr-name" select="local-name(.)"/>
             <xsl:variable name="attr-value" select="."/>
-            <xsl:variable name="lcSource" select="translate($attr-value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
-            <xsl:variable name="scrubbedSource" select="translate($attr-value, $simple-sanitizer-match, $simple-sanitizer-replace)"/>
+            <xsl:variable name="lcSource"
+                select="translate($attr-value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+            <xsl:variable name="scrubbedSource"
+                select="translate($attr-value, $simple-sanitizer-match, $simple-sanitizer-replace)"/>
             <xsl:choose>
-                <xsl:when test="contains($lcSource,'javascript')">
+                <xsl:when test="contains($lcSource, 'javascript')">
                     <xsl:variable name="warningText">
                         <xsl:call-template name="getLocalizedString">
                             <xsl:with-param name="key" select="'javascript-injection-warning'"/>
@@ -2209,7 +2400,9 @@
                     </xsl:message>
                     <xsl:if test="$attr-name = 'href'">
                         <xsl:attribute name="title">
-                            <xsl:value-of select="concat(normalize-space(concat(../@title, ' ', $warningText)), ' ', $attr-value)"/>
+                            <xsl:value-of
+                                select="concat(normalize-space(concat(../@title, ' ', $warningText)), ' ', $attr-value)"
+                            />
                         </xsl:attribute>
                     </xsl:if>
                 </xsl:when>
@@ -2226,12 +2419,16 @@
                     </xsl:message>
                     <xsl:if test="$attr-name = 'href'">
                         <xsl:attribute name="title">
-                            <xsl:value-of select="concat(normalize-space(concat(../@title, ' ', $warningText)), ' ', $attr-value)"/>
+                            <xsl:value-of
+                                select="concat(normalize-space(concat(../@title, ' ', $warningText)), ' ', $attr-value)"
+                            />
                         </xsl:attribute>
                     </xsl:if>
                 </xsl:when>
-                <xsl:when test="$table-elem-attrs/elem[@name = $elem-name] and not($table-elem-attrs//elem[@name = $elem-name]/attr[@name = $attr-name])">
-                    <xsl:message><xsl:value-of select="$attr-name"/> is not legal in <xsl:value-of select="$elem-name"/></xsl:message>
+                <xsl:when
+                    test="$table-elem-attrs/elem[@name = $elem-name] and not($table-elem-attrs//elem[@name = $elem-name]/attr[@name = $attr-name])">
+                    <xsl:message><xsl:value-of select="$attr-name"/> is not legal in <xsl:value-of
+                            select="$elem-name"/></xsl:message>
                 </xsl:when>
                 <!-- Regular handling from here -->
                 <xsl:when test="$attr-name = 'ID'">
@@ -2392,25 +2589,27 @@
             </xsl:choose>
         </xsl:for-each>
     </xsl:template>
-    
+
     <!-- 
         ====================================
         START CDAr3 NarrativeBlock specifics
         ====================================
     -->
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle HTML like CDAr3 style Section.text elements that are not handled already above</xd:p>
+            <xd:p>Handle HTML like CDAr3 style Section.text elements that are not handled already
+                above</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:template match="hl7:a | hl7:dd | hl7:dl | hl7:img | hl7:ins | hl7:span | hl7:p | hl7:ol | hl7:ul| hl7:li">
+    <xsl:template
+        match="hl7:a | hl7:dd | hl7:dl | hl7:img | hl7:ins | hl7:span | hl7:p | hl7:ol | hl7:ul | hl7:li">
         <xsl:element name="{local-name()}" namespace="http://www.w3.org/1999/xhtml">
             <xsl:apply-templates select="." mode="handleSectionTextAttributes"/>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
-    
+
     <!-- 
         ==================================
         END CDAr3 NarrativeBlock specifics
@@ -2419,7 +2618,8 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Handle the document title based on the ClinicalDocument.title, ClinicalDocument.code or finally just 'Clinical Document'</xd:p>
+            <xd:p>Handle the document title based on the ClinicalDocument.title,
+                ClinicalDocument.code or finally just 'Clinical Document'</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template name="show-title">
@@ -2457,9 +2657,11 @@
             <xsl:variable name="confidentialityText">
                 <xsl:for-each select="hl7:confidentialityCode">
                     <xsl:choose>
-                        <xsl:when test="string-length(@displayName) = 0 and @codeSystem = '2.16.840.1.113883.5.25' and (@code = 'N' or @code = 'R' or @code = 'V')">
+                        <xsl:when
+                            test="string-length(@displayName) = 0 and @codeSystem = '2.16.840.1.113883.5.25' and (@code = 'N' or @code = 'R' or @code = 'V')">
                             <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="concat(@codeSystem, '-', @code)"/>
+                                <xsl:with-param name="key" select="concat(@codeSystem, '-', @code)"
+                                />
                             </xsl:call-template>
                         </xsl:when>
                         <xsl:otherwise>
@@ -2470,7 +2672,7 @@
                     </xsl:choose>
                 </xsl:for-each>
             </xsl:variable>
-            
+
             <xsl:text> </xsl:text>
             <img style="width: 1.2em; height: 1.2em;">
                 <xsl:attribute name="src">
@@ -2493,7 +2695,34 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show patients, guardians, consents, encounters, serviceEvents, orders and authors</xd:p>
+            <xd:p>Show identifiant</xd:p>
+        </xd:desc>
+        <xd:param name="id"/>
+    </xd:doc>
+    <xsl:template name="show-identifiant">
+        <xsl:param name="id"/>
+        <xsl:choose>
+            <xsl:when test="not($id)">
+                <xsl:if test="not(@nullFlavor)">
+                    <xsl:if test="@extension">
+                        <xsl:value-of select="@extension"/>
+                    </xsl:if>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:if test="not($id/@nullFlavor)">
+                    <xsl:if test="$id/@extension">
+                        <xsl:value-of select="$id/@extension"/>
+                    </xsl:if>
+                </xsl:if>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Show patients, guardians, consents, encounters, serviceEvents, orders and
+                authors</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template name="show-header">
@@ -2501,294 +2730,376 @@
             <tbody>
                 <!-- Patient row -->
                 <xsl:for-each select="hl7:recordTarget/hl7:patientRole">
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'recordTarget'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <!-- IE8 hack: without this span with float, IE8 will render the span with float right on a new line -->
-                            <span class="span_value">
-                                <xsl:call-template name="show-name-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:name[1]"/>
-                                </xsl:call-template>
-                            </span>
-                            <span style="float: right; margin-left: 1em;">
-                                <xsl:if test="hl7:patient/hl7:birthTime[@value]">
-                                    <span>
-                                        <span class="span_label">
-                                            <xsl:choose>
-                                                <xsl:when test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="key" select="'birthTimeLongDeceased'"/>
-                                                    </xsl:call-template>
-                                                </xsl:when>
-                                                <xsl:otherwise>
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="key" select="'birthTimeLong'"/>
-                                                    </xsl:call-template>
-                                                </xsl:otherwise>
-                                            </xsl:choose>
-                                            <xsl:text>: </xsl:text>
-                                        </span>
-                                        <span class="span_value">
-                                            <xsl:call-template name="show-timestamp">
-                                                <xsl:with-param name="in" select="hl7:patient/hl7:birthTime"/>
-                                            </xsl:call-template>
-                                            <xsl:if test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
-                                                <xsl:text> - &#8224; </xsl:text>
-                                                <xsl:choose>
-                                                    <xsl:when test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
-                                                        <xsl:call-template name="show-timestamp">
-                                                            <xsl:with-param name="in" select="hl7:patient/*[local-name() = 'deceasedTime']"/>
-                                                        </xsl:call-template>
-                                                    </xsl:when>
-                                                    <xsl:when test="hl7:patient/*[local-name() = 'deceasedInd'][@nullFlavor]">
-                                                        <xsl:call-template name="show-nullFlavor">
-                                                            <xsl:with-param name="in" select="hl7:patient/*[local-name() = 'deceasedInd']/@nullFlavor"/>
-                                                        </xsl:call-template>
-                                                    </xsl:when>
-                                                    <xsl:otherwise>
-                                                        <xsl:call-template name="getLocalizedString">
-                                                            <xsl:with-param name="key" select="'date_unknown'"/>
-                                                        </xsl:call-template>
-                                                    </xsl:otherwise>
-                                                </xsl:choose>
-                                            </xsl:if>
-                                            <xsl:variable name="comparedate">
-                                                <xsl:choose>
-                                                    <xsl:when test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
-                                                        <xsl:value-of select="hl7:patient/*[local-name() = 'deceasedTime']/@value"/>
-                                                    </xsl:when>
-                                                    <xsl:when test="not(hl7:patient/*[local-name() = 'deceasedInd'] or hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] or hl7:patient/*[local-name() = 'deceasedTime'])">
-                                                        <xsl:value-of select="$currentDate"/>
-                                                    </xsl:when>
-                                                </xsl:choose>
-                                            </xsl:variable>
-                                            <xsl:if test="string-length($comparedate) > 0">
-                                                <span>
-                                                    <xsl:attribute name="title">
-                                                        <xsl:choose>
-                                                            <xsl:when test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
-                                                                <xsl:call-template name="getLocalizedString">
-                                                                    <xsl:with-param name="key" select="'At the time of death'"/>
-                                                                </xsl:call-template>
-                                                            </xsl:when>
-                                                            <xsl:otherwise>
-                                                                <xsl:call-template name="getLocalizedString">
-                                                                    <xsl:with-param name="key" select="'At document creation time'"/>
-                                                                </xsl:call-template>
-                                                            </xsl:otherwise>
-                                                        </xsl:choose>
-                                                    </xsl:attribute>
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="pre">
-                                                            <xsl:text> (</xsl:text>
-                                                            <xsl:call-template name="getAge">
-                                                                <xsl:with-param name="comparedate" select="$comparedate"/>
-                                                                <xsl:with-param name="date" select="hl7:patient/hl7:birthTime/@value"/>
-                                                            </xsl:call-template>
-                                                        </xsl:with-param>
-                                                        <xsl:with-param name="key" select="'yr'"/>
-                                                        <xsl:with-param name="post" select="')'"/>
-                                                    </xsl:call-template>
-                                                </span>
-                                            </xsl:if>
-                                            <xsl:if test="hl7:patient/*[local-name() = 'multipleBirthInd'][@value = 'true'] | hl7:patient/*[local-name() = 'multipleBirthOrderNumber']">
-                                                <i>
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="pre" select="' '"/>
-                                                        <xsl:with-param name="key" select="'partOfMultipleBirth'"/>
-                                                    </xsl:call-template>
-                                                </i>
-                                            </xsl:if>
-                                        </span>
-                                    </span>
-                                </xsl:if>
-                                <xsl:if test="hl7:patient/hl7:administrativeGenderCode[@code]">
-                                    <span class="span_label">
-                                        <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'administrativeGenderCode'"/>
-                                            <xsl:with-param name="post" select="': '"/>
-                                        </xsl:call-template>
-                                    </span>
-                                    <span class="span_value">
-                                        <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:patient/hl7:administrativeGenderCode"/>
-                                        </xsl:call-template>
-                                    </span>
-                                </xsl:if>
-                            </span>
-                            <xsl:if test="hl7:id[not(contains($skip-ids-var, concat(',',@root,',')))]">
-                                <span style="float: right;" class="print_visible">
-                                    <span class="span_label">
-                                        <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'patientIdLong'"/>
-                                            <xsl:with-param name="post" select="':&#160;'"/>
-                                        </xsl:call-template>
-                                    </span>
-                                    <span class="span_value">
-                                        <xsl:call-template name="show-id-set">
-                                            <xsl:with-param name="in" select="hl7:id[not(contains($skip-ids-var, concat(',', @root, ',')))]"/>
-                                            <xsl:with-param name="sep" select="', '"/>
-                                        </xsl:call-template>
-                                    </span>
-                                </span>
-                            </xsl:if>
-                        </td>
-                    </tr>
-                    <xsl:if test="hl7:patient/hl7:guardian">
+                    <xsl:if test="
+                            hl7:patient/hl7:name or hl7:patient/hl7:birthTime[@value] or hl7:patient/hl7:administrativeGenderCode[@code]
+                            or hl7:id/@root = '1.2.250.1.213.1.4.8' or hl7:id/@root = '1.2.250.1.213.1.4.9' or hl7:id/@root = '1.2.250.1.213.1.4.10' or hl7:id/@root = '1.2.250.1.213.1.4.11'">
                         <tr>
                             <td class="td_label">
                                 <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'Guardian'"/>
+                                    <xsl:with-param name="key" select="'recordTarget'"/>
                                 </xsl:call-template>
                             </td>
                             <td>
+                                <!-- IE8 hack: without this span with float, IE8 will render the span with float right on a new line -->
                                 <span class="span_value">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:patient/hl7:guardian/*/hl7:name[1]"/>
+                                        <xsl:with-param name="in" select="hl7:patient/hl7:name[1]"/>
                                     </xsl:call-template>
-                                    <xsl:if test="hl7:patient/hl7:guardian/hl7:code">
-                                        <xsl:text> - </xsl:text>
-                                        <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:patient/hl7:guardian/hl7:code"/>
-                                        </xsl:call-template>
+                                </span>
+                                <span style="float: right; margin-left: 1em;">
+                                    <xsl:if test="hl7:patient/hl7:birthTime[@value]">
+                                        <span>
+                                            <span class="span_label">
+                                                <xsl:choose>
+                                                  <xsl:when
+                                                  test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'birthTimeLongDeceased'"/>
+                                                  </xsl:call-template>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'birthTimeLong'"/>
+                                                  </xsl:call-template>
+                                                  </xsl:otherwise>
+                                                </xsl:choose>
+                                                <xsl:text>: </xsl:text>
+                                            </span>
+                                            <span class="span_value">
+                                                <xsl:call-template name="show-timestamp">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:patient/hl7:birthTime"/>
+                                                </xsl:call-template>
+                                                <xsl:if
+                                                  test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
+                                                  <xsl:text> - &#8224; </xsl:text>
+                                                  <xsl:choose>
+                                                  <xsl:when
+                                                  test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
+                                                  <xsl:call-template name="show-timestamp">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:patient/*[local-name() = 'deceasedTime']"
+                                                  />
+                                                  </xsl:call-template>
+                                                  </xsl:when>
+                                                  <xsl:when
+                                                  test="hl7:patient/*[local-name() = 'deceasedInd'][@nullFlavor]">
+                                                  <xsl:call-template name="show-nullFlavor">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:patient/*[local-name() = 'deceasedInd']/@nullFlavor"
+                                                  />
+                                                  </xsl:call-template>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key" select="'date_unknown'"
+                                                  />
+                                                  </xsl:call-template>
+                                                  </xsl:otherwise>
+                                                  </xsl:choose>
+                                                </xsl:if>
+                                                <xsl:variable name="comparedate">
+                                                  <xsl:choose>
+                                                  <xsl:when
+                                                  test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
+                                                  <xsl:value-of
+                                                  select="hl7:patient/*[local-name() = 'deceasedTime']/@value"
+                                                  />
+                                                  </xsl:when>
+                                                  <xsl:when
+                                                  test="not(hl7:patient/*[local-name() = 'deceasedInd'] or hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] or hl7:patient/*[local-name() = 'deceasedTime'])">
+                                                  <xsl:value-of select="$currentDate"/>
+                                                  </xsl:when>
+                                                  </xsl:choose>
+                                                </xsl:variable>
+                                                <xsl:if test="string-length($comparedate) > 0">
+                                                  <span>
+                                                  <xsl:attribute name="title">
+                                                  <xsl:choose>
+                                                  <xsl:when
+                                                  test="hl7:patient/*[local-name() = 'deceasedTime'][@value]">
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'At the time of death'"/>
+                                                  </xsl:call-template>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'At document creation time'"/>
+                                                  </xsl:call-template>
+                                                  </xsl:otherwise>
+                                                  </xsl:choose>
+                                                  </xsl:attribute>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="pre">
+                                                  <xsl:text> (</xsl:text>
+                                                  <xsl:call-template name="getAge">
+                                                  <xsl:with-param name="comparedate"
+                                                  select="$comparedate"/>
+                                                  <xsl:with-param name="date"
+                                                  select="hl7:patient/hl7:birthTime/@value"/>
+                                                  </xsl:call-template>
+                                                  <xsl:text> </xsl:text>
+                                                  </xsl:with-param>
+                                                  <xsl:with-param name="key" select="'yr'"/>
+                                                  </xsl:call-template>
+                                                  <xsl:text>) </xsl:text>
+                                                  </span>
+                                                </xsl:if>
+                                                <xsl:if
+                                                  test="hl7:patient/*[local-name() = 'multipleBirthInd'][@value = 'true'] | hl7:patient/*[local-name() = 'multipleBirthOrderNumber']">
+                                                  <i>
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="pre" select="' '"/>
+                                                  <xsl:with-param name="key"
+                                                  select="'partOfMultipleBirth'"/>
+                                                  </xsl:call-template>
+                                                  </i>
+                                                </xsl:if>
+                                            </span>
+                                        </span>
+                                    </xsl:if>
+                                    <xsl:if test="hl7:patient/hl7:administrativeGenderCode[@code]">
+                                        <span class="span_label">
+                                            <xsl:call-template name="getLocalizedString">
+                                                <xsl:with-param name="key"
+                                                  select="'administrativeGenderCode'"/>
+                                                <xsl:with-param name="post" select="': '"/>
+                                            </xsl:call-template>
+                                        </span>
+                                        <span class="span_value">
+                                            <xsl:call-template name="show-code-set">
+                                                <xsl:with-param name="in"
+                                                  select="hl7:patient/hl7:administrativeGenderCode"
+                                                />
+                                            </xsl:call-template>
+                                        </span>
                                     </xsl:if>
                                 </span>
+                                <xsl:if
+                                    test="hl7:id/@root = '1.2.250.1.213.1.4.8' or hl7:id/@root = '1.2.250.1.213.1.4.9' or hl7:id/@root = '1.2.250.1.213.1.4.10' or hl7:id/@root = '1.2.250.1.213.1.4.11'">
+                                    <span style="float: right;" class="print_visible">
+                                        <span class="span_label">
+                                            <xsl:call-template name="getLocalizedString">
+                                                <xsl:with-param name="key" select="'patientIdLong'"/>
+                                                <xsl:with-param name="post" select="':&#160;'"/>
+                                            </xsl:call-template>
+                                        </span>
+                                        <span class="span_value">
+                                            <xsl:for-each select="hl7:id">
+                                                <xsl:choose>
+                                                  <xsl:when test="@root = '1.2.250.1.213.1.4.8'">
+                                                  <xsl:call-template name="show-identifiant">
+                                                  <xsl:with-param name="id" select="."/>
+                                                  </xsl:call-template>
+                                                  <xsl:text>&#160;</xsl:text>
+                                                  <xsl:text>(1.2.250.1.213.1.4.8)</xsl:text>
+                                                  </xsl:when>
+                                                  <xsl:when test="@root = '1.2.250.1.213.1.4.9'">
+                                                  <xsl:call-template name="show-identifiant">
+                                                  <xsl:with-param name="id" select="."/>
+                                                  </xsl:call-template>
+                                                  <xsl:text>&#160;</xsl:text>
+                                                  <xsl:text>(1.2.250.1.213.1.4.9)</xsl:text>
+                                                  </xsl:when>
+                                                  <xsl:when test="@root = '1.2.250.1.213.1.4.10'">
+                                                  <xsl:call-template name="show-identifiant">
+                                                  <xsl:with-param name="id" select="."/>
+                                                  </xsl:call-template>
+                                                  <xsl:text>&#160;</xsl:text>
+                                                  <xsl:text>(1.2.250.1.213.1.4.10)</xsl:text>
+                                                  </xsl:when>
+                                                  <xsl:when test="@root = '1.2.250.1.213.1.4.11'">
+                                                  <xsl:call-template name="show-identifiant">
+                                                  <xsl:with-param name="id" select="."/>
+                                                  </xsl:call-template>
+                                                  <xsl:text>&#160;</xsl:text>
+                                                  <xsl:text>(1.2.250.1.213.1.4.11)</xsl:text>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:text>&#160;</xsl:text>
+                                                  </xsl:otherwise>
+                                                </xsl:choose>
+                                                <xsl:if test="position() != last()">
+                                                  <xsl:text>, </xsl:text>
+                                                </xsl:if>
+                                            </xsl:for-each>
+                                        </span>
+                                    </span>
+                                </xsl:if>
                             </td>
                         </tr>
+                    </xsl:if>
+                    <xsl:if test="hl7:patient/hl7:guardian">
+                        <xsl:if
+                            test="hl7:patient/hl7:guardian/*/hl7:name[1] or hl7:patient/hl7:guardian/hl7:code">
+                            <tr>
+                                <td class="td_label">
+                                    <xsl:call-template name="getLocalizedString">
+                                        <xsl:with-param name="key" select="'Guardian'"/>
+                                    </xsl:call-template>
+                                </td>
+                                <td>
+                                    <span class="span_value">
+                                        <xsl:if test="hl7:patient/hl7:guardian/*/hl7:name[1]">
+                                            <xsl:call-template name="show-name-set">
+                                                <xsl:with-param name="in"
+                                                  select="hl7:patient/hl7:guardian/*/hl7:name[1]"/>
+                                            </xsl:call-template>
+                                        </xsl:if>
+                                        <xsl:if test="hl7:patient/hl7:guardian/hl7:code">
+                                            <xsl:if test="hl7:patient/hl7:guardian/*/hl7:name[1]">
+                                                <xsl:text> - </xsl:text>
+                                            </xsl:if>
+                                            <xsl:call-template name="show-code-set">
+                                                <xsl:with-param name="in"
+                                                  select="hl7:patient/hl7:guardian/hl7:code"/>
+                                            </xsl:call-template>
+                                        </xsl:if>
+                                    </span>
+                                </td>
+                            </tr>
+                        </xsl:if>
                     </xsl:if>
                 </xsl:for-each>
                 <!-- Authorization -->
                 <xsl:for-each select="hl7:authorization/hl7:consent">
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'consent'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <xsl:if test="hl7:id">
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'id'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-id-set">
-                                        <xsl:with-param name="in" select="hl7:id"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:code">
+                    <xsl:if test="hl7:id or hl7:code or hl7:statusCode">
+                        <tr>
+                            <td class="td_label">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'consent'"/>
+                                </xsl:call-template>
+                            </td>
+                            <td>
                                 <xsl:if test="hl7:id">
-                                    <xsl:text>, </xsl:text>
-                                </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'code'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:code"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:statusCode">
-                                <xsl:if test="hl7:id | hl7:code">
-                                    <xsl:text>, </xsl:text>
-                                </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'statusCode'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code">
-                                        <xsl:with-param name="in" select="hl7:statusCode"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                        </td>
-                    </tr>
-                </xsl:for-each>
-                <!-- Encounter row -->
-                <xsl:for-each select="hl7:componentOf/hl7:encompassingEncounter">
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'Encounter'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <xsl:if test="hl7:id">
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'id'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-id-set">
-                                        <xsl:with-param name="in" select="hl7:id"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:code">
-                                <xsl:if test="hl7:id">
-                                    <xsl:text>, </xsl:text>
-                                </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'type'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:code"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:effectiveTime">
-                                <xsl:if test="hl7:id | hl7:code">
-                                    <xsl:text>, </xsl:text>
-                                </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'effectiveTime'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-ivlts">
-                                        <xsl:with-param name="in" select="hl7:effectiveTime"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:location/hl7:healthCareFacility/hl7:code">
-                                <div>
                                     <span class="span_label">
                                         <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'location'"/>
+                                            <xsl:with-param name="key" select="'id'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-id-set">
+                                            <xsl:with-param name="in" select="hl7:id"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                                <xsl:if test="hl7:code">
+                                    <xsl:if test="hl7:id">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'code'"/>
                                             <xsl:with-param name="post" select="': '"/>
                                         </xsl:call-template>
                                     </span>
                                     <span class="span_value">
                                         <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:code"/>
+                                            <xsl:with-param name="in" select="hl7:code"/>
                                         </xsl:call-template>
                                     </span>
-                                </div>
-                            </xsl:if>
-                        </td>
-                    </tr>
+                                </xsl:if>
+                                <xsl:if test="hl7:statusCode">
+                                    <xsl:if test="hl7:id | hl7:code">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'statusCode'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-code">
+                                            <xsl:with-param name="in" select="hl7:statusCode"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                            </td>
+                        </tr>
+                    </xsl:if>
+                </xsl:for-each>
+                <!-- Encounter row -->
+                <xsl:for-each select="hl7:componentOf/hl7:encompassingEncounter">
+                    <xsl:if
+                        test="hl7:id or hl7:code or hl7:effectiveTime or hl7:location/hl7:healthCareFacility/hl7:code">
+                        <tr>
+                            <td class="td_label">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'Encounter'"/>
+                                </xsl:call-template>
+                            </td>
+                            <td>
+                                <xsl:if test="hl7:id">
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'id'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-id-set">
+                                            <xsl:with-param name="in" select="hl7:id"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                                <xsl:if test="hl7:code">
+                                    <xsl:if test="hl7:id">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'type'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-code-set">
+                                            <xsl:with-param name="in" select="hl7:code"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                                <xsl:if test="hl7:effectiveTime">
+                                    <xsl:if test="hl7:id | hl7:code">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'effectiveTime'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-ivlts">
+                                            <xsl:with-param name="in" select="hl7:effectiveTime"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                                <xsl:if test="hl7:location/hl7:healthCareFacility/hl7:code">
+                                    <div>
+                                        <span class="span_label">
+                                            <xsl:call-template name="getLocalizedString">
+                                                <xsl:with-param name="key" select="'location'"/>
+                                                <xsl:with-param name="post" select="': '"/>
+                                            </xsl:call-template>
+                                        </span>
+                                        <span class="span_value">
+                                            <xsl:call-template name="show-code-set">
+                                                <xsl:with-param name="in"
+                                                  select="hl7:location/hl7:healthCareFacility/hl7:code"
+                                                />
+                                            </xsl:call-template>
+                                        </span>
+                                    </div>
+                                </xsl:if>
+                            </td>
+                        </tr>
+                    </xsl:if>
                 </xsl:for-each>
                 <!-- DocumentationOf -->
                 <xsl:for-each select="hl7:documentationOf/hl7:serviceEvent">
@@ -2799,262 +3110,305 @@
                             </xsl:call-template>
                         </xsl:if>
                     </xsl:variable>
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'documentationOf'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <xsl:if test="string-length($displayName) > 0">
-                                <xsl:call-template name="firstCharCaseUp">
-                                    <xsl:with-param name="data" select="$displayName"/>
+                    <xsl:if
+                        test="string-length($displayName) > 0 or hl7:code or hl7:effectiveTime or hl7:performer/hl7:assignedEntity/hl7:assignedPerson[hl7:name]">
+                        <tr>
+                            <td class="td_label">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'documentationOf'"/>
                                 </xsl:call-template>
-                            </xsl:if>
-                            <xsl:if test="hl7:code">
+                            </td>
+                            <td>
                                 <xsl:if test="string-length($displayName) > 0">
-                                    <xsl:text>, </xsl:text>
+                                    <xsl:call-template name="firstCharCaseUp">
+                                        <xsl:with-param name="data" select="$displayName"/>
+                                    </xsl:call-template>
                                 </xsl:if>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code">
-                                        <xsl:with-param name="in" select="hl7:code"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:effectiveTime">
-                                <xsl:if test="string-length($displayName) > 0 or hl7:code">
-                                    <xsl:text>, </xsl:text>
+                                <xsl:if test="hl7:code">
+                                    <xsl:if test="string-length($displayName) > 0">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-code">
+                                            <xsl:with-param name="in" select="hl7:code"/>
+                                        </xsl:call-template>
+                                    </span>
                                 </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'effectiveTime'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-ivlts">
-                                        <xsl:with-param name="in" select="hl7:effectiveTime"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:for-each select="hl7:performer/hl7:assignedEntity/hl7:assignedPerson[hl7:name]">
-                                <xsl:if test="string-length($displayName) > 0 or ancestor::hl7:serviceEvent[1]/hl7:code or ancestor::hl7:serviceEvent[1]/hl7:effectiveTime">
-                                    <xsl:text>, </xsl:text>
+                                <xsl:if test="hl7:effectiveTime">
+                                    <xsl:if test="string-length($displayName) > 0 or hl7:code">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'effectiveTime'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-ivlts">
+                                            <xsl:with-param name="in" select="hl7:effectiveTime"/>
+                                        </xsl:call-template>
+                                    </span>
                                 </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="concat('typeCode-', ancestor::hl7:performer[1]/@typeCode)"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-name">
-                                        <xsl:with-param name="in" select="hl7:name[1]"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:for-each>
-                        </td>
-                    </tr>
+                                <xsl:for-each
+                                    select="hl7:performer/hl7:assignedEntity/hl7:assignedPerson[hl7:name]">
+                                    <xsl:if
+                                        test="string-length($displayName) > 0 or ancestor::hl7:serviceEvent[1]/hl7:code or ancestor::hl7:serviceEvent[1]/hl7:effectiveTime">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key"
+                                                select="concat('typeCode-', ancestor::hl7:performer[1]/@typeCode)"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-name">
+                                            <xsl:with-param name="in" select="hl7:name[1]"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:for-each>
+                            </td>
+                        </tr>
+                    </xsl:if>
                 </xsl:for-each>
                 <!-- InFulfillmentOf -->
                 <xsl:for-each select="hl7:inFulfillmentOf/hl7:order">
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'typeCode-FLFS'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <span class="span_label">
+                    <xsl:if test="hl7:id or hl7:code or hl7:priorityCode">
+                        <tr>
+                            <td class="td_label">
                                 <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'order'"/>
+                                    <xsl:with-param name="key" select="'typeCode-FLFS'"/>
                                 </xsl:call-template>
-                                <xsl:text> </xsl:text>
-                            </span>
-                            <xsl:if test="hl7:id">
+                            </td>
+                            <td>
                                 <span class="span_label">
                                     <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'id'"/>
-                                        <xsl:with-param name="post" select="': '"/>
+                                        <xsl:with-param name="key" select="'order'"/>
                                     </xsl:call-template>
+                                    <xsl:text> </xsl:text>
                                 </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-id-set">
-                                        <xsl:with-param name="in" select="hl7:id"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:code">
                                 <xsl:if test="hl7:id">
-                                    <xsl:text>, </xsl:text>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'id'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-id-set">
+                                            <xsl:with-param name="in" select="hl7:id"/>
+                                        </xsl:call-template>
+                                    </span>
                                 </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'code'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:code"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                            <xsl:if test="hl7:priorityCode">
-                                <xsl:if test="hl7:id | hl7:code">
-                                    <xsl:text>, </xsl:text>
+                                <xsl:if test="hl7:code">
+                                    <xsl:if test="hl7:id">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'code'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-code-set">
+                                            <xsl:with-param name="in" select="hl7:code"/>
+                                        </xsl:call-template>
+                                    </span>
                                 </xsl:if>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'priorityCode'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:priorityCode"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                        </td>
-                    </tr>
+                                <xsl:if test="hl7:priorityCode">
+                                    <xsl:if test="hl7:id | hl7:code">
+                                        <xsl:text>, </xsl:text>
+                                    </xsl:if>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'priorityCode'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-code-set">
+                                            <xsl:with-param name="in" select="hl7:priorityCode"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                            </td>
+                        </tr>
+                    </xsl:if>
                 </xsl:for-each>
                 <!-- Author row -->
                 <xsl:for-each select="hl7:author/hl7:assignedAuthor">
-                    <tr>
-                        <td class="td_label">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'author'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <span class="span_value">
-                                <xsl:choose>
-                                    <xsl:when test="hl7:assignedPerson/hl7:name">
-                                        <xsl:call-template name="show-name-set">
-                                            <xsl:with-param name="in" select="hl7:assignedPerson/hl7:name[1]"/>
-                                        </xsl:call-template>
-                                        <xsl:if test="hl7:assignedPerson/hl7:desc">
-                                            <div>
-                                                <xsl:value-of select="hl7:assignedPerson/hl7:desc"/>
-                                            </div>
-                                        </xsl:if>
-                                        <xsl:if test="hl7:assignedPerson/hl7:birthTime">
-                                            <xsl:text> </xsl:text>
-                                            <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'birthTimeLong'"/>
-                                            </xsl:call-template>
-                                            <xsl:text> </xsl:text>
-                                            <xsl:call-template name="show-timestamp">
-                                                <xsl:with-param name="in" select="hl7:assignedPerson/hl7:birthTime"/>
-                                            </xsl:call-template>
-                                        </xsl:if>
-                                    </xsl:when>
-                                    <xsl:when test="hl7:assignedAuthoringDevice/hl7:softwareName">
-                                        <xsl:value-of select="hl7:assignedAuthoringDevice/hl7:softwareName"/>
-                                    </xsl:when>
-                                    <xsl:when test="hl7:assignedDevice/hl7:softwareName">
-                                        <xsl:value-of select="hl7:assignedDevice/hl7:softwareName/@value"/>
-                                    </xsl:when>
-                                </xsl:choose>
-                            </span>
-                            <xsl:if test="hl7:representedOrganization">
-                                <xsl:variable name="organizationName">
+                    <xsl:if
+                        test="hl7:assignedPerson/hl7:name or hl7:assignedAuthoringDevice/hl7:softwareName or hl7:representedOrganization or ../hl7:time[@value | *]">
+                        <tr>
+                            <td class="td_label">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'author'"/>
+                                </xsl:call-template>
+                            </td>
+                            <td>
+                                <span class="span_value">
                                     <xsl:choose>
-                                        <xsl:when test="hl7:representedOrganization/hl7:name">
+                                        <xsl:when test="hl7:assignedPerson/hl7:name">
                                             <xsl:call-template name="show-name-set">
-                                                <xsl:with-param name="in" select="hl7:representedOrganization/hl7:name[1]"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:assignedPerson/hl7:name[1]"/>
                                             </xsl:call-template>
+                                            <xsl:text> </xsl:text>
+                                            <xsl:if test="hl7:assignedPerson/hl7:desc">
+                                                <div>
+                                                  <xsl:value-of select="hl7:assignedPerson/hl7:desc"
+                                                  />
+                                                </div>
+                                            </xsl:if>
+                                            <xsl:if test="hl7:assignedPerson/hl7:birthTime">
+                                                <xsl:text> </xsl:text>
+                                                <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key"
+                                                  select="'birthTimeLong'"/>
+                                                </xsl:call-template>
+                                                <xsl:text> </xsl:text>
+                                                <xsl:call-template name="show-timestamp">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:assignedPerson/hl7:birthTime"/>
+                                                </xsl:call-template>
+                                            </xsl:if>
                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:variable name="id-root" select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@root"/>
-                                            <xsl:variable name="id-ext" select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@extension"/>
-                                            <xsl:choose>
-                                                <xsl:when test="$id-ext">
-                                                    <xsl:call-template name="show-name-set">
-                                                        <xsl:with-param name="in" select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name[1]"/>
-                                                    </xsl:call-template>
-                                                </xsl:when>
-                                                <xsl:otherwise>
-                                                    <xsl:call-template name="show-name-set">
-                                                        <xsl:with-param name="in" select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][not(@extension)]][hl7:name])[1]/hl7:name[1]"/>
-                                                    </xsl:call-template>
-                                                </xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:variable>
-                                <xsl:text>, </xsl:text>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'organization'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:choose>
-                                        <xsl:when test="string-length(normalize-space($organizationName)) > 0">
-                                            <xsl:value-of select="normalize-space($organizationName)"/>
+                                        <xsl:when
+                                            test="hl7:assignedAuthoringDevice/hl7:softwareName">
+                                            <xsl:value-of
+                                                select="hl7:assignedAuthoringDevice/hl7:softwareName"
+                                            />
                                         </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:call-template name="show-id-set">
-                                                <xsl:with-param name="in" select="hl7:representedOrganization/hl7:id"/>
-                                            </xsl:call-template>
-                                        </xsl:otherwise>
+                                        <xsl:when test="hl7:assignedDevice/hl7:softwareName">
+                                            <xsl:value-of
+                                                select="hl7:assignedDevice/hl7:softwareName/@value"
+                                            />
+                                        </xsl:when>
                                     </xsl:choose>
                                 </span>
-                            </xsl:if>
-                            <xsl:if test="../hl7:time[@value | *]">
-                                <xsl:text>, </xsl:text>
-                                <span class="span_label">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'Authored_on'"/>
-                                        <xsl:with-param name="post" select="': '"/>
-                                    </xsl:call-template>
-                                </span>
-                                <span class="span_value">
-                                    <xsl:call-template name="show-timestamp">
-                                        <xsl:with-param name="in" select="../hl7:time"/>
-                                    </xsl:call-template>
-                                </span>
-                            </xsl:if>
-                        </td>
-                    </tr>
+                                <xsl:if test="hl7:representedOrganization">
+                                    <xsl:variable name="organizationName">
+                                        <xsl:choose>
+                                            <xsl:when test="hl7:representedOrganization/hl7:name">
+                                                <xsl:call-template name="show-name-set">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:representedOrganization/hl7:name[1]"/>
+                                                </xsl:call-template>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:variable name="id-root"
+                                                  select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@root"/>
+                                                <xsl:variable name="id-ext"
+                                                  select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@extension"/>
+                                                <xsl:choose>
+                                                  <xsl:when test="$id-ext">
+                                                  <xsl:call-template name="show-name-set">
+                                                  <xsl:with-param name="in"
+                                                  select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name[1]"
+                                                  />
+                                                  </xsl:call-template>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:call-template name="show-name-set">
+                                                  <xsl:with-param name="in"
+                                                  select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][not(@extension)]][hl7:name])[1]/hl7:name[1]"
+                                                  />
+                                                  </xsl:call-template>
+                                                  </xsl:otherwise>
+                                                </xsl:choose>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:variable>
+                                    <xsl:text>, </xsl:text>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'organization'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:choose>
+                                            <xsl:when
+                                                test="string-length(normalize-space($organizationName)) > 0">
+                                                <xsl:value-of
+                                                  select="normalize-space($organizationName)"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:call-template name="show-id-set">
+                                                  <xsl:with-param name="in"
+                                                  select="hl7:representedOrganization/hl7:id"/>
+                                                </xsl:call-template>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </span>
+                                </xsl:if>
+                                <xsl:if test="../hl7:time[@value | *]">
+                                    <xsl:text>, </xsl:text>
+                                    <span class="span_label">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'Authored_on'"/>
+                                            <xsl:with-param name="post" select="': '"/>
+                                        </xsl:call-template>
+                                    </span>
+                                    <span class="span_value">
+                                        <xsl:call-template name="show-timestamp">
+                                            <xsl:with-param name="in" select="../hl7:time"/>
+                                        </xsl:call-template>
+                                    </span>
+                                </xsl:if>
+                            </td>
+                        </tr>
+                    </xsl:if>
                 </xsl:for-each>
             </tbody>
         </table>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle general document propreties (id + creation time)</xd:p>
         </xd:desc>
     </xd:doc>
     <xsl:template name="documentGeneral">
-        <table class="header_table">
-            <tbody>
-                <tr>
-                    <td class="td_label td_label_width">
-                        <xsl:call-template name="getLocalizedString">
-                            <xsl:with-param name="key" select="'Document'"/>
-                        </xsl:call-template>
-                    </td>
-                    <td style="width: 30%;">
-                        <xsl:call-template name="idVersionSetId"/>
-                    </td>
-                    <td class="td_label td_label_width">
-                        <xsl:call-template name="getLocalizedString">
-                            <xsl:with-param name="key" select="'Created_on'"/>
-                        </xsl:call-template>
-                    </td>
-                    <td>
-                        <xsl:call-template name="show-timestamp">
-                            <xsl:with-param name="in" select="hl7:effectiveTime"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <xsl:if test="hl7:id | hl7:setId | hl7:versionNumber | hl7:effectiveTime">
+            <table class="header_table">
+                <tbody>
+                    <tr>
+                        <td class="td_label td_label_width">
+                            <xsl:if
+                                test="hl7:id | hl7:setId | hl7:versionNumber | hl7:effectiveTime">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'Document'"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </td>
+                        <td style="width: 30%;">
+                            <xsl:if test="hl7:id | hl7:setId | hl7:versionNumber">
+                                <xsl:call-template name="idVersionSetId"/>
+                            </xsl:if>
+                        </td>
+                        <td class="td_label td_label_width">
+                            <xsl:if test="hl7:effectiveTime">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'Created_on'"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if test="hl7:effectiveTime">
+                                <xsl:call-template name="show-timestamp">
+                                    <xsl:with-param name="in" select="hl7:effectiveTime"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </td>
+
+                    </tr>
+                </tbody>
+            </table>
+        </xsl:if>
     </xsl:template>
 
     <xd:doc>
@@ -3078,7 +3432,7 @@
             </tbody>
         </table>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header author</xd:p>
@@ -3090,7 +3444,8 @@
                 <tbody>
                     <tr>
                         <td class="td_label td_label_width">
-                            <xsl:if test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
+                            <xsl:if
+                                test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
                                 <xsl:attribute name="rowspan">2</xsl:attribute>
                             </xsl:if>
                             <xsl:call-template name="getLocalizedString">
@@ -3106,13 +3461,15 @@
                                     <xsl:attribute name="colspan">3</xsl:attribute>
                                 </xsl:otherwise>
                             </xsl:choose>
-                            <xsl:if test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
+                            <xsl:if
+                                test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
                                 <xsl:attribute name="rowspan">2</xsl:attribute>
                             </xsl:if>
                             <xsl:choose>
                                 <xsl:when test="hl7:assignedPerson/hl7:name">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:assignedPerson/hl7:name"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:assignedPerson/hl7:name"/>
                                     </xsl:call-template>
                                     <xsl:if test="hl7:assignedPerson/hl7:desc">
                                         <div>
@@ -3126,15 +3483,18 @@
                                         </xsl:call-template>
                                         <xsl:text> </xsl:text>
                                         <xsl:call-template name="show-timestamp">
-                                            <xsl:with-param name="in" select="hl7:assignedPerson/hl7:birthTime"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedPerson/hl7:birthTime"/>
                                         </xsl:call-template>
                                     </xsl:if>
                                 </xsl:when>
                                 <xsl:when test="hl7:assignedAuthoringDevice/hl7:softwareName">
-                                    <xsl:value-of select="hl7:assignedAuthoringDevice/hl7:softwareName"/>
+                                    <xsl:value-of
+                                        select="hl7:assignedAuthoringDevice/hl7:softwareName"/>
                                 </xsl:when>
                                 <xsl:when test="hl7:assignedDevice/hl7:softwareName">
-                                    <xsl:value-of select="hl7:assignedDevice/hl7:softwareName/@value"/>
+                                    <xsl:value-of
+                                        select="hl7:assignedDevice/hl7:softwareName/@value"/>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:call-template name="show-id-set">
@@ -3161,45 +3521,62 @@
                                     <xsl:with-param name="post" select="': '"/>
                                 </xsl:call-template>
                             </xsl:if>
-                            <xsl:variable name="id-root" select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@root"/>
-                            <xsl:variable name="id-ext" select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@extension"/>
+                            <xsl:variable name="id-root"
+                                select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@root"/>
+                            <xsl:variable name="id-ext"
+                                select="(hl7:representedOrganization/hl7:id[not(@nullFlavor)])[1]/@extension"/>
+                            <xsl:text>(</xsl:text>
                             <xsl:choose>
                                 <xsl:when test="hl7:representedOrganization/hl7:name">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:representedOrganization/hl7:name"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:representedOrganization/hl7:name"/>
                                     </xsl:call-template>
                                 </xsl:when>
-                                <xsl:when test="string-length($id-ext) &gt; 0 and (ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name">
+                                <xsl:when
+                                    test="string-length($id-ext) &gt; 0 and (ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name"/>
+                                        <xsl:with-param name="in"
+                                            select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root][@extension = $id-ext]][hl7:name])[1]/hl7:name"
+                                        />
                                     </xsl:call-template>
                                 </xsl:when>
-                                <xsl:when test="string-length($id-ext) = 0 and (ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root]][hl7:name])[1]/hl7:name">
+                                <xsl:when
+                                    test="string-length($id-ext) = 0 and (ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root]][hl7:name])[1]/hl7:name">
                                     <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root]][hl7:name])[1]/hl7:name"/>
+                                        <xsl:with-param name="in"
+                                            select="(ancestor::hl7:ClinicalDocument//*[hl7:id[@root = $id-root]][hl7:name])[1]/hl7:name"
+                                        />
                                     </xsl:call-template>
                                 </xsl:when>
                                 <xsl:otherwise>
+                                    <xsl:text>(</xsl:text>
                                     <xsl:call-template name="show-id-set">
-                                        <xsl:with-param name="in" select="hl7:representedOrganization/hl7:id"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:representedOrganization/hl7:id"/>
                                     </xsl:call-template>
+                                    <xsl:text>)</xsl:text>
                                 </xsl:otherwise>
                             </xsl:choose>
+                            <xsl:text>)</xsl:text>
                         </td>
-                        <xsl:if test="hl7:addr | hl7:telecom">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if test="hl7:addr | hl7:telecom">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if test="hl7:addr | hl7:telecom">
                                 <xsl:call-template name="show-contactInfo">
                                     <xsl:with-param name="contact" select="."/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
-                    <xsl:if test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
+                    <xsl:if
+                        test="hl7:representedOrganization/hl7:addr | hl7:representedOrganization/hl7:telecom">
                         <tr>
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
@@ -3213,7 +3590,8 @@
                             </td>
                             <td>
                                 <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="hl7:representedOrganization"/>
+                                    <xsl:with-param name="contact"
+                                        select="hl7:representedOrganization"/>
                                 </xsl:call-template>
                             </td>
                         </tr>
@@ -3222,7 +3600,7 @@
             </table>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header authenticator</xd:p>
@@ -3239,16 +3617,22 @@
                             </xsl:call-template>
                         </td>
                         <td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:attribute name="style">width: 30%;</xsl:attribute>
                             </xsl:if>
-                            <xsl:call-template name="show-assignedEntity">
-                                <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
-                            </xsl:call-template>
-                            <xsl:text> </xsl:text>
-                            <xsl:call-template name="show-code-set">
-                                <xsl:with-param name="in" select="hl7:signatureCode"/>
-                            </xsl:call-template>
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:assignedPerson/hl7:name | hl7:representedOrganization | hl7:id">
+                                <xsl:call-template name="show-assignedEntity">
+                                    <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
+                                </xsl:call-template>
+                                <xsl:text> </xsl:text>
+                            </xsl:if>
+                            <xsl:if test="hl7:signatureCode">
+                                <xsl:call-template name="show-code-set">
+                                    <xsl:with-param name="in" select="hl7:signatureCode"/>
+                                </xsl:call-template>
+                            </xsl:if>
                             <xsl:if test="hl7:time/@value">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="pre" select="'&#160;'"/>
@@ -3260,21 +3644,26 @@
                                 </xsl:call-template>
                             </xsl:if>
                             <xsl:call-template name="show-signatureText">
-                                <xsl:with-param name="in" select="*[local-name() = 'signatureText']"/>
+                                <xsl:with-param name="in" select="*[local-name() = 'signatureText']"
+                                />
                             </xsl:call-template>
                         </td>
-                        <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="show-contactInfo">
                                     <xsl:with-param name="contact" select="hl7:assignedEntity"/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
                 </tbody>
             </table>
@@ -3297,16 +3686,22 @@
                             </xsl:call-template>
                         </td>
                         <td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:attribute name="style">width: 30%;</xsl:attribute>
                             </xsl:if>
-                            <xsl:call-template name="show-assignedEntity">
-                                <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
-                            </xsl:call-template>
-                            <xsl:text> </xsl:text>
-                            <xsl:call-template name="show-code-set">
-                                <xsl:with-param name="in" select="hl7:signatureCode"/>
-                            </xsl:call-template>
+                            <xsl:if
+                                test="hl7:assignedPerson/hl7:name | hl7:representedOrganization | hl7:id">
+                                <xsl:call-template name="show-assignedEntity">
+                                    <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
+                                </xsl:call-template>
+                                <xsl:text> </xsl:text>
+                            </xsl:if>
+                            <xsl:if test="hl7:signatureCode">
+                                <xsl:call-template name="show-code-set">
+                                    <xsl:with-param name="in" select="hl7:signatureCode"/>
+                                </xsl:call-template>
+                            </xsl:if>
                             <xsl:if test="hl7:time/@value">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="pre" select="'&#160;'"/>
@@ -3318,27 +3713,32 @@
                                 </xsl:call-template>
                             </xsl:if>
                             <xsl:call-template name="show-signatureText">
-                                <xsl:with-param name="in" select="*[local-name() = 'signatureText']"/>
+                                <xsl:with-param name="in" select="*[local-name() = 'signatureText']"
+                                />
                             </xsl:call-template>
                         </td>
-                        <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="show-contactInfo">
                                     <xsl:with-param name="contact" select="hl7:assignedEntity"/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
                 </tbody>
             </table>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header dataEnterer</xd:p>
@@ -3355,31 +3755,39 @@
                             </xsl:call-template>
                         </td>
                         <td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:dataEnterer/hl7:assignedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:dataEnterer/hl7:assignedEntity/hl7:telecom">
                                 <xsl:attribute name="style">width: 30%;</xsl:attribute>
                             </xsl:if>
-                            <xsl:call-template name="show-assignedEntity">
-                                <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
-                            </xsl:call-template>
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:assignedPerson/hl7:name | hl7:assignedEntity/hl7:representedOrganization | hl7:assignedEntity/hl7:id">
+                                <xsl:call-template name="show-assignedEntity">
+                                    <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
+                                </xsl:call-template>
+                            </xsl:if>
                         </td>
-                        <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:dataEnterer/hl7:assignedEntity/hl7:telecom">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:dataEnterer/hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:dataEnterer/hl7:assignedEntity/hl7:telecom">
                                 <xsl:call-template name="show-contactInfo">
                                     <xsl:with-param name="contact" select="hl7:assignedEntity"/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
                 </tbody>
             </table>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header componentOf</xd:p>
@@ -3406,28 +3814,30 @@
                             </xsl:choose>
                             <table class="table_simple">
                                 <tbody>
-                                    <tr>
-                                        <td class="td_label">
-                                            <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'id'"/>
-                                            </xsl:call-template>
-                                        </td>
-                                        <td>
-                                            <xsl:call-template name="show-id-set">
-                                                <xsl:with-param name="in" select="hl7:id"/>
-                                            </xsl:call-template>
-                                        </td>
-                                    </tr>
+                                    <xsl:if test="hl7:id">
+                                        <tr>
+                                            <td class="td_label">
+                                                <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key" select="'id'"/>
+                                                </xsl:call-template>
+                                            </td>
+                                            <td>
+                                                <xsl:call-template name="show-id-set">
+                                                  <xsl:with-param name="in" select="hl7:id"/>
+                                                </xsl:call-template>
+                                            </td>
+                                        </tr>
+                                    </xsl:if>
                                     <xsl:if test="hl7:code">
                                         <tr>
                                             <td class="td_label">
                                                 <xsl:call-template name="getLocalizedString">
-                                                    <xsl:with-param name="key" select="'type'"/>
+                                                  <xsl:with-param name="key" select="'type'"/>
                                                 </xsl:call-template>
                                             </td>
                                             <td>
                                                 <xsl:call-template name="show-code-set">
-                                                    <xsl:with-param name="in" select="hl7:code"/>
+                                                  <xsl:with-param name="in" select="hl7:code"/>
                                                 </xsl:call-template>
                                             </td>
                                         </tr>
@@ -3435,53 +3845,64 @@
                                 </tbody>
                             </table>
                         </td>
-                        <xsl:if test="hl7:effectiveTime">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if test="hl7:effectiveTime">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Encounter Date'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if test="hl7:effectiveTime">
                                 <xsl:call-template name="show-ivlts">
                                     <xsl:with-param name="in" select="hl7:effectiveTime"/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
-                    <xsl:if test="hl7:dischargeDispositionCode | sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode">
+                    <xsl:if
+                        test="hl7:dischargeDispositionCode | sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode">
                         <tr>
                             <xsl:choose>
-                                <xsl:when test="sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode">
+                                <xsl:when
+                                    test="sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode">
                                     <td class="td_label td_label_width">
                                         <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'Encounter Admission Referral Source'"/>
+                                            <xsl:with-param name="key"
+                                                select="'Encounter Admission Referral Source'"/>
                                         </xsl:call-template>
                                     </td>
                                     <td style="width: 30%;">
                                         <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode"/>
+                                            <xsl:with-param name="in"
+                                                select="sdtc:admissionReferralSourceCode | hl7:admissionReferralSourceCode"
+                                            />
                                         </xsl:call-template>
                                     </td>
                                     <td class="td_label td_label_width">
                                         <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'Encounter Discharge Disposition'"/>
+                                            <xsl:with-param name="key"
+                                                select="'Encounter Discharge Disposition'"/>
                                         </xsl:call-template>
                                     </td>
                                     <td style="width: 30%;">
                                         <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:dischargeDispositionCode"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:dischargeDispositionCode"/>
                                         </xsl:call-template>
                                     </td>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <td class="td_label td_label_width">
                                         <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'Encounter Discharge Disposition'"/>
+                                            <xsl:with-param name="key"
+                                                select="'Encounter Discharge Disposition'"/>
                                         </xsl:call-template>
                                     </td>
                                     <td colspan="3">
                                         <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:dischargeDispositionCode"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:dischargeDispositionCode"/>
                                         </xsl:call-template>
                                     </td>
                                 </xsl:otherwise>
@@ -3499,14 +3920,19 @@
                                 <xsl:choose>
                                     <!-- FIXME: playingPlace is CDAr3 May Ballot specific. This is unlikely to remain this way -->
                                     <!-- FIXME: scopingOrganization is CDAr3 May Ballot specific. This is unlikely to remain this way -->
-                                    <xsl:when test="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:name">
+                                    <xsl:when
+                                        test="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:name">
                                         <xsl:call-template name="show-name-set">
-                                            <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:name"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:name"
+                                            />
                                         </xsl:call-template>
-                                        <xsl:if test="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:addr">
+                                        <xsl:if
+                                            test="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:addr">
                                             <xsl:text> (</xsl:text>
                                             <xsl:call-template name="show-address-set">
-                                                <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:addr"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:location/hl7:healthCareFacility/hl7:*[local-name() = 'location' or local-name() = 'playingPlace']/hl7:addr"/>
                                                 <xsl:with-param name="sep" select="', '"/>
                                             </xsl:call-template>
                                             <xsl:text>)</xsl:text>
@@ -3520,13 +3946,17 @@
                                                 <xsl:with-param name="post" select="'&#160;'"/>
                                             </xsl:call-template>
                                             <xsl:call-template name="show-name-set">
-                                                <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:serviceProviderOrganization/hl7:name"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:location/hl7:healthCareFacility/hl7:serviceProviderOrganization/hl7:name"
+                                                />
                                             </xsl:call-template>
                                         </xsl:for-each>
                                     </xsl:when>
                                     <xsl:when test="hl7:location/hl7:healthCareFacility/hl7:code">
                                         <xsl:call-template name="show-code-set">
-                                            <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:code"/>
+                                            <xsl:with-param name="in"
+                                                select="hl7:location/hl7:healthCareFacility/hl7:code"
+                                            />
                                         </xsl:call-template>
                                     </xsl:when>
                                     <xsl:otherwise>
@@ -3536,7 +3966,9 @@
                                                 <xsl:with-param name="post" select="':'"/>
                                             </xsl:call-template>
                                             <xsl:call-template name="show-id-set">
-                                                <xsl:with-param name="in" select="hl7:location/hl7:healthCareFacility/hl7:id"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:location/hl7:healthCareFacility/hl7:id"
+                                                />
                                             </xsl:call-template>
                                         </xsl:if>
                                     </xsl:otherwise>
@@ -3553,7 +3985,8 @@
                             </td>
                             <td>
                                 <xsl:choose>
-                                    <xsl:when test="hl7:responsibleParty/hl7:assignedEntity/hl7:addr | hl7:responsibleParty/hl7:assignedEntity/hl7:telecom">
+                                    <xsl:when
+                                        test="hl7:responsibleParty/hl7:assignedEntity/hl7:addr | hl7:responsibleParty/hl7:assignedEntity/hl7:telecom">
                                         <xsl:attribute name="style">width: 30%;</xsl:attribute>
                                     </xsl:when>
                                     <xsl:otherwise>
@@ -3561,10 +3994,12 @@
                                     </xsl:otherwise>
                                 </xsl:choose>
                                 <xsl:call-template name="show-assignedEntity">
-                                    <xsl:with-param name="asgnEntity" select="hl7:responsibleParty/hl7:assignedEntity"/>
+                                    <xsl:with-param name="asgnEntity"
+                                        select="hl7:responsibleParty/hl7:assignedEntity"/>
                                 </xsl:call-template>
                             </td>
-                            <xsl:if test="hl7:responsibleParty/hl7:assignedEntity/hl7:addr | hl7:responsibleParty/hl7:assignedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:responsibleParty/hl7:assignedEntity/hl7:addr | hl7:responsibleParty/hl7:assignedEntity/hl7:telecom">
                                 <td class="td_label td_label_width">
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Contact_details'"/>
@@ -3572,7 +4007,8 @@
                                 </td>
                                 <td>
                                     <xsl:call-template name="show-contactInfo">
-                                        <xsl:with-param name="contact" select="hl7:responsibleParty/hl7:assignedEntity"/>
+                                        <xsl:with-param name="contact"
+                                            select="hl7:responsibleParty/hl7:assignedEntity"/>
                                     </xsl:call-template>
                                 </td>
                             </xsl:if>
@@ -3594,7 +4030,8 @@
                             </td>
                             <td>
                                 <xsl:choose>
-                                    <xsl:when test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                                    <xsl:when
+                                        test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                         <xsl:attribute name="style">width: 30%;</xsl:attribute>
                                     </xsl:when>
                                     <xsl:otherwise>
@@ -3605,7 +4042,8 @@
                                     <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
                                 </xsl:call-template>
                             </td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <td class="td_label td_label_width">
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Contact_details'"/>
@@ -3623,7 +4061,7 @@
             </table>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header custodian</xd:p>
@@ -3631,48 +4069,59 @@
     </xd:doc>
     <xsl:template name="custodian">
         <xsl:for-each select="hl7:custodian">
-            <table class="header_table">
-                <tbody>
-                    <tr>
-                        <td class="td_label td_label_width">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'custodian'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td>
-                            <xsl:if test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:addr | hl7:custodian/hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:telecom">
-                                <xsl:attribute name="style">width: 30%;</xsl:attribute>
-                            </xsl:if>
-                            <xsl:choose>
-                                <xsl:when test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:name">
-                                    <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:name"/>
-                                        <xsl:with-param name="sep" select="'br'"/>
-                                    </xsl:call-template>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:call-template name="show-id-set">
-                                        <xsl:with-param name="in" select="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:id"/>
-                                        <xsl:with-param name="sep" select="'br'"/>
-                                    </xsl:call-template>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </td>
-                        <xsl:if test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:addr | hl7:custodian/hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:telecom">
+            <xsl:if test="
+                    hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:addr | hl7:custodian/hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:telecom |
+                    hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:name">
+                <table class="header_table">
+                    <tbody>
+                        <tr>
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'Contact_details'"/>
+                                    <xsl:with-param name="key" select="'custodian'"/>
                                 </xsl:call-template>
                             </td>
                             <td>
-                                <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="hl7:assignedCustodian/hl7:representedCustodianOrganization"/>
-                                </xsl:call-template>
+                                <xsl:if
+                                    test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:addr | hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:telecom">
+                                    <xsl:attribute name="style">width: 30%;</xsl:attribute>
+                                </xsl:if>
+                                <xsl:choose>
+                                    <xsl:when
+                                        test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:name">
+                                        <xsl:call-template name="show-name-set">
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:name"/>
+                                            <xsl:with-param name="sep" select="'br'"/>
+                                        </xsl:call-template>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:call-template name="show-id-set">
+                                            <xsl:with-param name="in"
+                                                select="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:id"/>
+                                            <xsl:with-param name="sep" select="'br'"/>
+                                        </xsl:call-template>
+                                    </xsl:otherwise>
+                                </xsl:choose>
                             </td>
-                        </xsl:if>
-                    </tr>
-                </tbody>
-            </table>
+                            <xsl:if
+                                test="hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:addr | hl7:assignedCustodian/hl7:representedCustodianOrganization/hl7:telecom">
+                                <td class="td_label td_label_width">
+                                    <xsl:call-template name="getLocalizedString">
+                                        <xsl:with-param name="key" select="'Contact_details'"/>
+                                    </xsl:call-template>
+                                </td>
+                                <td>
+                                    <xsl:call-template name="show-contactInfo">
+                                        <xsl:with-param name="contact"
+                                            select="hl7:assignedCustodian/hl7:representedCustodianOrganization"
+                                        />
+                                    </xsl:call-template>
+                                </td>
+                            </xsl:if>
+                        </tr>
+                    </tbody>
+                </table>
+            </xsl:if>
         </xsl:for-each>
     </xsl:template>
 
@@ -3685,11 +4134,12 @@
         <xsl:for-each select="hl7:documentationOf">
             <table class="header_table">
                 <tbody>
-                    <xsl:if test="hl7:serviceEvent[@classCode | hl7:code]">
+                    <xsl:if test="hl7:serviceEvent[@classCode | hl7:code | hl7:effectiveTime]">
                         <xsl:variable name="displayName">
                             <xsl:if test="hl7:serviceEvent/@classCode[not(. = 'ACT')]">
                                 <xsl:call-template name="show-actClassCode">
-                                    <xsl:with-param name="clsCode" select="hl7:serviceEvent/@classCode"/>
+                                    <xsl:with-param name="clsCode"
+                                        select="hl7:serviceEvent/@classCode"/>
                                 </xsl:call-template>
                             </xsl:if>
                         </xsl:variable>
@@ -3704,15 +4154,24 @@
                                 </xsl:if>
                             </td>
                             <td style="width: 80%;" colspan="3">
-                                <xsl:call-template name="show-code">
-                                    <xsl:with-param name="in" select="hl7:serviceEvent/hl7:code"/>
-                                </xsl:call-template>
-                                <xsl:call-template name="show-ivlts">
-                                    <xsl:with-param name="in" select="hl7:serviceEvent/hl7:effectiveTime"/>
-                                </xsl:call-template>
-                                <xsl:call-template name="show-code">
-                                    <xsl:with-param name="in" select="hl7:serviceEvent/hl7:statusCode"/>
-                                </xsl:call-template>
+                                <xsl:if test="hl7:serviceEvent/hl7:code">
+                                    <xsl:call-template name="show-code">
+                                        <xsl:with-param name="in" select="hl7:serviceEvent/hl7:code"
+                                        />
+                                    </xsl:call-template>
+                                </xsl:if>
+                                <xsl:if test="hl7:serviceEvent/hl7:effectiveTime">
+                                    <xsl:call-template name="show-ivlts">
+                                        <xsl:with-param name="in"
+                                            select="hl7:serviceEvent/hl7:effectiveTime"/>
+                                    </xsl:call-template>
+                                </xsl:if>
+                                <xsl:if test="hl7:serviceEvent/hl7:statusCode">
+                                    <xsl:call-template name="show-code">
+                                        <xsl:with-param name="in"
+                                            select="hl7:serviceEvent/hl7:statusCode"/>
+                                    </xsl:call-template>
+                                </xsl:if>
                             </td>
                         </tr>
                     </xsl:if>
@@ -3721,45 +4180,54 @@
                             <xsl:call-template name="show-participationType">
                                 <xsl:with-param name="ptype" select="@typeCode"/>
                             </xsl:call-template>
-                            <xsl:text> - </xsl:text>
                             <xsl:if test="hl7:functionCode//@code">
+                                <xsl:text> - </xsl:text>
                                 <xsl:call-template name="show-code-set">
                                     <xsl:with-param name="in" select="hl7:functionCode"/>
                                 </xsl:call-template>
                             </xsl:if>
                         </xsl:variable>
-                        <tr>
-                            <td class="td_label td_label_width">
-                                <xsl:call-template name="firstCharCaseUp">
-                                    <xsl:with-param name="data" select="$displayName"/>
-                                </xsl:call-template>
-                            </td>
-                            <td>
-                                <xsl:choose>
-                                    <xsl:when test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
-                                        <xsl:attribute name="style">width: 30%;</xsl:attribute>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:attribute name="colspan">3</xsl:attribute>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                                <xsl:call-template name="show-assignedEntity">
-                                    <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
-                                </xsl:call-template>
-                            </td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                        <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                            <tr>
                                 <td class="td_label td_label_width">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'Contact_details'"/>
+                                    <xsl:call-template name="firstCharCaseUp">
+                                        <xsl:with-param name="data" select="$displayName"/>
                                     </xsl:call-template>
                                 </td>
                                 <td>
-                                    <xsl:call-template name="show-contactInfo">
-                                        <xsl:with-param name="contact" select="hl7:assignedEntity"/>
+                                    <xsl:choose>
+                                        <xsl:when
+                                            test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                                            <xsl:attribute name="style">width: 30%;</xsl:attribute>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:attribute name="colspan">3</xsl:attribute>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                    <xsl:call-template name="show-assignedEntity">
+                                        <xsl:with-param name="asgnEntity"
+                                            select="hl7:assignedEntity"/>
                                     </xsl:call-template>
                                 </td>
-                            </xsl:if>
-                        </tr>
+                                <td class="td_label td_label_width">
+                                    <xsl:if
+                                        test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'Contact_details'"/>
+                                        </xsl:call-template>
+                                    </xsl:if>
+                                </td>
+                                <td>
+                                    <xsl:if
+                                        test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                                        <xsl:call-template name="show-contactInfo">
+                                            <xsl:with-param name="contact"
+                                                select="hl7:assignedEntity"/>
+                                        </xsl:call-template>
+                                    </xsl:if>
+                                </td>
+                            </tr>
+                        </xsl:if>
                     </xsl:for-each>
                 </tbody>
             </table>
@@ -3821,27 +4289,33 @@
                 <tbody>
                     <tr>
                         <td class="td_label td_label_width">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'typeCode-INF'"/>
-                            </xsl:call-template>
+                            <xsl:if test="hl7:assignedEntity | hl7:relatedEntity">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'typeCode-INF'"/>
+                                </xsl:call-template>
+                            </xsl:if>
                         </td>
                         <td>
-                            <xsl:if test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom | hl7:relatedEntity/hl7:addr | hl7:relatedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom | hl7:relatedEntity/hl7:addr | hl7:relatedEntity/hl7:telecom">
                                 <xsl:attribute name="style">width: 30%;</xsl:attribute>
                             </xsl:if>
-                            <xsl:if test="hl7:assignedEntity">
+                            <xsl:if
+                                test="hl7:assignedEntity/hl7:assignedPerson/hl7:name | hl7:assignedEntity/hl7:representedOrganization | hl7:assignedEntity/hl7:id">
                                 <xsl:call-template name="show-assignedEntity">
                                     <xsl:with-param name="asgnEntity" select="hl7:assignedEntity"/>
                                 </xsl:call-template>
                             </xsl:if>
-                            <xsl:if test="hl7:relatedEntity">
+                            <xsl:if test="hl7:relatedEntity/hl7:relatedPerson/hl7:name">
                                 <xsl:call-template name="show-relatedEntity">
-                                    <xsl:with-param name="relatedEntity" select="hl7:relatedEntity"/>
+                                    <xsl:with-param name="relatedEntity" select="hl7:relatedEntity"
+                                    />
                                 </xsl:call-template>
                             </xsl:if>
                         </td>
                         <xsl:choose>
-                            <xsl:when test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
+                            <xsl:when
+                                test="hl7:assignedEntity/hl7:addr | hl7:assignedEntity/hl7:telecom">
                                 <td class="td_label td_label_width">
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Contact_details'"/>
@@ -3850,12 +4324,14 @@
                                 <td>
                                     <xsl:if test="hl7:assignedEntity">
                                         <xsl:call-template name="show-contactInfo">
-                                            <xsl:with-param name="contact" select="hl7:assignedEntity"/>
+                                            <xsl:with-param name="contact"
+                                                select="hl7:assignedEntity"/>
                                         </xsl:call-template>
                                     </xsl:if>
                                 </td>
                             </xsl:when>
-                            <xsl:when test="hl7:relatedEntity/hl7:addr | hl7:relatedEntity/hl7:telecom">
+                            <xsl:when
+                                test="hl7:relatedEntity/hl7:addr | hl7:relatedEntity/hl7:telecom">
                                 <td class="td_label td_label_width">
                                     <xsl:call-template name="getLocalizedString">
                                         <xsl:with-param name="key" select="'Contact_details'"/>
@@ -3864,7 +4340,8 @@
                                 <td>
                                     <xsl:if test="hl7:relatedEntity">
                                         <xsl:call-template name="show-contactInfo">
-                                            <xsl:with-param name="contact" select="hl7:relatedEntity"/>
+                                            <xsl:with-param name="contact"
+                                                select="hl7:relatedEntity"/>
                                         </xsl:call-template>
                                     </xsl:if>
                                 </td>
@@ -3893,7 +4370,8 @@
                         </td>
                         <td>
                             <xsl:choose>
-                                <xsl:when test="hl7:intendedRecipient/hl7:addr | hl7:intendedRecipient/hl7:telecom">
+                                <xsl:when
+                                    test="hl7:intendedRecipient/hl7:addr | hl7:intendedRecipient/hl7:telecom">
                                     <xsl:attribute name="style">width: 30%;</xsl:attribute>
                                 </xsl:when>
                                 <xsl:otherwise>
@@ -3901,8 +4379,10 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                             <xsl:choose>
-                                <xsl:when test="hl7:intendedRecipient/hl7:informationRecipient/hl7:name">
-                                    <xsl:for-each select="hl7:intendedRecipient/hl7:informationRecipient">
+                                <xsl:when
+                                    test="hl7:intendedRecipient/hl7:informationRecipient/hl7:name">
+                                    <xsl:for-each
+                                        select="hl7:intendedRecipient/hl7:informationRecipient">
                                         <xsl:call-template name="show-name-set">
                                             <xsl:with-param name="in" select="hl7:name"/>
                                             <xsl:with-param name="sep" select="'br'"/>
@@ -3920,75 +4400,86 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                         </td>
-                        <xsl:if test="hl7:intendedRecipient/hl7:addr | hl7:intendedRecipient/hl7:telecom">
-                            <td class="td_label td_label_width">
+                        <td class="td_label td_label_width">
+                            <xsl:if
+                                test="hl7:intendedRecipient/hl7:addr | hl7:intendedRecipient/hl7:telecom">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
                                 </xsl:call-template>
-                            </td>
-                            <td>
+                            </xsl:if>
+                        </td>
+                        <td>
+                            <xsl:if
+                                test="hl7:intendedRecipient/hl7:addr | hl7:intendedRecipient/hl7:telecom">
                                 <xsl:call-template name="show-contactInfo">
                                     <xsl:with-param name="contact" select="hl7:intendedRecipient"/>
                                 </xsl:call-template>
-                            </td>
-                        </xsl:if>
+                            </xsl:if>
+                        </td>
                     </tr>
                     <xsl:for-each select="hl7:intendedRecipient/hl7:receivedOrganization">
-                        <tr>
-                            <td class="td_label td_label_width">
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="pre" select="''"/>
-                                    <xsl:with-param name="key" select="'Organization'"/>
-                                    <xsl:with-param name="post" select="''"/>
-                                </xsl:call-template>
-                            </td>
-                            <td style="width: 30%;">
-                                <div>
-                                    <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:name"/>
+                        <xsl:if test="hl7:name | hl7:id | hl7:addr | hl7:telecom">
+                            <tr>
+                                <td class="td_label td_label_width">
+                                    <xsl:call-template name="getLocalizedString">
+                                        <xsl:with-param name="pre" select="''"/>
+                                        <xsl:with-param name="key" select="'Organization'"/>
+                                        <xsl:with-param name="post" select="''"/>
                                     </xsl:call-template>
-                                </div>
-                                <xsl:if test="hl7:id">
-                                    <table class="table_simple">
-                                        <tbody>
-                                            <tr>
-                                                <td class="td_label">
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="key" select="'id'"/>
-                                                    </xsl:call-template>
-                                                </td>
-                                                <td>
-                                                    <xsl:call-template name="show-id-set">
-                                                        <xsl:with-param name="in" select="hl7:id"/>
-                                                    </xsl:call-template>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </xsl:if>
-                            </td>
-                            <td class="td_label td_label_width">
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'Contact_details'"/>
-                                </xsl:call-template>
-                                <xsl:text> (</xsl:text>
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'organization'"/>
-                                </xsl:call-template>
-                                <xsl:text>)</xsl:text>
-                            </td>
-                            <td style="width: 30%;">
-                                <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="."/>
-                                </xsl:call-template>
-                            </td>
-                        </tr>
+                                </td>
+                                <td style="width: 30%;">
+                                    <xsl:if test="hl7:name">
+                                        <div>
+                                            <xsl:call-template name="show-name-set">
+                                                <xsl:with-param name="in" select="hl7:name"/>
+                                            </xsl:call-template>
+                                        </div>
+                                    </xsl:if>
+                                    <xsl:if test="hl7:id">
+                                        <table class="table_simple">
+                                            <tbody>
+                                                <tr>
+                                                  <td class="td_label">
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key" select="'id'"/>
+                                                  </xsl:call-template>
+                                                  </td>
+                                                  <td>
+                                                  <xsl:call-template name="show-id-set">
+                                                  <xsl:with-param name="in" select="hl7:id"/>
+                                                  </xsl:call-template>
+                                                  </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </xsl:if>
+                                </td>
+                                <td class="td_label td_label_width">
+                                    <xsl:if test="hl7:addr | hl7:telecom">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'Contact_details'"/>
+                                        </xsl:call-template>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'organization'"/>
+                                        </xsl:call-template>
+                                        <xsl:text>)</xsl:text>
+                                    </xsl:if>
+                                </td>
+                                <td style="width: 30%;">
+                                    <xsl:if test="hl7:addr | hl7:telecom">
+                                        <xsl:call-template name="show-contactInfo">
+                                            <xsl:with-param name="contact" select="."/>
+                                        </xsl:call-template>
+                                    </xsl:if>
+                                </td>
+                            </tr>
+                        </xsl:if>
                     </xsl:for-each>
                 </tbody>
             </table>
         </xsl:for-each>
     </xsl:template>
-
     <xd:doc>
         <xd:desc>
             <xd:p>Handle CDA Header participant</xd:p>
@@ -4003,8 +4494,10 @@
                             <xsl:variable name="participtRole">
                                 <xsl:call-template name="show-participationTypeOrCode">
                                     <xsl:with-param name="typeCode" select="@typeCode"/>
-                                    <xsl:with-param name="classCode" select="hl7:associatedEntity/@classCode"/>
-                                    <xsl:with-param name="code" select="hl7:associatedEntity/hl7:code"/>
+                                    <xsl:with-param name="classCode"
+                                        select="hl7:associatedEntity/@classCode"/>
+                                    <xsl:with-param name="code"
+                                        select="hl7:associatedEntity/hl7:code"/>
                                 </xsl:call-template>
                             </xsl:variable>
                             <xsl:choose>
@@ -4021,7 +4514,8 @@
                             </xsl:choose>
                         </td>
                         <td>
-                            <xsl:if test="hl7:associatedEntity/hl7:addr | hl7:associatedEntity/hl7:telecom">
+                            <xsl:if
+                                test="hl7:associatedEntity/hl7:addr | hl7:associatedEntity/hl7:telecom">
                                 <xsl:attribute name="style">width: 30%;</xsl:attribute>
                             </xsl:if>
                             <xsl:if test="hl7:functionCode">
@@ -4030,6 +4524,9 @@
                                 </xsl:call-template>
                                 <xsl:text>, </xsl:text>
                             </xsl:if>
+                            <xsl:if test="not(hl7:functionCode[@nullFlavor])">
+                                <br/>
+                            </xsl:if>
                             <xsl:call-template name="show-associatedEntity">
                                 <xsl:with-param name="assoEntity" select="hl7:associatedEntity"/>
                             </xsl:call-template>
@@ -4037,7 +4534,8 @@
                                 <xsl:with-param name="in" select="hl7:time"/>
                             </xsl:call-template>
                         </td>
-                        <xsl:if test="hl7:associatedEntity/hl7:addr | hl7:associatedEntity/hl7:telecom">
+                        <xsl:if
+                            test="hl7:associatedEntity/hl7:addr | hl7:associatedEntity/hl7:telecom">
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'Contact_details'"/>
@@ -4077,23 +4575,27 @@
                                 <xsl:with-param name="in" select="hl7:patient/hl7:name"/>
                             </xsl:call-template>
                         </td>
-                        <td class="td_label td_label_width">
-                            <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="'Contact_details'"/>
-                            </xsl:call-template>
-                        </td>
-                        <td style="width: 30%;">
-                            <xsl:call-template name="show-contactInfo">
-                                <xsl:with-param name="contact" select="."/>
-                            </xsl:call-template>
-                        </td>
+                        <xsl:if test="hl7:addr | hl7:telecom">
+                            <td class="td_label td_label_width">
+                                <xsl:call-template name="getLocalizedString">
+                                    <xsl:with-param name="key" select="'Contact_details'"/>
+                                </xsl:call-template>
+                            </td>
+                            <td style="width: 30%;">
+                                <xsl:call-template name="show-contactInfo">
+                                    <xsl:with-param name="contact" select="."/>
+                                </xsl:call-template>
+                            </td>
+                        </xsl:if>
                     </tr>
                     <tr>
                         <td class="td_label td_label_width">
                             <xsl:choose>
-                                <xsl:when test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
+                                <xsl:when
+                                    test="hl7:patient/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | hl7:patient/*[local-name() = 'deceasedTime']">
                                     <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'birthTimeLongDeceased'"/>
+                                        <xsl:with-param name="key" select="'birthTimeLongDeceased'"
+                                        />
                                     </xsl:call-template>
                                 </xsl:when>
                                 <xsl:otherwise>
@@ -4106,7 +4608,9 @@
                         <td style="width: 30%;">
                             <xsl:call-template name="show-birthDeathTime-multipleBirth">
                                 <xsl:with-param name="in" select="hl7:patient"/>
-                                <xsl:with-param name="clinicalDocumentEffectiveTime" select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"/>
+                                <xsl:with-param name="clinicalDocumentEffectiveTime"
+                                    select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"
+                                />
                             </xsl:call-template>
                         </td>
                         <td class="td_label td_label_width">
@@ -4116,12 +4620,14 @@
                         </td>
                         <td>
                             <xsl:call-template name="show-code-set">
-                                <xsl:with-param name="in" select="hl7:patient/hl7:administrativeGenderCode"/>
+                                <xsl:with-param name="in"
+                                    select="hl7:patient/hl7:administrativeGenderCode"/>
                             </xsl:call-template>
                         </td>
                     </tr>
-                    <xsl:if test="hl7:patient/hl7:raceCode | hl7:patient/hl7:ethnicGroupCode |
-                                  hl7:patient/sdtc:raceCode | hl7:patient/sdtc:ethnicGroupCode">
+                    <xsl:if test="
+                            hl7:patient/hl7:raceCode | hl7:patient/hl7:ethnicGroupCode |
+                            hl7:patient/sdtc:raceCode | hl7:patient/sdtc:ethnicGroupCode">
                         <tr>
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
@@ -4130,7 +4636,9 @@
                             </td>
                             <td style="width: 30%;">
                                 <xsl:call-template name="show-code-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:raceCode | hl7:patient/sdtc:raceCode"/>
+                                    <xsl:with-param name="in"
+                                        select="hl7:patient/hl7:raceCode | hl7:patient/sdtc:raceCode"
+                                    />
                                 </xsl:call-template>
                             </td>
                             <td class="td_label td_label_width">
@@ -4140,7 +4648,9 @@
                             </td>
                             <td>
                                 <xsl:call-template name="show-code-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:ethnicGroupCode | hl7:patient/sdtc:ethnicGroupCode"/>
+                                    <xsl:with-param name="in"
+                                        select="hl7:patient/hl7:ethnicGroupCode | hl7:patient/sdtc:ethnicGroupCode"
+                                    />
                                 </xsl:call-template>
                             </td>
                         </tr>
@@ -4156,11 +4666,13 @@
                                 <xsl:attribute name="colspan">3</xsl:attribute>
                             </xsl:if>
                             <xsl:call-template name="show-id-set">
-                                <xsl:with-param name="in" select="hl7:id[not(contains($skip-ids-var, concat(',',@root,',')))]"/>
+                                <xsl:with-param name="in"
+                                    select="hl7:id[not(contains($skip-ids-var, concat(',', @root, ',')))]"/>
                                 <xsl:with-param name="sep" select="'br'"/>
                             </xsl:call-template>
                         </td>
-                        <xsl:if test="hl7:patient/hl7:languageCommunication">
+                        <xsl:if
+                            test="hl7:patient/hl7:languageCommunication/hl7:languageCode/@code | hl7:modeCode | hl7:proficiencyLevelCode | hl7:preferenceInd">
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
                                     <xsl:with-param name="key" select="'languageCommunication'"/>
@@ -4180,18 +4692,21 @@
                                         <xsl:if test="hl7:proficiencyLevelCode">
                                             <xsl:text>, </xsl:text>
                                             <xsl:call-template name="show-code-set">
-                                                <xsl:with-param name="in" select="hl7:proficiencyLevelCode"/>
+                                                <xsl:with-param name="in"
+                                                  select="hl7:proficiencyLevelCode"/>
                                                 <xsl:with-param name="sep" select="' '"/>
                                             </xsl:call-template>
                                         </xsl:if>
                                         <xsl:if test="hl7:preferenceInd">
                                             <xsl:text>, </xsl:text>
                                             <xsl:call-template name="getLocalizedString">
-                                                <xsl:with-param name="key" select="'preferredLanguage'"/>
+                                                <xsl:with-param name="key"
+                                                  select="'preferredLanguage'"/>
                                                 <xsl:with-param name="post" select="': '"/>
                                             </xsl:call-template>
                                             <xsl:call-template name="show-boolean">
-                                                <xsl:with-param name="in" select="hl7:preferenceInd"/>
+                                                <xsl:with-param name="in" select="hl7:preferenceInd"
+                                                />
                                             </xsl:call-template>
                                         </xsl:if>
                                     </div>
@@ -4199,7 +4714,8 @@
                             </td>
                         </xsl:if>
                     </tr>
-                    <xsl:if test="hl7:patient/hl7:guardian">
+                    <xsl:if
+                        test="hl7:patient/hl7:guardian/*/hl7:name | hl7:patient/hl7:guardian/hl7:code | hl7:patient/hl7:guardian/hl7:addr | hl7:patient/hl7:guardian/hl7:telecom">
                         <tr>
                             <td class="td_label td_label_width">
                                 <xsl:call-template name="getLocalizedString">
@@ -4208,12 +4724,14 @@
                             </td>
                             <td style="width: 30%;">
                                 <xsl:call-template name="show-name-set">
-                                    <xsl:with-param name="in" select="hl7:patient/hl7:guardian/*/hl7:name"/>
+                                    <xsl:with-param name="in"
+                                        select="hl7:patient/hl7:guardian/*/hl7:name"/>
                                 </xsl:call-template>
                                 <xsl:if test="hl7:patient/hl7:guardian/hl7:code">
                                     <xsl:text> - </xsl:text>
                                     <xsl:call-template name="show-code-set">
-                                        <xsl:with-param name="in" select="hl7:patient/hl7:guardian/hl7:code"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:patient/hl7:guardian/hl7:code"/>
                                     </xsl:call-template>
                                 </xsl:if>
                             </td>
@@ -4224,61 +4742,70 @@
                             </td>
                             <td>
                                 <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="hl7:patient/hl7:guardian"/>
+                                    <xsl:with-param name="contact" select="hl7:patient/hl7:guardian"
+                                    />
                                 </xsl:call-template>
                             </td>
                         </tr>
                     </xsl:if>
                     <xsl:for-each select="hl7:providerOrganization">
-                        <tr>
-                            <td class="td_label td_label_width">
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="pre" select="''"/>
-                                    <xsl:with-param name="key" select="'providerOrganization'"/>
-                                    <xsl:with-param name="post" select="''"/>
-                                </xsl:call-template>
-                            </td>
-                            <td style="width: 30%;">
-                                <div>
-                                    <xsl:call-template name="show-name-set">
-                                        <xsl:with-param name="in" select="hl7:name"/>
+                        <xsl:if test="hl7:name | hl7:id | hl7:addr | hl7:telecom">
+                            <tr>
+                                <td class="td_label td_label_width">
+                                    <xsl:call-template name="getLocalizedString">
+                                        <xsl:with-param name="pre" select="''"/>
+                                        <xsl:with-param name="key" select="'providerOrganization'"/>
+                                        <xsl:with-param name="post" select="''"/>
                                     </xsl:call-template>
-                                </div>
-                                <xsl:if test="hl7:id">
-                                    <table class="table_simple">
-                                        <tbody>
-                                            <tr>
-                                                <td class="td_label">
-                                                    <xsl:call-template name="getLocalizedString">
-                                                        <xsl:with-param name="key" select="'id'"/>
-                                                    </xsl:call-template>
-                                                </td>
-                                                <td>
-                                                    <xsl:call-template name="show-id-set">
-                                                        <xsl:with-param name="in" select="hl7:id"/>
-                                                    </xsl:call-template>
-                                                </td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </xsl:if>
-                            </td>
-                            <td class="td_label td_label_width">
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'Contact_details'"/>
-                                </xsl:call-template>
-                                <xsl:text> (</xsl:text>
-                                <xsl:call-template name="getLocalizedString">
-                                    <xsl:with-param name="key" select="'organization'"/>
-                                </xsl:call-template>
-                                <xsl:text>)</xsl:text>
-                            </td>
-                            <td style="width: 30%;">
-                                <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="."/>
-                                </xsl:call-template>
-                            </td>
-                        </tr>
+                                </td>
+                                <td style="width: 30%;">
+                                    <xsl:if test="hl7:name">
+                                        <div>
+                                            <xsl:call-template name="show-name-set">
+                                                <xsl:with-param name="in" select="hl7:name"/>
+                                            </xsl:call-template>
+                                        </div>
+                                    </xsl:if>
+                                    <xsl:if test="hl7:id">
+                                        <table class="table_simple">
+                                            <tbody>
+                                                <tr>
+                                                  <td class="td_label">
+                                                  <xsl:call-template name="getLocalizedString">
+                                                  <xsl:with-param name="key" select="'id'"/>
+                                                  </xsl:call-template>
+                                                  </td>
+                                                  <td>
+                                                  <xsl:call-template name="show-id-set">
+                                                  <xsl:with-param name="in" select="hl7:id"/>
+                                                  </xsl:call-template>
+                                                  </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </xsl:if>
+                                </td>
+                                <td class="td_label td_label_width">
+                                    <xsl:if test="hl7:addr | hl7:telecom">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'Contact_details'"/>
+                                        </xsl:call-template>
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'organization'"/>
+                                        </xsl:call-template>
+                                        <xsl:text>)</xsl:text>
+                                    </xsl:if>
+                                </td>
+                                <td style="width: 30%;">
+                                    <xsl:if test="hl7:addr | hl7:telecom">
+                                        <xsl:call-template name="show-contactInfo">
+                                            <xsl:with-param name="contact" select="."/>
+                                        </xsl:call-template>
+                                    </xsl:if>
+                                </td>
+                            </tr>
+                        </xsl:if>
                     </xsl:for-each>
                 </tbody>
             </table>
@@ -4293,36 +4820,24 @@
     <xsl:template name="relatedDocument">
         <xsl:for-each select="hl7:relatedDocument">
             <xsl:variable name="parentCDACode" select="ancestor::hl7:ClinicalDocument[1]/hl7:code"/>
-            <table class="header_table">
-                <tbody>
-                    <tr>
-                        <td class="td_label td_label_width">
-                            <xsl:choose>
-                                <xsl:when test="@inversionInd = 'true'">
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'relatingDocumentInverted'"/>
-                                    </xsl:call-template>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:call-template name="getLocalizedString">
-                                        <xsl:with-param name="key" select="'relatingDocument'"/>
-                                    </xsl:call-template>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            <xsl:text> (</xsl:text>
-                            <xsl:call-template name="show-actRelationship">
-                                <xsl:with-param name="ptype" select="@typeCode"/>
-                            </xsl:call-template>
-                            <xsl:text>)</xsl:text>
-                        </td>
-                        <td style="width: 80%;">
-                            <xsl:for-each select="hl7:parentDocument">
-                                <xsl:call-template name="idVersionSetId"/>
-                            </xsl:for-each>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <xsl:if test="hl7:parentDocument/hl7:id">
+                <table class="header_table">
+                    <tbody>
+                        <tr>
+                            <td class="td_label td_label_width">
+                                <xsl:call-template name="show-actRelationship">
+                                    <xsl:with-param name="ptype" select="@typeCode"/>
+                                </xsl:call-template>
+                            </td>
+                            <td style="width: 80%;">
+                                <xsl:for-each select="hl7:parentDocument">
+                                    <xsl:call-template name="idVersionSetId"/>
+                                </xsl:for-each>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </xsl:if>
         </xsl:for-each>
     </xsl:template>
 
@@ -4350,7 +4865,8 @@
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:call-template name="show-code">
-                                        <xsl:with-param name="in" select="hl7:consent/hl7:statusCode"/>
+                                        <xsl:with-param name="in"
+                                            select="hl7:consent/hl7:statusCode"/>
                                     </xsl:call-template>
                                 </xsl:otherwise>
                             </xsl:choose>
@@ -4387,18 +4903,17 @@
                     </xsl:call-template>
                     <xsl:text> </xsl:text>
                     <xsl:call-template name="show-timestamp">
-                        <xsl:with-param name="in" select="$asgnEntity/hl7:assignedPerson/hl7:birthTime"/>
+                        <xsl:with-param name="in"
+                            select="$asgnEntity/hl7:assignedPerson/hl7:birthTime"/>
                     </xsl:call-template>
                 </xsl:if>
                 <xsl:if test="$asgnEntity/hl7:representedOrganization/hl7:name">
-                    <xsl:call-template name="getLocalizedString">
-                        <xsl:with-param name="pre" select="' '"/>
-                        <xsl:with-param name="key" select="'of'"/>
-                        <xsl:with-param name="post" select="' '"/>
-                    </xsl:call-template>
+                    <xsl:text>(</xsl:text>
                     <xsl:call-template name="show-name-set">
-                        <xsl:with-param name="in" select="$asgnEntity/hl7:representedOrganization/hl7:name"/>
+                        <xsl:with-param name="in"
+                            select="$asgnEntity/hl7:representedOrganization/hl7:name"/>
                     </xsl:call-template>
+                    <xsl:text>)</xsl:text>
                 </xsl:if>
             </xsl:when>
             <xsl:when test="$asgnEntity/hl7:representedOrganization">
@@ -4438,7 +4953,8 @@
                     </xsl:call-template>
                     <xsl:text> </xsl:text>
                     <xsl:call-template name="show-timestamp">
-                        <xsl:with-param name="in" select="$relatedEntity/hl7:relatedPerson/hl7:birthTime"/>
+                        <xsl:with-param name="in"
+                            select="$relatedEntity/hl7:relatedPerson/hl7:birthTime"/>
                     </xsl:call-template>
                 </xsl:if>
             </xsl:when>
@@ -4470,12 +4986,14 @@
                 </xsl:call-template>
                 <xsl:text> </xsl:text>
                 <xsl:call-template name="show-timestamp">
-                    <xsl:with-param name="in" select="$assoEntity/hl7:assignedPerson/hl7:birthTime"/>
+                    <xsl:with-param name="in" select="$assoEntity/hl7:assignedPerson/hl7:birthTime"
+                    />
                 </xsl:call-template>
             </xsl:if>
         </xsl:if>
         <xsl:if test="$assoEntity/hl7:code">
-            <xsl:if test="$assoEntity/hl7:associatedPerson/hl7:name or $assoEntity/hl7:associatedPerson/hl7:id">
+            <xsl:if
+                test="$assoEntity/hl7:associatedPerson/hl7:name or $assoEntity/hl7:associatedPerson/hl7:id">
                 <xsl:text>, </xsl:text>
             </xsl:if>
             <xsl:call-template name="show-code-set">
@@ -4505,30 +5023,37 @@
         <xsl:choose>
             <xsl:when test="$assoEntity/hl7:scopingOrganization/hl7:name">
                 <xsl:call-template name="show-name-set">
-                    <xsl:with-param name="in" select="$assoEntity/hl7:scopingOrganization/hl7:name"/>
+                    <xsl:with-param name="in" select="$assoEntity/hl7:scopingOrganization/hl7:name"
+                    />
                 </xsl:call-template>
                 <xsl:if test="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode">
-                    <xsl:value-of select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@displayName"/>
+                    <xsl:value-of
+                        select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@displayName"/>
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="pre" select="' '"/>
                         <xsl:with-param name="key" select="'code'"/>
                         <xsl:with-param name="post" select="':'"/>
                     </xsl:call-template>
                     <xsl:call-template name="show-code-set">
-                        <xsl:with-param name="in" select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@code"/>
+                        <xsl:with-param name="in"
+                            select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@code"
+                        />
                     </xsl:call-template>
                 </xsl:if>
                 <xsl:text>, </xsl:text>
             </xsl:when>
             <xsl:when test="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode">
-                <xsl:value-of select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@displayName"/>
+                <xsl:value-of
+                    select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@displayName"/>
                 <xsl:call-template name="getLocalizedString">
                     <xsl:with-param name="pre" select="' '"/>
                     <xsl:with-param name="key" select="'code'"/>
                     <xsl:with-param name="post" select="':'"/>
                 </xsl:call-template>
                 <xsl:call-template name="show-code-set">
-                    <xsl:with-param name="in" select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@code"/>
+                    <xsl:with-param name="in"
+                        select="$assoEntity/hl7:scopingOrganization/hl7:standardIndustryClassCode/@code"
+                    />
                 </xsl:call-template>
                 <xsl:text>, </xsl:text>
             </xsl:when>
@@ -4622,27 +5147,34 @@
 
     <xd:doc>
         <xd:desc>Handle one line of birth/death/multiple birth data</xd:desc>
-        <xd:param name="in">One element with the child elements birthTime, deceasedInd, deceasedTime, multipleBirthInd, multipleBirthOrderNumber. Each of those is optional and may bein the V3 namespace or in another namespace like sdtc</xd:param>
-        <xd:param name="clinicalDocumentEffectiveTime">hl7:ClinicalDocument/hl7:effectiveTime/@value</xd:param>
+        <xd:param name="in">One element with the child elements birthTime, deceasedInd,
+            deceasedTime, multipleBirthInd, multipleBirthOrderNumber. Each of those is optional and
+            may bein the V3 namespace or in another namespace like sdtc</xd:param>
+        <xd:param name="clinicalDocumentEffectiveTime"
+            >hl7:ClinicalDocument/hl7:effectiveTime/@value</xd:param>
     </xd:doc>
     <xsl:template name="show-birthDeathTime-multipleBirth">
         <xsl:param name="in"/>
-        <xsl:param name="clinicalDocumentEffectiveTime" select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"/>
+        <xsl:param name="clinicalDocumentEffectiveTime"
+            select="ancestor-or-self::hl7:ClinicalDocument/hl7:effectiveTime/@value"/>
         <xsl:if test="$in">
             <xsl:call-template name="show-timestamp">
                 <xsl:with-param name="in" select="$in/*[local-name() = 'birthTime']"/>
             </xsl:call-template>
-            <xsl:if test="$in/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | $in/*[local-name() = 'deceasedTime']">
+            <xsl:if
+                test="$in/*[local-name() = 'deceasedInd'][@value = 'true' or @nullFlavor] | $in/*[local-name() = 'deceasedTime']">
                 <xsl:text> - </xsl:text>
                 <xsl:choose>
                     <xsl:when test="$in/*[local-name() = 'deceasedTime'][@value]">
                         <xsl:call-template name="show-timestamp">
-                            <xsl:with-param name="in" select="$in/*[local-name() = 'deceasedTime']"/>
+                            <xsl:with-param name="in" select="$in/*[local-name() = 'deceasedTime']"
+                            />
                         </xsl:call-template>
                     </xsl:when>
                     <xsl:when test="$in/*[local-name() = 'deceasedInd'][@nullFlavor]">
                         <xsl:call-template name="show-nullFlavor">
-                            <xsl:with-param name="in" select="$in/*[local-name() = 'deceasedInd']/@nullFlavor"/>
+                            <xsl:with-param name="in"
+                                select="$in/*[local-name() = 'deceasedInd']/@nullFlavor"/>
                         </xsl:call-template>
                     </xsl:when>
                     <xsl:otherwise>
@@ -4658,7 +5190,8 @@
                     <xsl:when test="$in/*[local-name() = 'deceasedTime'][@value]">
                         <xsl:value-of select="$in/*[local-name() = 'deceasedTime']/@value"/>
                     </xsl:when>
-                    <xsl:when test="not($in/*[local-name() = 'deceasedInd'] or $in/*[local-name() = 'deceasedTime'][@value = 'true' or @nullFlavor] or $in/*[local-name() = 'deceasedTime'])">
+                    <xsl:when
+                        test="not($in/*[local-name() = 'deceasedInd'] or $in/*[local-name() = 'deceasedTime'][@value = 'true' or @nullFlavor] or $in/*[local-name() = 'deceasedTime'])">
                         <xsl:value-of select="$clinicalDocumentEffectiveTime"/>
                     </xsl:when>
                 </xsl:choose>
@@ -4676,7 +5209,8 @@
                     <xsl:with-param name="post" select="')'"/>
                 </xsl:call-template>
             </xsl:if>
-            <xsl:if test="$in/*[local-name() = 'multipleBirthInd'][@value = 'true'] | $in/*[local-name() = 'multipleBirthOrderNumber']">
+            <xsl:if
+                test="$in/*[local-name() = 'multipleBirthInd'][@value = 'true'] | $in/*[local-name() = 'multipleBirthOrderNumber']">
                 <i>
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="pre" select="' '"/>
@@ -4686,7 +5220,7 @@
             </xsl:if>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Get localized string for a classCode</xd:p>
@@ -4696,7 +5230,7 @@
     <xsl:template name="show-actClassCode">
         <xsl:param name="clsCode"/>
         <xsl:call-template name="getLocalizedString">
-            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.6-',$clsCode)"/>
+            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.6-', $clsCode)"/>
         </xsl:call-template>
     </xsl:template>
 
@@ -4709,7 +5243,7 @@
     <xsl:template name="show-actRelationship">
         <xsl:param name="ptype"/>
         <xsl:call-template name="getLocalizedString">
-            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.1002-',$ptype)"/>
+            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.1002-', $ptype)"/>
         </xsl:call-template>
     </xsl:template>
 
@@ -4722,13 +5256,14 @@
     <xsl:template name="show-participationType">
         <xsl:param name="ptype"/>
         <xsl:call-template name="getLocalizedString">
-            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.90-',$ptype)"/>
+            <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.90-', $ptype)"/>
         </xsl:call-template>
     </xsl:template>
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Takes the participation typeCode attribute and translates that to a human readable form and adds the Role.code in human readable form if available.</xd:p>
+            <xd:p>Takes the participation typeCode attribute and translates that to a human readable
+                form and adds the Role.code in human readable form if available.</xd:p>
         </xd:desc>
         <xd:param name="typeCode">required. Participation typeCode</xd:param>
         <xd:param name="code">optional. Role.code</xd:param>
@@ -4740,7 +5275,7 @@
         <xsl:param name="code"/>
         <xsl:if test="string-length($typeCode) > 0">
             <xsl:call-template name="getLocalizedString">
-                <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.90-',$typeCode)"/>
+                <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.90-', $typeCode)"/>
             </xsl:call-template>
         </xsl:if>
         <xsl:if test="string-length($classCode) > 0">
@@ -4748,7 +5283,7 @@
                 <xsl:text> - </xsl:text>
             </xsl:if>
             <xsl:call-template name="getLocalizedString">
-                <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.110-',$classCode)"/>
+                <xsl:with-param name="key" select="concat('2.16.840.1.113883.5.110-', $classCode)"/>
             </xsl:call-template>
         </xsl:if>
         <xsl:if test="$code">
@@ -4767,11 +5302,13 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype II separated with the value in 'sep'. Calls <xd:ref name="show-id" type="template">show-id</xd:ref>
-        </xd:p>
+            <xd:p>Show elements with datatype II separated with the value in 'sep'. Calls <xd:ref
+                    name="show-id" type="template">show-id</xd:ref>
+            </xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-id-set">
         <xsl:param name="in"/>
@@ -4842,7 +5379,7 @@
                 <xsl:variable name="extension">
                     <xsl:if test="$in[@extension][@root]">
                         <xsl:choose>
-                            <xsl:when test="$in[contains($mask-ids-var, concat(',',@root,','))]">
+                            <xsl:when test="$in[contains($mask-ids-var, concat(',', @root, ','))]">
                                 <span>
                                     <xsl:attribute name="title">
                                         <xsl:call-template name="show-nullFlavor">
@@ -4887,11 +5424,13 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype INT separated with the value in 'sep'. Calls <xd:ref name="show-integer" type="template">show-integer</xd:ref>
+            <xd:p>Show elements with datatype INT separated with the value in 'sep'. Calls <xd:ref
+                    name="show-integer" type="template">show-integer</xd:ref>
             </xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-integer-set">
         <xsl:param name="in"/>
@@ -4973,11 +5512,16 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype CD, CE, CV, CO separated with the value in 'sep'. Calls <xd:ref name="show-code" type="template">show-code</xd:ref></xd:p>
+            <xd:p>Show elements with datatype CD, CE, CV, CO separated with the value in 'sep'.
+                Calls <xd:ref name="show-code" type="template">show-code</xd:ref></xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
-        <xd:param name="textonly">XSLT 1.0 will output a warning when you create an element inside an attribute/text node/processing instruction. To prevent that warning, we should just prevent creation of elements in that context. Set to 'true' if that's the case. Default is 'false'.</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="textonly">XSLT 1.0 will output a warning when you create an element inside
+            an attribute/text node/processing instruction. To prevent that warning, we should just
+            prevent creation of elements in that context. Set to 'true' if that's the case. Default
+            is 'false'.</xd:param>
     </xd:doc>
     <xsl:template name="show-code-set">
         <xsl:param name="in"/>
@@ -5039,7 +5583,10 @@
             <xd:p>Show elements with datatype CD, CE, CV, CO</xd:p>
         </xd:desc>
         <xd:param name="in">One element, possibly out of a set</xd:param>
-        <xd:param name="textonly">XSLT 1.0 will output a warning when you create an element inside an attribute/text node/processing instruction. To prevent that warning, we should just prevent creation of elements in that context. Set to 'true' if that's the case. Default is 'false'.</xd:param>
+        <xd:param name="textonly">XSLT 1.0 will output a warning when you create an element inside
+            an attribute/text node/processing instruction. To prevent that warning, we should just
+            prevent creation of elements in that context. Set to 'true' if that's the case. Default
+            is 'false'.</xd:param>
     </xd:doc>
     <xsl:template name="show-code">
         <xsl:param name="in"/>
@@ -5047,8 +5594,11 @@
         <xsl:if test="$in">
             <xsl:variable name="codeSystem">
                 <xsl:choose>
-                    <xsl:when test="@codeSystem"><xsl:value-of select="$in/@codeSystem"/></xsl:when>
-                    <xsl:when test="$in/self::hl7:signatureCode[not(@codeSystem)]">2.16.840.1.113883.5.89</xsl:when>
+                    <xsl:when test="@codeSystem">
+                        <xsl:value-of select="$in/@codeSystem"/>
+                    </xsl:when>
+                    <xsl:when test="$in/self::hl7:signatureCode[not(@codeSystem)]"
+                        >2.16.840.1.113883.5.89</xsl:when>
                 </xsl:choose>
             </xsl:variable>
             <xsl:choose>
@@ -5094,22 +5644,27 @@
                 </xsl:when>
                 <!-- DTr1 or DTr2 -->
                 <xsl:when test="$in[@nullFlavor]">
-                    <xsl:call-template name="show-nullFlavor">
-                        <xsl:with-param name="in" select="$in/@nullFlavor"/>
-                    </xsl:call-template>
+                    <xsl:if test="not($in/hl7:originalText)">
+                        <xsl:call-template name="show-nullFlavor">
+                            <xsl:with-param name="in" select="$in/@nullFlavor"/>
+                        </xsl:call-template>
+                    </xsl:if>
                 </xsl:when>
             </xsl:choose>
             <!-- DTr1 | DTr2 -->
-            <xsl:for-each select="$in/*[local-name() = 'originalText'] | $in/*[local-name() = 'originalText']/*[local-name() = 'xml']">
-                <xsl:text> - </xsl:text>
+            <xsl:for-each
+                select="$in/*[local-name() = 'originalText'] | $in/*[local-name() = 'originalText']/*[local-name() = 'xml']">
+                <xsl:if test="not($in[@nullFlavor])">
+                    <xsl:text> - </xsl:text>
+                </xsl:if>
                 <xsl:value-of select="."/>
             </xsl:for-each>
-            <xsl:for-each select="$in/*[local-name() = 'translation']">
+            <!-- <xsl:for-each select="$in/*[local-name() = 'translation']">
                 <xsl:choose>
                     <xsl:when test="$textonly = 'true'">
                         <xsl:text>. </xsl:text>
                         <xsl:call-template name="getLocalizedString">
-                            <xsl:with-param name="key" select="local-name()"/>
+                            <xsl:with-param name="key" select="'translation'"/>
                             <xsl:with-param name="post" select="': '"/>
                         </xsl:call-template>
                         <xsl:call-template name="show-code-set">
@@ -5119,7 +5674,7 @@
                     <xsl:otherwise>
                         <div style="margin-left: 2em;">
                             <xsl:call-template name="getLocalizedString">
-                                <xsl:with-param name="key" select="local-name()"/>
+                                <xsl:with-param name="key" select="'translation'"/>
                                 <xsl:with-param name="post" select="': '"/>
                             </xsl:call-template>
                             <xsl:call-template name="show-code-set">
@@ -5128,16 +5683,18 @@
                         </div>
                     </xsl:otherwise>
                 </xsl:choose>
-            </xsl:for-each>
+            </xsl:for-each>-->
         </xsl:if>
     </xsl:template>
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype EN, ON, PN or TN separated with the value in 'sep'. Calls <xd:ref name="show-name" type="template">show-name</xd:ref></xd:p>
+            <xd:p>Show elements with datatype EN, ON, PN or TN separated with the value in 'sep'.
+                Calls <xd:ref name="show-name" type="template">show-name</xd:ref></xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-name-set">
         <xsl:param name="in"/>
@@ -5213,64 +5770,122 @@
             <xsl:call-template name="show-nullFlavor">
                 <xsl:with-param name="in" select="$in/@nullFlavor"/>
             </xsl:call-template>
-            <xsl:for-each select="$in/node()">
-                <!-- 
-                        Except for prefix, suffix and delimiter name parts, every name part is surrounded by implicit whitespace.
-                        Leading and trailing explicit whitespace is insignificant in all those name parts. 
-                    -->
-                <xsl:if test="self::hl7:given[string-length(normalize-space(.)) > 0] | self::hl7:family[string-length(normalize-space(.)) > 0] | self::hl7:part[@type='GIV' or @type='FAM'][string-length(normalize-space(@value)) > 0]">
-                    <xsl:if test="preceding-sibling::node()[string-length(normalize-space(.)) > 0]">
+            <xsl:for-each select="$in">
+                <xsl:variable name="givenBR" select="$in/hl7:given[@qualifier = 'BR']"/>
+                <xsl:variable name="givenCL" select="$in/hl7:given[@qualifier = 'CL']"/>
+                <xsl:variable name="familyBR" select="$in/hl7:family[@qualifier = 'BR']"/>
+                <xsl:variable name="familySP" select="$in/hl7:family[@qualifier = 'SP']"/>
+                <xsl:variable name="familyCL" select="$in/hl7:family[@qualifier = 'CL']"/>
+                <xsl:variable name="family" select="$in/hl7:family[not(@qualifier)]"/>
+                <xsl:variable name="part" select="$in/hl7:part"/>
+                <xsl:variable name="suffix" select="$in/hl7:suffix"/>
+                <xsl:variable name="prefix" select="$in/hl7:prefix"/>
+                <xsl:variable name="delimiter" select="$in/hl7:delimiter"/>
+                <xsl:variable name="text" select="normalize-space($in/text())"/>
+                <xsl:if
+                    test="$in/given[string-length(normalize-space(.)) > 0] | $family[string-length(normalize-space(.)) > 0] | $part[@type = 'GIV' or @type = 'FAM'][string-length(normalize-space(@value)) > 0]">
+                    <xsl:if
+                        test="node()/preceding-sibling::node()[string-length(normalize-space(.)) > 0]">
                         <xsl:text> </xsl:text>
                     </xsl:if>
                 </xsl:if>
-                <xsl:choose>
-                    <xsl:when test="self::comment() | self::processing-instruction()"/>
-                    <!-- DTr1 -->
-                    <xsl:when test="self::hl7:family">
-                        <xsl:call-template name="caseUp">
-                            <xsl:with-param name="data" select="."/>
-                        </xsl:call-template>
-                    </xsl:when>
-                    <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type = 'FAM']">
-                        <xsl:call-template name="caseUp">
-                            <xsl:with-param name="data" select="@value"/>
-                        </xsl:call-template>
-                    </xsl:when>
-                    <!-- DTr1 -->
-                    <xsl:when test="self::hl7:prefix[contains(@qualifier, 'VV')]">
-                        <xsl:call-template name="caseUp">
-                            <xsl:with-param name="data" select="."/>
-                        </xsl:call-template>
-                        <xsl:text> </xsl:text>
-                    </xsl:when>
-                    <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type = 'PFX' and contains(@qualifier, 'VV')]">
-                        <xsl:call-template name="caseUp">
-                            <xsl:with-param name="data" select="@value"/>
-                        </xsl:call-template>
-                        <xsl:text> </xsl:text>
-                    </xsl:when>
-                    <!-- DTr1 -->
-                    <xsl:when test="self::hl7:prefix | self::hl7:given | self::delimiter">
-                        <xsl:value-of select="."/>
-                    </xsl:when>
-                    <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type = 'PFX' or @type = 'GIV' or @type = 'DEL']">
-                        <xsl:value-of select="@value"/>
-                    </xsl:when>
-                    <xsl:when test="string-length(normalize-space(.)) > 0">
-                        <xsl:value-of select="."/>
-                    </xsl:when>
-                    <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[not(@type)][string-length(normalize-space(@value)) > 0]">
-                        <xsl:value-of select="@value"/>
-                    </xsl:when>
-                </xsl:choose>
-                <xsl:if test="self::hl7:given[string-length(normalize-space(.)) > 0] | self::hl7:family[string-length(normalize-space(.)) > 0] | self::hl7:part[@type='GIV' or @type='FAM'][string-length(normalize-space(@value)) > 0]">
-                    <xsl:if test="following-sibling::node()[string-length(normalize-space(.)) > 0]">
+                <xsl:if test="$prefix">
+                    <xsl:if test="$suffix">
+                        <xsl:value-of select="$suffix"/>
                         <xsl:text> </xsl:text>
                     </xsl:if>
+                    <xsl:if test="contains(@qualifier, 'VV')">
+                        <xsl:call-template name="caseUp">
+                            <xsl:with-param name="data" select="$prefix"/>
+                        </xsl:call-template>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                    <xsl:if test="not(contains(@qualifier, 'VV'))">
+                        <xsl:value-of select="$prefix"/>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                </xsl:if>
+                <xsl:if test="not($prefix) and $suffix">
+                    <xsl:if test="$suffix">
+                        <xsl:value-of select="$suffix"/>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                    <xsl:if test="contains(@qualifier, 'VV')">
+                        <xsl:call-template name="caseUp">
+                            <xsl:with-param name="data" select="$prefix"/>
+                        </xsl:call-template>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                    <xsl:if test="not(contains(@qualifier, 'VV'))">
+                        <xsl:value-of select="$prefix"/>
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                </xsl:if>
+                <xsl:if test="$delimiter">
+                    <xsl:value-of select="$delimiter"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <!-- DTr1 -->
+                <xsl:if test="$familyBR">
+                    <xsl:value-of select="$familyBR"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:if test="$givenBR">
+                    <xsl:value-of select="$givenBR"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:if test="$familyCL">
+                    <xsl:value-of select="$familyCL"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:if test="$givenCL">
+                    <xsl:value-of select="$givenCL"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:if test="$familySP">
+                    <xsl:text>[</xsl:text>
+                    <xsl:call-template name="caseUp">
+                        <xsl:with-param name="data" select="$familySP"/>
+                    </xsl:call-template>
+                    <xsl:text>]</xsl:text>
+                </xsl:if>
+                <xsl:for-each select="hl7:given[not(@qualifier)]">
+                    <xsl:text> </xsl:text>
+                    <xsl:value-of select="."/>
+                    <xsl:text> </xsl:text>
+                </xsl:for-each>
+                <xsl:if test="$family">
+                    <xsl:value-of select="$family"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <!-- DTr2 -->
+                <xsl:if test="$part[@type = 'FAM']">
+                    <xsl:call-template name="caseUp">
+                        <xsl:with-param name="data" select="@value"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <!-- DTr2 -->
+                <xsl:if test="$part[@type = 'PFX' and contains(@qualifier, 'VV')]">
+                    <xsl:call-template name="caseUp">
+                        <xsl:with-param name="data" select="@value"/>
+                    </xsl:call-template>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:if test="$part[@type = 'PFX' or @type = 'GIV' or @type = 'DEL']">
+                    <xsl:value-of select="@value"/>
+                </xsl:if>
+                <xsl:if test="$part[not(@type)][string-length(normalize-space(@value)) > 0]">
+                    <xsl:value-of select="@value"/>
+                </xsl:if>
+                <xsl:if
+                    test="$in/given[string-length(normalize-space(.)) > 0] | $family[string-length(normalize-space(.)) > 0] | $part[@type = 'GIV' or @type = 'FAM'][string-length(normalize-space(@value)) > 0]">
+                    <xsl:if
+                        test="node()/following-sibling::node()[string-length(normalize-space(.)) > 0]">
+                        <xsl:text> </xsl:text>
+                    </xsl:if>
+                </xsl:if>
+                <xsl:if test="$text and not(*)">
+                    <xsl:value-of select="normalize-space($text)"/>
                 </xsl:if>
             </xsl:for-each>
         </xsl:if>
@@ -5278,10 +5893,12 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype AD separated with the value in 'sep'. Calls <xd:ref name="show-address" type="template">show-address</xd:ref></xd:p>
+            <xd:p>Show elements with datatype AD separated with the value in 'sep'. Calls <xd:ref
+                    name="show-address" type="template">show-address</xd:ref></xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-address-set">
         <xsl:param name="in"/>
@@ -5294,6 +5911,7 @@
                         <xsl:call-template name="show-address">
                             <xsl:with-param name="in" select="."/>
                         </xsl:call-template>
+                        <br/>
                         <xsl:if test="position() != last()">
                             <xsl:choose>
                                 <xsl:when test="$sep = 'br'">
@@ -5311,6 +5929,7 @@
                     <xsl:for-each select="$in/hl7:item">
                         <xsl:call-template name="show-address">
                             <xsl:with-param name="in" select="."/>
+                            <xsl:with-param name="inform"/>
                         </xsl:call-template>
                         <xsl:if test="position() != last()">
                             <xsl:choose>
@@ -5328,6 +5947,7 @@
                 <xsl:otherwise>
                     <xsl:call-template name="show-address">
                         <xsl:with-param name="in" select="$in"/>
+                        <xsl:with-param name="inform"/>
                     </xsl:call-template>
                 </xsl:otherwise>
             </xsl:choose>
@@ -5363,13 +5983,16 @@
                     <!-- DTr1 only if not streetAddressLine -->
                     <xsl:when test="self::hl7:streetName">
                         <xsl:if test="not(../hl7:streetAddressLine)">
-                            <xsl:variable name="additionalLocator" select="following-sibling::hl7:*[1][local-name() = 'additionalLocator'] |
-                                                                           following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber' or local-name() = 'buildingNumberSuffix']/following-sibling::hl7:*[1][local-name() = 'additionalLocator'] | 
-                                                                           following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']/following-sibling::hl7:*[1][local-name() = 'additionalLocator']"/>
-                            <xsl:variable name="houseNumber" select="following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric'] | 
-                                                                     following-sibling::hl7:*[1][local-name() = 'houseNumber']"/>
-                            <xsl:variable name="buildingNumberSuffix" select="following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix'] | 
-                                                                              following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']"/>
+                            <xsl:variable name="additionalLocator" select="
+                                    following-sibling::hl7:*[1][local-name() = 'additionalLocator'] |
+                                    following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber' or local-name() = 'buildingNumberSuffix']/following-sibling::hl7:*[1][local-name() = 'additionalLocator'] |
+                                    following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']/following-sibling::hl7:*[1][local-name() = 'additionalLocator']"/>
+                            <xsl:variable name="houseNumber" select="
+                                    following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric'] |
+                                    following-sibling::hl7:*[1][local-name() = 'houseNumber']"/>
+                            <xsl:variable name="buildingNumberSuffix" select="
+                                    following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix'] |
+                                    following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']"/>
                             <!-- 
                                 Look for
                                 - streetName houseNumber|houseNumberNumeric|buildingNumberSuffix
@@ -5395,12 +6018,14 @@
                             <xsl:if test="string-length($additionalLocator) > 0">
                                 <xsl:text>&#160;</xsl:text>
                                 <xsl:value-of select="$additionalLocator"/>
-                                
-                                <xsl:variable name="houseNumber2" select="$additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric'] | 
-                                                                          $additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumber']"/>
-                                <xsl:variable name="buildingNumberSuffix2" select="$additionalLocator/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix'] | 
-                                                                                   $additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']"/>
-                                
+
+                                <xsl:variable name="houseNumber2" select="
+                                        $additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric'] |
+                                        $additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumber']"/>
+                                <xsl:variable name="buildingNumberSuffix2" select="
+                                        $additionalLocator/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix'] |
+                                        $additionalLocator/following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber']/following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']"/>
+
                                 <xsl:choose>
                                     <xsl:when test="string-length($houseNumber2) > 0">
                                         <xsl:text>&#160;</xsl:text>
@@ -5416,21 +6041,25 @@
                                     </xsl:when>
                                 </xsl:choose>
                             </xsl:if>
-                            <xsl:if test="following-sibling::*[not(local-name() = 'houseNumber' or local-name() = 'houseNumberNumeric' or local-name() = 'buildingNumberSuffix' or local-name() = 'additionalLocator')][string-length(.) > 0 or @code]">
+                            <xsl:if
+                                test="following-sibling::*[not(local-name() = 'houseNumber' or local-name() = 'houseNumberNumeric' or local-name() = 'buildingNumberSuffix' or local-name() = 'additionalLocator')][string-length(.) > 0 or @code]">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 only if not streetAddressLine -->
-                    <xsl:when test="self::hl7:part[@type='STR']">
-                        <xsl:if test="not(../hl7:part[@type='SAL'])">
-                            <xsl:variable name="additionalLocator" select="following-sibling::hl7:part[1][@type='ADL'] |
-                                                                           following-sibling::hl7:part[1][@type='BNN' or @type='BNR' or @type='BNS']/following-sibling::hl7:part[1][@type='ADL'] | 
-                                                                           following-sibling::hl7:part[1][@type='BNN' or @type='BNR' or @type='BNS']/following-sibling::hl7:part[1][@type='BNS']/following-sibling::hl7:part[1][@type='ADL']"/>
-                            <xsl:variable name="houseNumber" select="following-sibling::hl7:part[1][@type='BNN'] | 
-                                following-sibling::hl7:part[1][@type='BNR']"/>
-                            <xsl:variable name="buildingNumberSuffix" select="following-sibling::hl7:part[1][@type='BNS'] | 
-                                following-sibling::hl7:part[1][@type='BNN' or @type='BNR']/following-sibling::hl7:part[1][@type='BNS']"/>
+                    <xsl:when test="self::hl7:part[@type = 'STR']">
+                        <xsl:if test="not(../hl7:part[@type = 'SAL'])">
+                            <xsl:variable name="additionalLocator" select="
+                                    following-sibling::hl7:part[1][@type = 'ADL'] |
+                                    following-sibling::hl7:part[1][@type = 'BNN' or @type = 'BNR' or @type = 'BNS']/following-sibling::hl7:part[1][@type = 'ADL'] |
+                                    following-sibling::hl7:part[1][@type = 'BNN' or @type = 'BNR' or @type = 'BNS']/following-sibling::hl7:part[1][@type = 'BNS']/following-sibling::hl7:part[1][@type = 'ADL']"/>
+                            <xsl:variable name="houseNumber" select="
+                                    following-sibling::hl7:part[1][@type = 'BNN'] |
+                                    following-sibling::hl7:part[1][@type = 'BNR']"/>
+                            <xsl:variable name="buildingNumberSuffix" select="
+                                    following-sibling::hl7:part[1][@type = 'BNS'] |
+                                    following-sibling::hl7:part[1][@type = 'BNN' or @type = 'BNR']/following-sibling::hl7:part[1][@type = 'BNS']"/>
                             <!-- 
                                 Look for
                                 - streetName houseNumber|houseNumberNumeric|buildingNumberSuffix
@@ -5456,12 +6085,14 @@
                             <xsl:if test="string-length($additionalLocator) > 0">
                                 <xsl:text>&#160;</xsl:text>
                                 <xsl:value-of select="$additionalLocator"/>
-                                
-                                <xsl:variable name="houseNumber2" select="$additionalLocator/following-sibling::hl7:part[1][@type='BNN'] | 
-                                    $additionalLocator/following-sibling::hl7:part[1][@type='BNR']"/>
-                                <xsl:variable name="buildingNumberSuffix2" select="$additionalLocator/following-sibling::hl7:part[1][@type='BNS'] | 
-                                    $additionalLocator/following-sibling::hl7:part[1][@type='BNN' or @type='BNR']/following-sibling::hl7:part[1][@type='BNS']"/>
-                                
+
+                                <xsl:variable name="houseNumber2" select="
+                                        $additionalLocator/following-sibling::hl7:part[1][@type = 'BNN'] |
+                                        $additionalLocator/following-sibling::hl7:part[1][@type = 'BNR']"/>
+                                <xsl:variable name="buildingNumberSuffix2" select="
+                                        $additionalLocator/following-sibling::hl7:part[1][@type = 'BNS'] |
+                                        $additionalLocator/following-sibling::hl7:part[1][@type = 'BNN' or @type = 'BNR']/following-sibling::hl7:part[1][@type = 'BNS']"/>
+
                                 <xsl:choose>
                                     <xsl:when test="string-length($houseNumber2) > 0">
                                         <xsl:text>&#160;</xsl:text>
@@ -5477,75 +6108,98 @@
                                     </xsl:when>
                                 </xsl:choose>
                             </xsl:if>
-                            <xsl:if test="following-sibling::*[not(@type='BNR' or local-name() = 'houseNumberNumeric' or @type='BNS' or @type='ADL')][string-length(.) > 0 or @code]">
+                            <xsl:if
+                                test="following-sibling::*[not(@type = 'BNR' or local-name() = 'houseNumberNumeric' or @type = 'BNS' or @type = 'ADL')][string-length(.) > 0 or @code]">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr1 only if not streetAddressLine -->
-                    <xsl:when test="self::hl7:houseNumber or self::hl7:houseNumberNumeric or self::hl7:buildingNumberSuffix">
+                    <xsl:when
+                        test="self::hl7:houseNumber or self::hl7:houseNumberNumeric or self::hl7:buildingNumberSuffix">
                         <xsl:if test="not(../hl7:streetAddressLine)">
-                            <xsl:if test="not(preceding-sibling::hl7:*[1][local-name() = 'streetName' or local-name() = 'additionalLocator'])">
-                                <xsl:if test="not(self::hl7:buildingNumberSuffix and preceding-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber'])">
+                            <xsl:if
+                                test="not(preceding-sibling::hl7:*[1][local-name() = 'streetName' or local-name() = 'additionalLocator'])">
+                                <xsl:if
+                                    test="not(self::hl7:buildingNumberSuffix and preceding-sibling::hl7:*[1][local-name() = 'houseNumberNumeric' or local-name() = 'houseNumber'])">
                                     <xsl:value-of select="."/>
-                                    <xsl:if test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
-                                        <br/>
+                                    <xsl:if
+                                        test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
+                                        <xsl:text> </xsl:text>
                                     </xsl:if>
                                 </xsl:if>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 only if not streetAddressLine -->
-                    <xsl:when test="self::hl7:part[@type='BNN' or @type='BNR' or @type='BNS']">
+                    <xsl:when test="self::hl7:part[@type = 'BNN' or @type = 'BNR' or @type = 'BNS']">
                         <xsl:if test="not(../hl7:part[@type = 'SAL'])">
-                            <xsl:if test="not(preceding-sibling::hl7:*[1][hl7:part[@type = 'STR' or @type = 'ADL']])">
-                                <xsl:if test="not(self::hl7:part[@type='BNS'] and preceding-sibling::hl7:*[1][@type='BNN' or @type='BNR'])">
-                                        <xsl:value-of select="@value"/>
-                                        <xsl:if test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
-                                             <br/>
-                                        </xsl:if>
-                                  </xsl:if>
+                            <xsl:if
+                                test="not(preceding-sibling::hl7:*[1][hl7:part[@type = 'STR' or @type = 'ADL']])">
+                                <xsl:if
+                                    test="not(self::hl7:part[@type = 'BNS'] and preceding-sibling::hl7:*[1][@type = 'BNN' or @type = 'BNR'])">
+                                    <xsl:value-of select="@value"/>
+                                    <xsl:if
+                                        test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
+                                        <br/>
+                                    </xsl:if>
+                                </xsl:if>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr1 -->
                     <xsl:when test="self::hl7:additionalLocator">
-                        <xsl:if test="not(preceding-sibling::hl7:*[1][local-name()='houseNumber' or local-name()='houseNumberNumeric' or local-name()='buildingNumberSuffix'])">
+                        <xsl:if
+                            test="not(preceding-sibling::hl7:*[1][local-name() = 'houseNumber' or local-name() = 'houseNumberNumeric' or local-name() = 'buildingNumberSuffix'])">
                             <xsl:value-of select="."/>
-                            <xsl:if test="following-sibling::hl7:*[1][local-name()='houseNumberNumeric']">
+                            <xsl:if
+                                test="following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][local-name()='houseNumberNumeric']"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][local-name() = 'houseNumberNumeric']"
+                                />
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:*[1][local-name()='houseNumber']">
+                            <xsl:if test="following-sibling::hl7:*[1][local-name() = 'houseNumber']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][local-name()='houseNumber']"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][local-name() = 'houseNumber']"
+                                />
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:*[1][local-name()='buildingNumberSuffix']">
+                            <xsl:if
+                                test="following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][local-name()='buildingNumberSuffix']"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][local-name() = 'buildingNumberSuffix']"
+                                />
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
+                            <xsl:if
+                                test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type='ADL']">
-                        <xsl:if test="not(preceding-sibling::hl7:*[1][@type='BNN' or @type='BNR' or @type='BNS'])">
+                    <xsl:when test="self::hl7:part[@type = 'ADL']">
+                        <xsl:if
+                            test="not(preceding-sibling::hl7:*[1][@type = 'BNN' or @type = 'BNR' or @type = 'BNS'])">
                             <xsl:value-of select="@value"/>
-                            <xsl:if test="following-sibling::hl7:*[1][@type='BNN']">
+                            <xsl:if test="following-sibling::hl7:*[1][@type = 'BNN']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][@type='BNN']/@value"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][@type = 'BNN']/@value"/>
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:*[1][@type='BNR']">
+                            <xsl:if test="following-sibling::hl7:*[1][@type = 'BNR']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][@type='BNR']/@value"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][@type = 'BNR']/@value"/>
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:*[1][@type='BNS']">
+                            <xsl:if test="following-sibling::hl7:*[1][@type = 'BNS']">
                                 <xsl:text>&#160;</xsl:text>
-                                <xsl:value-of select="following-sibling::hl7:*[1][@type='BNS']/@value"/>
+                                <xsl:value-of
+                                    select="following-sibling::hl7:*[1][@type = 'BNS']/@value"/>
                             </xsl:if>
-                            <xsl:if test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
+                            <xsl:if
+                                test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
@@ -5562,42 +6216,53 @@
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type='POB']">
+                    <xsl:when test="self::hl7:part[@type = 'POB']">
                         <xsl:call-template name="getLocalizedString">
                             <xsl:with-param name="key" select="'Postbox'"/>
                             <xsl:with-param name="post" select="' '"/>
                         </xsl:call-template>
                         <xsl:value-of select="@value"/>
-                        <xsl:if test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
+                        <xsl:if
+                            test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
                             <br/>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr1 ZIP CITY, STATE or CITY, STATE ZIP depending on addr part contents -->
                     <xsl:when test="self::hl7:city">
-                        <xsl:if test="preceding-sibling::hl7:postalCode[1][string-length(.) > 0 or @code]">
+                        <xsl:if
+                            test="preceding-sibling::hl7:postalCode[1][string-length(.) > 0 or @code]">
                             <xsl:choose>
-                                <xsl:when test="preceding-sibling::hl7:postalCode[1][string-length(.) > 0]">
-                                    <xsl:value-of select="preceding-sibling::hl7:postalCode[1][string-length(.) > 0]"/>
+                                <xsl:when
+                                    test="preceding-sibling::hl7:postalCode[1][string-length(.) > 0]">
+                                    <xsl:value-of
+                                        select="preceding-sibling::hl7:postalCode[1][string-length(.) > 0]"
+                                    />
                                 </xsl:when>
                                 <xsl:otherwise>
-                                    <xsl:value-of select="preceding-sibling::hl7:postalCode[1][@code]/@code"/>
+                                    <xsl:value-of
+                                        select="preceding-sibling::hl7:postalCode[1][@code]/@code"/>
                                 </xsl:otherwise>
                             </xsl:choose>
                             <xsl:text> </xsl:text>
                         </xsl:if>
                         <xsl:value-of select="."/>
-                        <xsl:if test="../hl7:state[string-length(.)>0]">
+                        <xsl:if test="../hl7:state[string-length(.) > 0]">
                             <xsl:text>, </xsl:text>
                             <xsl:value-of select="../hl7:state"/>
                         </xsl:if>
-                        <xsl:if test="following-sibling::hl7:postalCode[1][string-length(.) > 0 or @code]">
+                        <xsl:if
+                            test="following-sibling::hl7:postalCode[1][string-length(.) > 0 or @code]">
                             <xsl:text> </xsl:text>
                             <xsl:choose>
-                                <xsl:when test="following-sibling::hl7:postalCode[1][string-length(.) > 0]">
-                                    <xsl:value-of select="following-sibling::hl7:postalCode[1][string-length(.) > 0]"/>
+                                <xsl:when
+                                    test="following-sibling::hl7:postalCode[1][string-length(.) > 0]">
+                                    <xsl:value-of
+                                        select="following-sibling::hl7:postalCode[1][string-length(.) > 0]"
+                                    />
                                 </xsl:when>
                                 <xsl:otherwise>
-                                    <xsl:value-of select="following-sibling::hl7:postalCode[1][@code]/@code"/>
+                                    <xsl:value-of
+                                        select="following-sibling::hl7:postalCode[1][@code]/@code"/>
                                 </xsl:otherwise>
                             </xsl:choose>
                         </xsl:if>
@@ -5606,62 +6271,77 @@
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 ZIP CITY, STATE or CITY, STATE ZIP depending on addr part contents -->
-                    <xsl:when test="self::hl7:part[@type='CTY']">
-                        <xsl:if test="preceding-sibling::hl7:part[@type='ZIP'][1][string-length(@value) > 0 or @code]">
+                    <xsl:when test="self::hl7:part[@type = 'CTY']">
+                        <xsl:if
+                            test="preceding-sibling::hl7:part[@type = 'ZIP'][1][string-length(@value) > 0 or @code]">
                             <xsl:choose>
-                                <xsl:when test="preceding-sibling::hl7:postalCode[1][string-length(@value) > 0]">
-                                    <xsl:value-of select="preceding-sibling::hl7:postalCode[1][string-length(@value) > 0]/@value"/>
+                                <xsl:when
+                                    test="preceding-sibling::hl7:postalCode[1][string-length(@value) > 0]">
+                                    <xsl:value-of
+                                        select="preceding-sibling::hl7:postalCode[1][string-length(@value) > 0]/@value"
+                                    />
                                 </xsl:when>
                                 <xsl:otherwise>
-                                    <xsl:value-of select="preceding-sibling::hl7:postalCode[1][@code]/@code"/>
+                                    <xsl:value-of
+                                        select="preceding-sibling::hl7:postalCode[1][@code]/@code"/>
                                 </xsl:otherwise>
                             </xsl:choose>
                             <xsl:text> </xsl:text>
                         </xsl:if>
                         <xsl:value-of select="@value"/>
-                        <xsl:if test="../hl7:part[@type='STA'][string-length(@value)>0]">
+                        <xsl:if test="../hl7:part[@type = 'STA'][string-length(@value) > 0]">
                             <xsl:text>, </xsl:text>
-                            <xsl:value-of select="../hl7:part[@type='STA']/@value"/>
+                            <xsl:value-of select="../hl7:part[@type = 'STA']/@value"/>
                         </xsl:if>
-                        <xsl:if test="following-sibling::hl7:part[@type='ZIP'][1][string-length(@value) > 0 or @code]">
+                        <xsl:if
+                            test="following-sibling::hl7:part[@type = 'ZIP'][1][string-length(@value) > 0 or @code]">
                             <xsl:choose>
-                                <xsl:when test="following-sibling::hl7:postalCode[1][string-length(@value) > 0]">
-                                    <xsl:value-of select="following-sibling::hl7:postalCode[1][string-length(@value) > 0]/@value"/>
+                                <xsl:when
+                                    test="following-sibling::hl7:postalCode[1][string-length(@value) > 0]">
+                                    <xsl:value-of
+                                        select="following-sibling::hl7:postalCode[1][string-length(@value) > 0]/@value"
+                                    />
                                 </xsl:when>
                                 <xsl:otherwise>
-                                    <xsl:value-of select="following-sibling::hl7:postalCode[1][@code]/@code"/>
+                                    <xsl:value-of
+                                        select="following-sibling::hl7:postalCode[1][@code]/@code"/>
                                 </xsl:otherwise>
                             </xsl:choose>
                             <xsl:text> </xsl:text>
                         </xsl:if>
-                        <xsl:if test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
+                        <xsl:if
+                            test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
                             <br/>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr1 -->
                     <xsl:when test="self::hl7:postalCode and ../hl7:city"/>
                     <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type='ZIP'] and ../hl7:part[@type='CTY']"/>
+                    <xsl:when test="self::hl7:part[@type = 'ZIP'] and ../hl7:part[@type = 'CTY']"/>
                     <!-- DTr1 -->
                     <xsl:when test="self::hl7:state">
                         <xsl:if test="not(../hl7:city)">
-                            <xsl:if test="(string-length(preceding-sibling::hl7:*[1]) > 0 or preceding-sibling::*/@code)">
+                            <xsl:if
+                                test="(string-length(preceding-sibling::hl7:*[1]) > 0 or preceding-sibling::*/@code)">
                                 <br/>
                             </xsl:if>
                             <xsl:value-of select="."/>
-                            <xsl:if test="(string-length(following-sibling::hl7:*[1]) > 0 or following-sibling::*/@code)">
+                            <xsl:if
+                                test="(string-length(following-sibling::hl7:*[1]) > 0 or following-sibling::*/@code)">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
-                    <xsl:when test="self::hl7:part[@type='STA']">
+                    <xsl:when test="self::hl7:part[@type = 'STA']">
                         <xsl:if test="not(../hl7:part[@type = 'CTY'])">
-                            <xsl:if test="(string-length(preceding-sibling::hl7:*[1]/@value) > 0 or preceding-sibling::hl7:*/@code)">
+                            <xsl:if
+                                test="(string-length(preceding-sibling::hl7:*[1]/@value) > 0 or preceding-sibling::hl7:*/@code)">
                                 <br/>
                             </xsl:if>
                             <xsl:value-of select="@value"/>
-                            <xsl:if test="(string-length(following-sibling::hl7:*[1]/@value) > 0 or following-sibling::hl7:*/@code)">
+                            <xsl:if
+                                test="(string-length(following-sibling::hl7:*[1]/@value) > 0 or following-sibling::hl7:*/@code)">
                                 <br/>
                             </xsl:if>
                         </xsl:if>
@@ -5669,14 +6349,16 @@
                     <!-- DTr1 -->
                     <xsl:when test="string-length(text()) > 0">
                         <xsl:value-of select="."/>
-                        <xsl:if test="(string-length(following-sibling::hl7:*[1]) > 0 or following-sibling::hl7:*/@code)">
+                        <xsl:if
+                            test="(string-length(following-sibling::hl7:*[1]) > 0 or following-sibling::hl7:*/@code)">
                             <br/>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
                     <xsl:when test="string-length(@value) > 0">
                         <xsl:value-of select="@value"/>
-                        <xsl:if test="(string-length(following-sibling::hl7:*[1]/@value) > 0 or following-sibling::hl7:*/@code)">
+                        <xsl:if
+                            test="(string-length(following-sibling::hl7:*[1]/@value) > 0 or following-sibling::hl7:*/@code)">
                             <br/>
                         </xsl:if>
                     </xsl:when>
@@ -5699,11 +6381,13 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype QTY/PQ separated with the value in 'sep'. Calls <xd:ref name="show-quantity" type="template">show-quantity</xd:ref>
+            <xd:p>Show elements with datatype QTY/PQ separated with the value in 'sep'. Calls
+                    <xd:ref name="show-quantity" type="template">show-quantity</xd:ref>
             </xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-quantity-set">
         <xsl:param name="in"/>
@@ -5841,7 +6525,7 @@
                     <xsl:with-param name="part" select="'time'"/>
                 </xsl:call-template>
             </xsl:variable>
-            
+
             <xsl:choose>
                 <xsl:when test="$in/@value">
                     <xsl:call-template name="getLocalizedString">
@@ -5858,11 +6542,11 @@
                         <xsl:with-param name="in" select="$in/hl7:low"/>
                         <xsl:with-param name="part" select="'date'"/>
                     </xsl:call-template>
-                    
+
                     <xsl:if test="string-length(normalize-space($fromTime)) > 0">
                         <xsl:text> </xsl:text>
                         <xsl:value-of select="normalize-space($fromTime)"/>
-                        
+
                         <xsl:if test="string-length(normalize-space($toTime)) > 0">
                             <xsl:text> - </xsl:text>
                             <xsl:value-of select="normalize-space($toTime)"/>
@@ -5900,13 +6584,15 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype TEL or URI separated with the value in 'sep'. Calls <xd:ref name="show-telecom" type="template">show-telecom</xd:ref></xd:p>
+            <xd:p>Show elements with datatype TEL or URI separated with the value in 'sep'. Calls
+                    <xd:ref name="show-telecom" type="template">show-telecom</xd:ref></xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-telecom-set">
         <xsl:param name="in"/>
@@ -5919,14 +6605,12 @@
                         <xsl:call-template name="show-telecom">
                             <xsl:with-param name="in" select="."/>
                         </xsl:call-template>
+                        <br/>
                         <xsl:if test="position() != last()">
                             <xsl:choose>
                                 <xsl:when test="$sep = 'br'">
                                     <br/>
                                 </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="$sep"/>
-                                </xsl:otherwise>
                             </xsl:choose>
                         </xsl:if>
                     </xsl:for-each>
@@ -5942,9 +6626,6 @@
                                 <xsl:when test="$sep = 'br'">
                                     <br/>
                                 </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="$sep"/>
-                                </xsl:otherwise>
                             </xsl:choose>
                         </xsl:if>
                     </xsl:for-each>
@@ -5973,22 +6654,34 @@
                     <xsl:if test="position() > 1">
                         <br/>
                     </xsl:if>
-                    
+
                     <xsl:variable name="type" select="substring-before(@value, ':')"/>
                     <xsl:variable name="value" select="substring-after(@value, ':')"/>
                     <xsl:if test="$type">
-                        <xsl:call-template name="translateTelecomUriScheme">
-                            <xsl:with-param name="code" select="$type"/>
-                        </xsl:call-template>
+                        <xsl:if test="not($type = 'mailto')">
+                            <xsl:call-template name="translateTelecomUriScheme">
+                                <xsl:with-param name="code" select="$type"/>
+                            </xsl:call-template>
+                        </xsl:if>
                     </xsl:if>
                     <xsl:if test="@use">
-                        <xsl:text> </xsl:text>
-                        <xsl:call-template name="tokenize">
-                            <xsl:with-param name="prefix" select="'addressUse_'"/>
-                            <xsl:with-param name="string" select="@use"/>
-                            <xsl:with-param name="delimiters" select="' '"/>
-                        </xsl:call-template>
+                        <xsl:if test="not($type = 'mailto')">
+                            <xsl:text> </xsl:text>
+                            <xsl:call-template name="tokenize">
+                                <xsl:with-param name="prefix" select="'addressUse_'"/>
+                                <xsl:with-param name="string" select="@use"/>
+                                <xsl:with-param name="delimiters" select="' '"/>
+                            </xsl:call-template>
+                        </xsl:if>
                     </xsl:if>
+                    <xsl:if test="$type">
+                        <xsl:if test="$type = 'mailto'">
+                            <xsl:call-template name="getLocalizedString">
+                                <xsl:with-param name="key" select="'mailto'"/>
+                            </xsl:call-template>
+                        </xsl:if>
+                    </xsl:if>
+
                     <xsl:if test="$type or @use">
                         <xsl:text>: </xsl:text>
                     </xsl:if>
@@ -6015,12 +6708,13 @@
             <xd:p>Show element with datatype TS</xd:p>
         </xd:desc>
         <xd:param name="in">One element, possibly out of a set</xd:param>
-        <xd:param name="part">value to tell if we want the full thing 'datetime', date only 'date', or time only 'time'</xd:param>
+        <xd:param name="part">value to tell if we want the full thing 'datetime', date only 'date',
+            or time only 'time'</xd:param>
     </xd:doc>
     <xsl:template name="show-timestamp">
         <xsl:param name="in"/>
         <xsl:param name="part" select="'datetime'"/>
-        
+
         <xsl:call-template name="formatDateTime">
             <xsl:with-param name="date" select="$in/@value"/>
             <xsl:with-param name="part" select="$part"/>
@@ -6029,10 +6723,12 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Show elements with datatype ST separated with the value in 'sep'. Calls <xd:ref name="show-text" type="template">show-text</xd:ref></xd:p>
+            <xd:p>Show elements with datatype ST separated with the value in 'sep'. Calls <xd:ref
+                    name="show-text" type="template">show-text</xd:ref></xd:p>
         </xd:desc>
         <xd:param name="in">Set of 0 to * elements</xd:param>
-        <xd:param name="sep">Separator between output of different elements. Default ', ' and special is 'br' which generates an HTML br tag</xd:param>
+        <xd:param name="sep">Separator between output of different elements. Default ', ' and
+            special is 'br' which generates an HTML br tag</xd:param>
     </xd:doc>
     <xsl:template name="show-text-set">
         <xsl:param name="in"/>
@@ -6112,7 +6808,7 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Show element with datatype BL/BN</xd:p>
@@ -6138,7 +6834,7 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>Show a nullFlavor as text</xd:p>
@@ -6153,9 +6849,10 @@
             </xsl:call-template>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
-        <xd:desc>SDTC defines sdtc:signatureText including a digital signature. XSLT lacks tools to verify validity, but may signal its presence</xd:desc>
+        <xd:desc>SDTC defines sdtc:signatureText including a digital signature. XSLT lacks tools to
+            verify validity, but may signal its presence</xd:desc>
         <xd:param name="in">sdtc:signatureText element</xd:param>
     </xd:doc>
     <xsl:template name="show-signatureText">
@@ -6177,14 +6874,15 @@
             </img>
         </xsl:for-each>
     </xsl:template>
-    
+
     <!-- ====================================================================== -->
     <!--                           Supporting functions                         -->
     <!-- ====================================================================== -->
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Takes the 5th and 6th character from a timestamp, and returns the localized month name</xd:p>
+            <xd:p>Takes the 5th and 6th character from a timestamp, and returns the localized month
+                name</xd:p>
         </xd:desc>
         <xd:param name="date">Timestamp string</xd:param>
     </xd:doc>
@@ -6276,14 +6974,15 @@
             <xd:p>Formats a timestamp</xd:p>
         </xd:desc>
         <xd:param name="date"/>
-        <xd:param name="part">value to tell if we want the full thing 'datetime', date only 'date', or time only 'time'</xd:param>
+        <xd:param name="part">value to tell if we want the full thing 'datetime', date only 'date',
+            or time only 'time'</xd:param>
     </xd:doc>
     <xsl:template name="formatDateTime">
         <xsl:param name="date"/>
         <xsl:param name="part" select="'datetime'"/>
-        
-        <xsl:variable name="yearNum" select="substring ($date, 1, 4)"/>
-        <xsl:variable name="monthNum" select="substring ($date, 5, 2)"/>
+
+        <xsl:variable name="yearNum" select="substring($date, 1, 4)"/>
+        <xsl:variable name="monthNum" select="substring($date, 5, 2)"/>
         <xsl:variable name="monthText">
             <xsl:call-template name="formatMonth">
                 <xsl:with-param name="date" select="$date"/>
@@ -6355,10 +7054,12 @@
                     </xsl:otherwise>
                 </xsl:choose>
                 <xsl:choose>
-                    <xsl:when test="string-length($mm) > 1 and not(contains($mm, '-')) and not(contains($mm, '+')) and not($mm = '00' and $ss = '00')">
+                    <xsl:when
+                        test="string-length($mm) > 1 and not(contains($mm, '-')) and not(contains($mm, '+')) and not($mm = '00' and $ss = '00')">
                         <xsl:text>:</xsl:text>
                         <xsl:value-of select="$mm"/>
-                        <xsl:if test="string-length($ss) > 1 and not(contains($ss, '-')) and not(contains($ss, '+')) and not($ss = '00')">
+                        <xsl:if
+                            test="string-length($ss) > 1 and not(contains($ss, '-')) and not(contains($ss, '+')) and not($ss = '00')">
                             <xsl:text>:</xsl:text>
                             <xsl:value-of select="$ss"/>
                         </xsl:if>
@@ -6396,10 +7097,12 @@
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Get someones age based on the difference between 'date' and <xd:ref name="currentDate" type="parameter">currentDate</xd:ref>.</xd:p>
+            <xd:p>Get someones age based on the difference between 'date' and <xd:ref
+                    name="currentDate" type="parameter">currentDate</xd:ref>.</xd:p>
         </xd:desc>
         <xd:param name="date">Persons date of birth as HL7 TS</xd:param>
-        <xd:param name="comparedate">The date, format yyyymmdd as HL7 TS, that the age should be calculated relative to</xd:param>
+        <xd:param name="comparedate">The date, format yyyymmdd as HL7 TS, that the age should be
+            calculated relative to</xd:param>
     </xd:doc>
     <xsl:template name="getAge">
         <xsl:param name="comparedate"/>
@@ -6408,7 +7111,7 @@
         <xsl:variable name="monthNum" select="substring($date, 5, 2)"/>
         <xsl:variable name="dayNum">
             <xsl:choose>
-                <xsl:when test="substring ($date, 7, 1)=&quot;0&quot;">
+                <xsl:when test="substring($date, 7, 1) = &quot;0&quot;">
                     <xsl:value-of select="substring($date, 8, 1)"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -6421,7 +7124,7 @@
         <xsl:variable name="monthNumCreate" select="substring($comparedate, 5, 2)"/>
         <xsl:variable name="dayNumCreate">
             <xsl:choose>
-                <xsl:when test="substring ($comparedate, 7, 1)=&quot;0&quot;">
+                <xsl:when test="substring($comparedate, 7, 1) = &quot;0&quot;">
                     <xsl:value-of select="substring($comparedate, 8, 1)"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -6480,7 +7183,7 @@
             </xsl:when>
             <xsl:when test="$code = 'mailto'">
                 <xsl:call-template name="getLocalizedString">
-                    <xsl:with-param name="key" select="'Mail'"/>
+                    <xsl:with-param name="key" select="'Email'"/>
                 </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
@@ -6500,7 +7203,9 @@
     <xsl:template name="caseDown">
         <xsl:param name="data"/>
         <xsl:if test="$data">
-            <xsl:value-of select="translate($data, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"/>
+            <xsl:value-of
+                select="translate($data, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"
+            />
         </xsl:if>
     </xsl:template>
 
@@ -6513,13 +7218,16 @@
     <xsl:template name="caseUp">
         <xsl:param name="data"/>
         <xsl:if test="$data">
-            <xsl:value-of select="translate($data, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+            <xsl:value-of
+                select="translate($data, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+            />
         </xsl:if>
     </xsl:template>
 
     <xd:doc>
         <xd:desc>
-            <xd:p>Converts first character in input to upper case if it is a Latin character and returns the result</xd:p>
+            <xd:p>Converts first character in input to upper case if it is a Latin character and
+                returns the result</xd:p>
         </xd:desc>
         <xd:param name="data">Input string</xd:param>
     </xd:doc>
@@ -6540,7 +7248,8 @@
         <xd:param name="string">String to tokenize</xd:param>
         <xd:param name="delimiters">Optional delimiter string</xd:param>
         <xd:param name="prefix">Optional prefix for every 'array' item</xd:param>
-        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also try to localize array items (default)</xd:param>
+        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also
+            try to localize array items (default)</xd:param>
     </xd:doc>
     <xsl:template name="tokenize">
         <xsl:param name="string" select="''"/>
@@ -6573,7 +7282,8 @@
         </xd:desc>
         <xd:param name="string">String to tokenize</xd:param>
         <xd:param name="prefix">Optional prefix for every 'array' item</xd:param>
-        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also try to localize array items (default)</xd:param>
+        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also
+            try to localize array items (default)</xd:param>
     </xd:doc>
     <xsl:template name="_tokenize-characters">
         <xsl:param name="string"/>
@@ -6583,7 +7293,8 @@
             <xsl:choose>
                 <xsl:when test="$localize">
                     <xsl:call-template name="getLocalizedString">
-                        <xsl:with-param name="key" select="concat($prefix,substring($string, 1, 1))"/>
+                        <xsl:with-param name="key"
+                            select="concat($prefix, substring($string, 1, 1))"/>
                     </xsl:call-template>
                 </xsl:when>
                 <xsl:otherwise>
@@ -6605,14 +7316,15 @@
         <xd:param name="string">String to tokenize</xd:param>
         <xd:param name="delimiters">Required delimiter string</xd:param>
         <xd:param name="prefix">Optional prefix for every 'array' item</xd:param>
-        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also try to localize array items (default)</xd:param>
+        <xd:param name="localize">Optional parameter to determine if we should just tokenize or also
+            try to localize array items (default)</xd:param>
     </xd:doc>
     <xsl:template name="_tokenize-delimiters">
         <xsl:param name="string"/>
         <xsl:param name="delimiters"/>
         <xsl:param name="prefix"/>
         <xsl:param name="localize" select="true()"/>
-        
+
         <xsl:variable name="delimiter" select="substring($delimiters, 1, 1)"/>
         <xsl:choose>
             <xsl:when test="not($delimiter)">
@@ -6654,15 +7366,20 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Index the translation file for performance</xd:desc>
     </xd:doc>
     <xsl:key name="util-i18nkey" match="translation" use="@key"/>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Retrieves a language dependant string from our <xd:ref name="vocFile" type="parameter">language file</xd:ref> such as a label based on a key. Returns string based on <xd:ref name="textLang" type="parameter">textLang</xd:ref>, <xd:ref name="textLangDefault" type="parameter">textLangDefault</xd:ref>, the first two characters of the textLangDefault, e.g. 'en' in 'en-US' and finally if all else fails just the key text.</xd:p>
+            <xd:p>Retrieves a language dependant string from our <xd:ref name="vocFile"
+                    type="parameter">language file</xd:ref> such as a label based on a key. Returns
+                string based on <xd:ref name="textLang" type="parameter">textLang</xd:ref>, <xd:ref
+                    name="textLangDefault" type="parameter">textLangDefault</xd:ref>, the first two
+                characters of the textLangDefault, e.g. 'en' in 'en-US' and finally if all else
+                fails just the key text.</xd:p>
         </xd:desc>
         <xd:param name="pre">Some text or space to prefix our string with</xd:param>
         <xd:param name="key">The key to find our text with</xd:param>
@@ -6672,25 +7389,34 @@
         <xsl:param name="pre" select="''"/>
         <xsl:param name="key"/>
         <xsl:param name="post" select="''"/>
-        
+
         <xsl:for-each select="$vocMessages">
             <xsl:variable name="translation" select="key('util-i18nkey', $key)"/>
             <xsl:choose>
                 <!-- compare 'de-CH' -->
                 <xsl:when test="$translation/value[@lang = $textLangLowerCase]">
-                    <xsl:value-of select="concat($pre, $translation/value[@lang = $textLangLowerCase]/text(), $post)"/>
+                    <xsl:value-of
+                        select="concat($pre, $translation/value[@lang = $textLangLowerCase]/text(), $post)"
+                    />
                 </xsl:when>
                 <!-- compare 'de' in 'de-CH' -->
                 <xsl:when test="$translation/value[substring(@lang, 1, 2) = $textLangPartLowerCase]">
-                    <xsl:value-of select="concat($pre, $translation/value[substring(@lang, 1, 2) = $textLangPartLowerCase]/text(), $post)"/>
+                    <xsl:value-of
+                        select="concat($pre, $translation/value[substring(@lang, 1, 2) = $textLangPartLowerCase]/text(), $post)"
+                    />
                 </xsl:when>
                 <!-- compare 'en-US' -->
                 <xsl:when test="$translation/value[@lang = $textLangDefaultLowerCase]">
-                    <xsl:value-of select="concat($pre, $translation/value[@lang = $textLangDefaultLowerCase]/text(), $post)"/>
+                    <xsl:value-of
+                        select="concat($pre, $translation/value[@lang = $textLangDefaultLowerCase]/text(), $post)"
+                    />
                 </xsl:when>
                 <!-- compare 'en' in 'en-US' -->
-                <xsl:when test="$translation/value[substring(@lang, 1, 2) = $textLangDefaultPartLowerCase]">
-                    <xsl:value-of select="concat($pre, $translation/value[substring(@lang, 1, 2) = $textLangDefaultPartLowerCase]/text(), $post)"/>
+                <xsl:when
+                    test="$translation/value[substring(@lang, 1, 2) = $textLangDefaultPartLowerCase]">
+                    <xsl:value-of
+                        select="concat($pre, $translation/value[substring(@lang, 1, 2) = $textLangDefaultPartLowerCase]/text(), $post)"
+                    />
                 </xsl:when>
                 <xsl:when test="$translation/value[@lang = 'en-us']">
                     <xsl:value-of select="concat($pre, $translation/text(), $post)"/>
@@ -6701,25 +7427,29 @@
             </xsl:choose>
         </xsl:for-each>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
-            <xd:p>Helper template for calculation of CSS font sizes. Takes <xd:ref name="font-size-main" type="parameter">font-size-main</xd:ref> as base and adds the value in parameter <xd:i>with</xd:i> while retaining the unit.</xd:p>
+            <xd:p>Helper template for calculation of CSS font sizes. Takes <xd:ref
+                    name="font-size-main" type="parameter">font-size-main</xd:ref> as base and adds
+                the value in parameter <xd:i>with</xd:i> while retaining the unit.</xd:p>
         </xd:desc>
-        <xd:param name="with">The value to add to the base value. May be a negative number</xd:param>
+        <xd:param name="with">The value to add to the base value. May be a negative
+            number</xd:param>
     </xd:doc>
     <xsl:template name="raiseFontSize">
         <xsl:param name="with"/>
-        <xsl:variable name="mainsize" select="translate($font-size-main,'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz','')"/>
-        <xsl:variable name="mainunit" select="translate($font-size-main,'0123456789','')"/>
-        <xsl:value-of select="number($mainsize)+number($with)"/>
+        <xsl:variable name="mainsize"
+            select="translate($font-size-main, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz', '')"/>
+        <xsl:variable name="mainunit" select="translate($font-size-main, '0123456789', '')"/>
+        <xsl:value-of select="number($mainsize) + number($with)"/>
         <xsl:value-of select="$mainunit"/>
     </xsl:template>
 
     <!-- ====================================================================== -->
     <!--                             Javascript stuff                           -->
     <!-- ====================================================================== -->
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>generate global section toggle</xd:p>
@@ -6729,12 +7459,14 @@
         <xsl:if test="count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 0">
             <td style="background-color: white;">
                 <!-- creates toggle for sections -->
-                <div id="sectionsToggleExpand" style="display: none;" class="span_button" onclick="expandAllSections();">
+                <div id="sectionsToggleExpand" style="display: none;" class="span_button"
+                    onclick="expandAllSections();">
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="key" select="'Expand All'"/>
                     </xsl:call-template>
                 </div>
-                <div id="sectionsToggleCollapse" class="span_button" onclick="collapseAllSections();">
+                <div id="sectionsToggleCollapse" class="span_button"
+                    onclick="collapseAllSections();">
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="key" select="'Collapse All'"/>
                     </xsl:call-template>
@@ -6742,7 +7474,7 @@
             </td>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>generate revision toggle</xd:p>
@@ -6757,7 +7489,8 @@
                         <xsl:with-param name="key" select="'show revisions'"/>
                     </xsl:call-template>
                 </div>
-                <div id="revisionToggleOff" style="display: none;" class="span_button" onclick="hideReviewMarks();">
+                <div id="revisionToggleOff" style="display: none;" class="span_button"
+                    onclick="hideReviewMarks();">
                     <xsl:call-template name="getLocalizedString">
                         <xsl:with-param name="key" select="'hide revisions'"/>
                     </xsl:call-template>
@@ -6765,7 +7498,7 @@
             </td>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>
             <xd:p>generate table of contents</xd:p>
@@ -6774,8 +7507,12 @@
     <xsl:template name="make-tableofcontents">
         <xsl:variable name="tocid">
             <xsl:choose>
-                <xsl:when test="$useJavascript"><xsl:text>nav</xsl:text></xsl:when>
-                <xsl:otherwise><xsl:text>nonav</xsl:text></xsl:otherwise>
+                <xsl:when test="$useJavascript">
+                    <xsl:text>nav</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:text>nonav</xsl:text>
+                </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
         <xsl:if test="count(hl7:component/hl7:structuredBody/hl7:component[hl7:section]) &gt; 1">
@@ -6790,17 +7527,19 @@
                             <xsl:text>&#160;&#8711;</xsl:text>
                         </div>
                         <ul>
-                            <xsl:for-each select="hl7:component/hl7:structuredBody/hl7:component/hl7:section">
+                            <xsl:for-each
+                                select="hl7:component/hl7:structuredBody/hl7:component/hl7:section">
                                 <li>
                                     <a>
                                         <xsl:attribute name="href">
                                             <xsl:text>#</xsl:text>
                                             <xsl:choose>
                                                 <xsl:when test="@ID">
-                                                    <xsl:value-of select="@ID"/>
+                                                  <xsl:value-of select="@ID"/>
                                                 </xsl:when>
                                                 <xsl:otherwise>
-                                                    <xsl:apply-templates select="." mode="getAnchorName"/>
+                                                  <xsl:apply-templates select="."
+                                                  mode="getAnchorName"/>
                                                 </xsl:otherwise>
                                             </xsl:choose>
                                         </xsl:attribute>
@@ -6820,45 +7559,51 @@
                                         <ul>
                                             <xsl:for-each select="hl7:component/hl7:section">
                                                 <li style="padding-left: 2em;">
-                                                    <a>
-                                                        <xsl:attribute name="href">
-                                                            <xsl:text>#</xsl:text>
-                                                            <xsl:choose>
-                                                                <xsl:when test="@ID">
-                                                                    <xsl:value-of select="@ID"/>
-                                                                </xsl:when>
-                                                                <xsl:otherwise>
-                                                                    <xsl:apply-templates select="." mode="getAnchorName"/>
-                                                                </xsl:otherwise>
-                                                            </xsl:choose>
-                                                        </xsl:attribute>
-                                                        <xsl:apply-templates select="." mode="getTitleName"/>
-                                                        <xsl:if test="$menu-depth > 2 and hl7:component/hl7:section">
-                                                            <xsl:text> ▶</xsl:text>
-                                                        </xsl:if>
-                                                    </a>
-                                                    <xsl:if test="$menu-depth > 2 and hl7:component/hl7:section">
-                                                        <ul>
-                                                            <xsl:for-each select="hl7:component/hl7:section">
-                                                                <li style="padding-left: 2em;">
-                                                                    <a>
-                                                                        <xsl:attribute name="href">
-                                                                            <xsl:text>#</xsl:text>
-                                                                            <xsl:choose>
-                                                                                <xsl:when test="@ID">
-                                                                                    <xsl:value-of select="@ID"/>
-                                                                                </xsl:when>
-                                                                                <xsl:otherwise>
-                                                                                    <xsl:apply-templates select="." mode="getAnchorName"/>
-                                                                                </xsl:otherwise>
-                                                                            </xsl:choose>
-                                                                        </xsl:attribute>
-                                                                        <xsl:apply-templates select="." mode="getTitleName"/>
-                                                                    </a>
-                                                                </li>
-                                                            </xsl:for-each>
-                                                        </ul>
-                                                    </xsl:if>
+                                                  <a>
+                                                  <xsl:attribute name="href">
+                                                  <xsl:text>#</xsl:text>
+                                                  <xsl:choose>
+                                                  <xsl:when test="@ID">
+                                                  <xsl:value-of select="@ID"/>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:apply-templates select="."
+                                                  mode="getAnchorName"/>
+                                                  </xsl:otherwise>
+                                                  </xsl:choose>
+                                                  </xsl:attribute>
+                                                  <xsl:apply-templates select="."
+                                                  mode="getTitleName"/>
+                                                  <xsl:if
+                                                  test="$menu-depth > 2 and hl7:component/hl7:section">
+                                                  <xsl:text> ▶</xsl:text>
+                                                  </xsl:if>
+                                                  </a>
+                                                  <xsl:if
+                                                  test="$menu-depth > 2 and hl7:component/hl7:section">
+                                                  <ul>
+                                                  <xsl:for-each select="hl7:component/hl7:section">
+                                                  <li style="padding-left: 2em;">
+                                                  <a>
+                                                  <xsl:attribute name="href">
+                                                  <xsl:text>#</xsl:text>
+                                                  <xsl:choose>
+                                                  <xsl:when test="@ID">
+                                                  <xsl:value-of select="@ID"/>
+                                                  </xsl:when>
+                                                  <xsl:otherwise>
+                                                  <xsl:apply-templates select="."
+                                                  mode="getAnchorName"/>
+                                                  </xsl:otherwise>
+                                                  </xsl:choose>
+                                                  </xsl:attribute>
+                                                  <xsl:apply-templates select="."
+                                                  mode="getTitleName"/>
+                                                  </a>
+                                                  </li>
+                                                  </xsl:for-each>
+                                                  </ul>
+                                                  </xsl:if>
                                                 </li>
                                             </xsl:for-each>
                                         </ul>

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -6141,7 +6141,7 @@
                                     <xsl:value-of select="@value"/>
                                     <xsl:if
                                         test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
-                                        <br/>
+                                        <xsl:text> </xsl:text>
                                     </xsl:if>
                                 </xsl:if>
                             </xsl:if>
@@ -6174,7 +6174,7 @@
                             </xsl:if>
                             <xsl:if
                                 test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
-                                <br/>
+                                <xsl:text> </xsl:text>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
@@ -6200,7 +6200,7 @@
                             </xsl:if>
                             <xsl:if
                                 test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
-                                <br/>
+                                <xsl:text> </xsl:text>
                             </xsl:if>
                         </xsl:if>
                     </xsl:when>
@@ -6212,7 +6212,7 @@
                         </xsl:call-template>
                         <xsl:value-of select="."/>
                         <xsl:if test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
-                            <br/>
+                            <xsl:text> </xsl:text>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
@@ -6224,7 +6224,7 @@
                         <xsl:value-of select="@value"/>
                         <xsl:if
                             test="following-sibling::hl7:part[1][string-length(@value) > 0 or @code]">
-                            <br/>
+                            <xsl:text> </xsl:text>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr1 ZIP CITY, STATE or CITY, STATE ZIP depending on addr part contents -->
@@ -6267,7 +6267,7 @@
                             </xsl:choose>
                         </xsl:if>
                         <xsl:if test="following-sibling::hl7:*[1][string-length(.) > 0 or @code]">
-                            <br/>
+                            <xsl:text> </xsl:text>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 ZIP CITY, STATE or CITY, STATE ZIP depending on addr part contents -->
@@ -6351,7 +6351,7 @@
                         <xsl:value-of select="."/>
                         <xsl:if
                             test="(string-length(following-sibling::hl7:*[1]) > 0 or following-sibling::hl7:*/@code)">
-                            <br/>
+                            <xsl:text> </xsl:text>
                         </xsl:if>
                     </xsl:when>
                     <!-- DTr2 -->
@@ -6359,7 +6359,19 @@
                         <xsl:value-of select="@value"/>
                         <xsl:if
                             test="(string-length(following-sibling::hl7:*[1]/@value) > 0 or following-sibling::hl7:*/@code)">
-                            <br/>
+                            <xsl:text> </xsl:text>
+                        </xsl:if>
+                        <xsl:if test="string(number(following-sibling::hl7:*[1])) != 'NaN'">
+                            <xsl:if
+                                test="number(following-sibling::hl7:*[1]) = following-sibling::hl7:*[1]">
+                                <br/>
+                            </xsl:if>
+                        </xsl:if>
+                        <xsl:if test="string(number(following-sibling::hl7:*[1])) != 'NaN'">
+                            <xsl:if
+                                test="number(following-sibling::hl7:*[1]) = following-sibling::hl7:*[1]">
+                                <br/>
+                            </xsl:if>
                         </xsl:if>
                     </xsl:when>
                     <xsl:otherwise> </xsl:otherwise>
@@ -6679,6 +6691,15 @@
                             <xsl:call-template name="getLocalizedString">
                                 <xsl:with-param name="key" select="'mailto'"/>
                             </xsl:call-template>
+                            <xsl:if test="@use">
+                                <xsl:text> (</xsl:text>
+                                <xsl:call-template name="tokenize">
+                                    <xsl:with-param name="prefix" select="'addressUse_'"/>
+                                    <xsl:with-param name="string" select="@use"/>
+                                    <xsl:with-param name="delimiters" select="' '"/>
+                                </xsl:call-template>
+                                <xsl:text>) </xsl:text>
+                            </xsl:if>
                         </xsl:if>
                     </xsl:if>
 

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -4741,10 +4741,22 @@
                                 </xsl:call-template>
                             </td>
                             <td>
-                                <xsl:call-template name="show-contactInfo">
-                                    <xsl:with-param name="contact" select="hl7:patient/hl7:guardian"
-                                    />
-                                </xsl:call-template>
+                                <xsl:for-each select="hl7:patient/hl7:guardian">
+                                    <span style="color: black;">
+                                        <xsl:call-template name="getLocalizedString">
+                                            <xsl:with-param name="key" select="'Guardian'"/>
+                                        </xsl:call-template>
+                                        <xsl:text> </xsl:text>
+                                        <xsl:value-of select="position()"/>
+                                        <xsl:text> : </xsl:text>
+                                    </span>
+                                    <br/>
+                                    <br/>
+                                    <xsl:call-template name="show-contactInfo">
+                                        <xsl:with-param name="contact" select="."/>
+                                    </xsl:call-template>
+                                    <br/>
+                                </xsl:for-each>
                             </td>
                         </tr>
                     </xsl:if>
@@ -6666,7 +6678,6 @@
                     <xsl:if test="position() > 1">
                         <br/>
                     </xsl:if>
-
                     <xsl:variable name="type" select="substring-before(@value, ':')"/>
                     <xsl:variable name="value" select="substring-after(@value, ':')"/>
                     <xsl:if test="$type">
@@ -6702,7 +6713,6 @@
                             </xsl:if>
                         </xsl:if>
                     </xsl:if>
-
                     <xsl:if test="$type or @use">
                         <xsl:text>: </xsl:text>
                     </xsl:if>

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -4741,17 +4741,21 @@
                                 </xsl:call-template>
                             </td>
                             <td>
+                                <xsl:variable name="count"
+                                    select="count(hl7:patient/hl7:guardian)"/>
                                 <xsl:for-each select="hl7:patient/hl7:guardian">
-                                    <span style="color: black;">
-                                        <xsl:call-template name="getLocalizedString">
-                                            <xsl:with-param name="key" select="'Guardian'"/>
-                                        </xsl:call-template>
-                                        <xsl:text> </xsl:text>
-                                        <xsl:value-of select="position()"/>
-                                        <xsl:text> : </xsl:text>
-                                    </span>
-                                    <br/>
-                                    <br/>
+                                    <xsl:if test="$count > 1">
+                                        <span style="color: black;">
+                                            <xsl:call-template name="getLocalizedString">
+                                                <xsl:with-param name="key" select="'Guardian'"/>
+                                            </xsl:call-template>
+                                            <xsl:text> </xsl:text>
+                                            <xsl:value-of select="position()"/>
+                                            <xsl:text> : </xsl:text>
+                                        </span>
+                                        <br/>
+                                        <br/>
+                                    </xsl:if>
                                     <xsl:call-template name="show-contactInfo">
                                         <xsl:with-param name="contact" select="."/>
                                     </xsl:call-template>

--- a/cda_l10n.xml
+++ b/cda_l10n.xml
@@ -13,7 +13,8 @@
   CDA_R2_examples/CA_EMS/CDA.ReleaseTwo.MembershipBallot01.Dec.2004.xsl
 -->
 <?xml-stylesheet type="text/xsl" href="cda_l10n.xsl"?>
-<translations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="cda_l10n.xsd">
+<translations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="cda_l10n.xsd">
     <languageList>
         <language description="English (American)" lang="en-us"/>
         <language description="Dutch (Netherlands)" lang="nl-nl"/>
@@ -24,9 +25,16 @@
     </languageList>
     <translation key="Display Disclaimer">
         <comment>Label: Display disclaimer</comment>
-        <value lang="en-us">Disclaimer: the purpose of this stylesheet and the results it produces from xml messages is exclusively for testing. They are explicitly NOT suited for use in a medical practise.</value>
-        <value lang="nl-nl">Disclaimer: Deze stylesheet en de resulterende html weergave van xml berichten zijn uitsluitend bedoeld voor testdoeleinden. Zij zijn uitdrukkelijk niet bedoeld voor gebruik in de medische praktijk.</value> 
-        <value lang="fr-fr">Clause de non-responsabilité : L'objectif de cette feuille de style et les résultats qu'elle produit à partir des messages XML sont exclusivement destinés à des fins de test. Ils ne sont explicitement PAS adaptés à une utilisation dans un cabinet médical.</value>
+        <value lang="en-us">Disclaimer: the purpose of this stylesheet and the results it produces
+            from xml messages is exclusively for testing. They are explicitly NOT suited for use in
+            a medical practise.</value>
+        <value lang="nl-nl">Disclaimer: Deze stylesheet en de resulterende html weergave van xml
+            berichten zijn uitsluitend bedoeld voor testdoeleinden. Zij zijn uitdrukkelijk niet
+            bedoeld voor gebruik in de medische praktijk.</value>
+        <value lang="fr-fr">Clause de non-responsabilité : L'objectif de cette feuille de style et
+            les résultats qu'elle produit à partir des messages XML sont exclusivement destinés à
+            des fins de test. Ils ne sont explicitement PAS adaptés à une utilisation dans un
+            cabinet médical.</value>
     </translation>
     <translation key="Table of Contents">
         <comment>Label: Table of Contents</comment>
@@ -131,7 +139,8 @@
         <value lang="fr-fr">Patient</value>
     </translation>
     <translation key="informant">
-        <comment>Label: Informant - An informant (or source of information) is a person that provides relevant information</comment>
+        <comment>Label: Informant - An informant (or source of information) is a person that
+            provides relevant information</comment>
         <value lang="en-us">Informant</value>
         <value lang="de-ch">Informiert</value>
         <value lang="fr-ch">Informé</value>
@@ -284,7 +293,8 @@
         <value lang="fr-fr">Décédé</value>
     </translation>
     <translation key="date_unknown">
-        <comment>Label: date_unknown - used for saying you know patient has died, but unknown when</comment>
+        <comment>Label: date_unknown - used for saying you know patient has died, but unknown
+            when</comment>
         <value lang="en-us">date unknown</value>
         <value lang="de-ch">Datum unbekannt</value>
         <value lang="fr-ch">date inconnue</value>
@@ -318,13 +328,15 @@
         <value lang="fr-fr">ans</value>
     </translation>
     <translation key="At the time of death">
-        <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have date functions we need content based based relativity</comment>
+        <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have
+            date functions we need content based based relativity</comment>
         <value lang="en-us">At the time of death</value>
         <value lang="nl-nl">Bij overlijden</value>
         <value lang="fr-fr">au décès</value>
     </translation>
     <translation key="At document creation time">
-        <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have date functions we need content based based relativity</comment>
+        <comment>Title on age to tell us to what the age is relative to. As XSL 1.0 doesn't have
+            date functions we need content based based relativity</comment>
         <value lang="en-us">At document creation time</value>
         <value lang="nl-nl">Bij aanmaken van het document</value>
         <value lang="fr-fr">à la date de création du document</value>
@@ -563,6 +575,8 @@
     <translation key="code">
         <comment>Label: Code</comment>
         <value lang="en-us">Code</value>
+        <value lang="fr-fr">Code</value>
+        <value lang="nl-nl">Code</value>
     </translation>
     <translation key="type">
         <comment>Label: Type</comment>
@@ -801,6 +815,7 @@
         <comment>Label: statusCode</comment>
         <value lang="en-us">Status</value>
         <value lang="fr-fr">Statut</value>
+        <value lang="nl-nl">Toestand</value>
     </translation>
     <translation key="text">
         <comment>Label: text</comment>
@@ -1469,6 +1484,13 @@
         <value lang="nl-nl">E-mail</value>
         <value lang="fr-fr">Courriel</value>
     </translation>
+    <translation key="mailto">
+        <comment>Label: E-mail</comment>
+        <value lang="en-us">Secure email address</value>
+        <value lang="de-ch">Sichere E-Mail-Adresse</value>
+        <value lang="nl-nl">Veilig e-mailadres</value>
+        <value lang="fr-fr">Adresse de messagerie</value>
+    </translation>
     <translation key="Web">
         <comment>Label: Web (telecom type)</comment>
         <value lang="en-us">Web</value>
@@ -1508,6 +1530,12 @@
         <value lang="en-us">Not available</value>
         <value lang="nl-nl">Niet beschikbaar</value>
         <value lang="fr-fr">Pas disponible</value>
+    </translation>
+    <translation key="translation">
+        <comment>Label: translation</comment>
+        <value lang="en-us">accuracy</value>
+        <value lang="nl-nl">nauwkeurigheid</value>
+        <value lang="fr-fr">précision</value>
     </translation>
     <translation key="First day of period reported">
         <comment>Label: First day of period reported</comment>
@@ -1914,7 +1942,7 @@
     <translation key="2.16.840.1.113883.5.6-SPCOBS">
         <comment>Label: ActClass specimen observationActClassSpecObs </comment>
         <value lang="en-us">specimen observationActClassSpecObs </value>
-        <value lang="fr-fr">classe d'acte d'observation d'échantillon</value>
+        <value lang="fr-fr">classe d'acte d'observation d'échantillon </value>
     </translation>
     <translation key="2.16.840.1.113883.5.6-VERIF">
         <comment>Label: ActClass Verification</comment>
@@ -2516,15 +2544,15 @@
     </translation>
     <translation key="2.16.840.1.113883.5.1002-RPLC">
         <comment>Label: Act Relationship Type RPLC</comment>
-        <value lang="en-us">replaces</value>
-        <value lang="nl-nl">vervangt</value>
-        <value lang="fr-fr">remplacement</value>
+        <value lang="en-us">Document superseded</value>
+        <value lang="nl-nl">Document vervangen</value>
+        <value lang="fr-fr">Document remplacé</value>
     </translation>
     <translation key="2.16.840.1.113883.5.1002-XFRM">
         <comment>Label: Act Relationship Type XFRM</comment>
-        <value lang="en-us">transformation</value>
-        <value lang="nl-nl">transformatie</value>
-        <value lang="fr-fr">transformation</value>
+        <value lang="en-us">Reference document</value>
+        <value lang="nl-nl">Referentie document</value>
+        <value lang="fr-fr">Document de référence</value>
     </translation>
     <translation key="2.16.840.1.113883.5.88-AULR">
         <comment>Label: ParticipationFunction legitimate relationship information receiver</comment>
@@ -3526,10 +3554,12 @@
         <value lang="fr-fr">ingredient actif - la moitée est la base de la concentration</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ACTIR">
-        <comment>Label: RoleClass active ingredient - reference substance is basis of strength</comment>
+        <comment>Label: RoleClass active ingredient - reference substance is basis of
+            strength</comment>
         <value lang="en-us">active ingredient - reference substance is basis of strength</value>
         <value lang="nl-nl">actief ingrediënt - reference substance is basis of strength</value>
-        <value lang="fr-fr">ingredient actif - la substance de référence est la base de la concentration</value>
+        <value lang="fr-fr">ingredient actif - la substance de référence est la base de la
+            concentration</value>
     </translation>
     <translation key="2.16.840.1.113883.5.110-ADTV">
         <comment>Label: RoleClass additive</comment>
@@ -4224,7 +4254,8 @@
         <value lang="fr-fr">Délivré par</value>
     </translation>
     <translation key="typeCode-INF">
-        <comment>Label: Informant - An informant (or source of information) is a person that provides relevant information</comment>
+        <comment>Label: Informant - An informant (or source of information) is a person that
+            provides relevant information</comment>
         <value lang="en-us">Informant</value>
         <value lang="de-ch">Informiert</value>
         <value lang="fr-ch">Informé</value>
@@ -4418,25 +4449,31 @@
         <value lang="fr-fr">alphabetique</value>
     </translation>
     <translation key="nameUse_IDE">
-        <comment>Label: Ideographic representation of name (e.g., Japanese kanji, Chinese characters)</comment>
+        <comment>Label: Ideographic representation of name (e.g., Japanese kanji, Chinese
+            characters)</comment>
         <value lang="en-us">Ideographic</value>
         <value lang="nl-nl">ideographisch</value>
         <value lang="fr-fr">idéographique</value>
     </translation>
     <translation key="nameUse_SYL">
-        <comment>Label: Syllabic transcription of name (e.g., Japanese kana, Korean hangul)</comment>
+        <comment>Label: Syllabic transcription of name (e.g., Japanese kana, Korean
+            hangul)</comment>
         <value lang="en-us">Syllabic</value>
         <value lang="nl-nl">syllabisch</value>
         <value lang="fr-fr">syllabique</value>
     </translation>
     <translation key="nameUse_ASGN">
-        <comment>Label: A name assigned to a person. Reasons some organizations assign alternate names may include not knowing the person's name, or to maintain anonymity. Some, but not necessarily all, of the name types that people call "alias" may fit into this category.</comment>
+        <comment>Label: A name assigned to a person. Reasons some organizations assign alternate
+            names may include not knowing the person's name, or to maintain anonymity. Some, but not
+            necessarily all, of the name types that people call "alias" may fit into this
+            category.</comment>
         <value lang="en-us">assigned</value>
         <value lang="nl-nl">toegekend</value>
         <value lang="fr-fr">attribué</value>
     </translation>
     <translation key="nameUse_C">
-        <comment>Label: As recorded on a license, record, certificate, etc. (only if different from legal name)</comment>
+        <comment>Label: As recorded on a license, record, certificate, etc. (only if different from
+            legal name)</comment>
         <value lang="en-us">License</value>
         <value lang="nl-nl">licentie</value>
         <value lang="fr-fr">officiel</value>
@@ -4454,7 +4491,9 @@
         <value lang="fr-fr">Nom d'usage</value>
     </translation>
     <translation key="nameUse_OR">
-        <comment>Label: The formal name as registered in an official (government) registry, but which name might not be commonly used. Particularly used in countries with a law system based on Napoleonic law.</comment>
+        <comment>Label: The formal name as registered in an official (government) registry, but
+            which name might not be commonly used. Particularly used in countries with a law system
+            based on Napoleonic law.</comment>
         <value lang="en-us">official registry</value>
         <value lang="nl-nl">officieel</value>
         <value lang="fr-fr">de naissance</value>
@@ -4680,7 +4719,7 @@
         <comment>Label: LOINC DOC code 11495-9</comment>
         <value lang="en-us">Initial assessment note (Physical therapy)</value>
         <value lang="nl-nl">Verslag eerste anamnese (Lichamelijke oefening)</value>
-    </translation>    
+    </translation>
     <translation key="2.16.840.1.113883.6.1-11496-7">
         <comment>Label: LOINC DOC code 11496-7</comment>
         <value lang="en-us">Initial assessment note (Podiatry)</value>
@@ -4762,7 +4801,7 @@
         <value lang="fr-fr">Note d'évaluation (Psychologie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-11512-1">
-         <comment>Label: LOINC DOC code 11512-1</comment>
+        <comment>Label: LOINC DOC code 11512-1</comment>
         <value lang="en-us">Subsequent evaluation note (Speech therapy)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Spraaktherapie)</value>
         <value lang="fr-fr">Note d'évaluation (Orthophonie)</value>
@@ -5027,7 +5066,7 @@
         <value lang="en-us">Study report (Holter monitor)</value>
         <value lang="nl-nl">Onderzoeksverslag (Holter monitor)</value>
         <value lang="fr-fr">Compte-rendu (moniteur Holter)</value>
-    </translation>    
+    </translation>
     <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18755-9">
         <comment>Label: LOINC DOC code 18755-9</comment>
@@ -5089,7 +5128,7 @@
         <value lang="en-us">Subsequent evaluation note (Nurse practitioner)</value>
         <value lang="nl-nl">Verslag vervolgonderzoek (Nurse practitioner)</value>
         <value lang="fr-fr">Note d'évaluation (Infirmière)</value>
-    </translation>    
+    </translation>
     <!-- [ANS] End: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-18836-7">
         <comment>Label: LOINC DOC code 18836-7</comment>
@@ -5113,7 +5152,8 @@
         <comment>Label: LOINC DOC code 24611-6</comment>
         <value lang="en-us">Confirmatory consultation note ({Provider})</value>
         <value lang="nl-nl">Consultverslag ter bevestiging ({Instelling})</value>
-        <value lang="fr-fr">Compte-rendu de consultation ambulatoire - 2ème avis ({Fournisseur})</value>
+        <value lang="fr-fr">Compte-rendu de consultation ambulatoire - 2ème avis
+            ({Fournisseur})</value>
     </translation>
     <!-- [ANS] Start: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28032-1">
@@ -5250,7 +5290,7 @@
         <value lang="en-us">Initial evaluation note (Nurse practitioner)</value>
         <value lang="nl-nl">Verslag eerste onderzoek (Nurse practitioner)</value>
         <value lang="fr-fr">Note d'évaluation initiale (Infirmière)</value>
-    </translation>    
+    </translation>
     <!-- [ANS] Star: deprecated LOINC Codes -->
     <translation key="2.16.840.1.113883.6.1-28622-9">
         <comment>Label: LOINC DOC code 28622-9</comment>
@@ -5784,13 +5824,15 @@
     <translation key="2.16.840.1.113883.6.1-34880-5">
         <comment>Label: LOINC DOC code 34880-5</comment>
         <value lang="en-us">Post-operative evaluation and management note (Nurse.surgery)</value>
-        <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Operatieverpleegkundige)</value>
+        <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag
+            (Operatieverpleegkundige)</value>
         <value lang="fr-fr">Note d'évaluation post-opératoire (Infirmière.chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34881-3">
         <comment>Label: LOINC DOC code 34881-3</comment>
         <value lang="en-us">Pre-operative evaluation and management note (Nurse.surgery)</value>
-        <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag (Operatieverpleegkundige)</value>
+        <value lang="nl-nl">Preoperatief onderzoek en voortgangsverslag
+            (Operatieverpleegkundige)</value>
         <value lang="fr-fr">Note d'évaluation pré-opératoire (Infirmière.chirurgie)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34861-5">
@@ -5808,7 +5850,8 @@
     <translation key="2.16.840.1.113883.6.1-34863-1">
         <comment>Label: LOINC DOC code 34863-1</comment>
         <value lang="en-us">Post-operative evaluation and management note (General surgery)</value>
-        <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Algemene chirurgie)</value>
+        <value lang="nl-nl">Postoperatief onderzoek en voortgangsverslag (Algemene
+            chirurgie)</value>
         <value lang="fr-fr">Note d'évaluation post-opératoire (Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34864-9">
@@ -6023,20 +6066,25 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-34767-4">
         <comment>Label: LOINC DOC code 34767-4</comment>
-        <value lang="en-us">Evaluation and management note (Medical student.general medicine)</value>
-        <value lang="nl-nl">Evaluatie en voortgangsverslag (Medisch student.algemene geneeskunde)</value>
+        <value lang="en-us">Evaluation and management note (Medical student.general
+            medicine)</value>
+        <value lang="nl-nl">Evaluatie en voortgangsverslag (Medisch student.algemene
+            geneeskunde)</value>
         <value lang="fr-fr">Note d'évaluation (Etudiant en médecine.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34768-2">
         <comment>Label: LOINC DOC code 34768-2</comment>
         <value lang="en-us">Evaluation and management note (Nurse.general medicine)</value>
-        <value lang="nl-nl">Evaluatie en voortgangsverslag (Verpleegkundige.algemene geneeskunde)</value>
+        <value lang="nl-nl">Evaluatie en voortgangsverslag (Verpleegkundige.algemene
+            geneeskunde)</value>
         <value lang="fr-fr">Note d'évaluation (Infirmière.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34769-0">
         <comment>Label: LOINC DOC code 34769-0</comment>
-        <value lang="en-us">Evaluation and management note (Attending physician.general medicine)</value>
-        <value lang="nl-nl">Evaluatie en voortgangsverslag (Behandelend arts.algemene geneeskunde)</value>
+        <value lang="en-us">Evaluation and management note (Attending physician.general
+            medicine)</value>
+        <value lang="nl-nl">Evaluatie en voortgangsverslag (Behandelend arts.algemene
+            geneeskunde)</value>
         <value lang="fr-fr">Note d'évaluation (Médecin.Médecine générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34770-8">
@@ -6059,8 +6107,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-34773-2">
         <comment>Label: LOINC DOC code 34773-2</comment>
-        <value lang="en-us">Evaluation and management note (Attending physician.general surgery)</value>
-        <value lang="nl-nl">Evaluatie en voortgangsverslag (Attending physician.general surgery)</value>
+        <value lang="en-us">Evaluation and management note (Attending physician.general
+            surgery)</value>
+        <value lang="nl-nl">Evaluatie en voortgangsverslag (Attending physician.general
+            surgery)</value>
         <value lang="fr-fr">Note d'évaluation (Médecin.Chirurgie générale)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34774-0">
@@ -6311,8 +6361,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-34823-5">
         <comment>Label: LOINC DOC code 34823-5</comment>
-        <value lang="en-us">Evaluation and management note (Physical medicine and rehabilitation)</value>
-        <value lang="nl-nl">Evaluatie en voortgangsverslag (Physical medicine and rehabilitation)</value>
+        <value lang="en-us">Evaluation and management note (Physical medicine and
+            rehabilitation)</value>
+        <value lang="nl-nl">Evaluatie en voortgangsverslag (Physical medicine and
+            rehabilitation)</value>
         <value lang="fr-fr">Note d'évaluation (Médecine physique et réadaptation)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-34824-3">
@@ -6393,7 +6445,7 @@
         <value lang="en-us">Evaluation and management note (Rehabilitation)</value>
         <value lang="nl-nl">Evaluatie en voortgangsverslag (Rehabilitation)</value>
         <value lang="fr-fr">Note d'évaluation (Réhabilitation)</value>
-    </translation>    
+    </translation>
     <!-- Deprecated LOINC Code: End -->
     <translation key="2.16.840.1.113883.6.1-34837-5">
         <comment>Label: LOINC DOC code 34837-5</comment>
@@ -6625,8 +6677,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38933-8">
         <comment>Label: LOINC DOC code 38933-8</comment>
-        <value lang="en-us">VA C&amp;P exam.aid and attendance &amp;or housebound ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.aid and attendance &amp;or housebound ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.aid and attendance &amp;or housebound
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.aid and attendance &amp;or housebound
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38934-6">
         <comment>Label: LOINC DOC code 38934-6</comment>
@@ -6635,8 +6689,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38935-3">
         <comment>Label: LOINC DOC code 38935-3</comment>
-        <value lang="en-us">VA C&amp;P exam.miscellaneous arteries &amp;or veins ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.miscellaneous arteries &amp;or veins ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.miscellaneous arteries &amp;or veins
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.miscellaneous arteries &amp;or veins
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38936-1">
         <comment>Label: LOINC DOC code 38936-1</comment>
@@ -6645,8 +6701,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38937-9">
         <comment>Label: LOINC DOC code 38937-9</comment>
-        <value lang="en-us">VA C&amp;P exam.bones fractures &amp;or bone disease ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.bones fractures &amp;or bone disease ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.bones fractures &amp;or bone disease
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.bones fractures &amp;or bone disease
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38938-7">
         <comment>Label: LOINC DOC code 38938-7</comment>
@@ -6685,13 +6743,17 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38987-4">
         <comment>Label: LOINC DOC code 38987-4</comment>
-        <value lang="en-us">VA C&amp;P exam.stomach &amp;or duodenum &amp;or peritoneal adhesions ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.stomach &amp;or duodenum &amp;or peritoneal adhesions ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.stomach &amp;or duodenum &amp;or peritoneal adhesions
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.stomach &amp;or duodenum &amp;or peritoneal adhesions
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38988-2">
         <comment>Label: LOINC DOC code 38988-2</comment>
-        <value lang="en-us">VA C&amp;P exam.thyroid &amp;or parathyroid diseases ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.thyroid &amp;or parathyroid diseases ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.thyroid &amp;or parathyroid diseases
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.thyroid &amp;or parathyroid diseases
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38943-7">
         <comment>Label: LOINC DOC code 38943-7</comment>
@@ -6706,7 +6768,8 @@
     <translation key="2.16.840.1.113883.6.1-38945-2">
         <comment>Label: LOINC DOC code 38945-2</comment>
         <value lang="en-us">VA C&amp;P exam.miscellaneous digestive conditions ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.miscellaneous digestive conditions ({Instelling})</value>
+        <value lang="nl-nl">VA C&amp;P exam.miscellaneous digestive conditions
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38946-0">
         <comment>Label: LOINC DOC code 38946-0</comment>
@@ -6765,13 +6828,16 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38957-7">
         <comment>Label: LOINC DOC code 38957-7</comment>
-        <value lang="en-us">VA C&amp;P exam.gynecological conditions &amp;or disorders of the breast ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.gynecological conditions &amp;or disorders of the breast ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.gynecological conditions &amp;or disorders of the breast
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.gynecological conditions &amp;or disorders of the breast
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38958-5">
         <comment>Label: LOINC DOC code 38958-5</comment>
         <value lang="en-us">VA C&amp;P exam.hand &amp;or thumb &amp;or fingers ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.hand &amp;or thumb &amp;or fingers ({Instelling})</value>
+        <value lang="nl-nl">VA C&amp;P exam.hand &amp;or thumb &amp;or fingers
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38959-3">
         <comment>Label: LOINC DOC code 38959-3</comment>
@@ -6795,13 +6861,17 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38963-5">
         <comment>Label: LOINC DOC code 38963-5</comment>
-        <value lang="en-us">VA C&amp;P exam.infectious &amp;or immune &amp;or nutritional disabilities ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.infectious &amp;or immune &amp;or nutritional disabilities ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.infectious &amp;or immune &amp;or nutritional
+            disabilities ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.infectious &amp;or immune &amp;or nutritional
+            disabilities ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38964-3">
         <comment>Label: LOINC DOC code 38964-3</comment>
-        <value lang="en-us">VA C&amp;P exam.initial evaluation post-traumatic stress disorder ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.initial evaluation post-traumatic stress disorder ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.initial evaluation post-traumatic stress disorder
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.initial evaluation post-traumatic stress disorder
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38965-0">
         <comment>Label: LOINC DOC code 38965-0</comment>
@@ -6815,8 +6885,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38967-6">
         <comment>Label: LOINC DOC code 38967-6</comment>
-        <value lang="en-us">VA C&amp;P exam.liver &amp;or gall bladder &amp;or pancreas ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.liver &amp;or gall bladder &amp;or pancreas ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.liver &amp;or gall bladder &amp;or pancreas
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.liver &amp;or gall bladder &amp;or pancreas
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38968-4">
         <comment>Label: LOINC DOC code 38968-4</comment>
@@ -6840,13 +6912,17 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38972-6">
         <comment>Label: LOINC DOC code 38972-6</comment>
-        <value lang="en-us">VA C&amp;P exam.miscellaneous neurological disorders ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.miscellaneous neurological disorders ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.miscellaneous neurological disorders
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.miscellaneous neurological disorders
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38973-4">
         <comment>Label: LOINC DOC code 38973-4</comment>
-        <value lang="en-us">VA C&amp;P exam.nose &amp;or sinus &amp;or larynx &amp;or pharynx ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.nose &amp;or sinus &amp;or larynx &amp;or pharynx ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.nose &amp;or sinus &amp;or larynx &amp;or pharynx
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.nose &amp;or sinus &amp;or larynx &amp;or pharynx
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38974-2">
         <comment>Label: LOINC DOC code 38974-2</comment>
@@ -6860,8 +6936,10 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38976-7">
         <comment>Label: LOINC DOC code 38976-7</comment>
-        <value lang="en-us">VA C&amp;P exam.pulmonary tuberculosis &amp;or mycobacterial diseases ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.pulmonary tuberculosis &amp;or mycobacterial diseases ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.pulmonary tuberculosis &amp;or mycobacterial diseases
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.pulmonary tuberculosis &amp;or mycobacterial diseases
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38977-5">
         <comment>Label: LOINC DOC code 38977-5</comment>
@@ -6875,18 +6953,23 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-38979-1">
         <comment>Label: LOINC DOC code 38979-1</comment>
-        <value lang="en-us">VA C&amp;P exam.obstructive &amp;or restrictive &amp;or interstitial respiratory diseases ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.obstructive &amp;or restrictive &amp;or interstitial respiratory diseases ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.obstructive &amp;or restrictive &amp;or interstitial
+            respiratory diseases ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.obstructive &amp;or restrictive &amp;or interstitial
+            respiratory diseases ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38980-9">
         <comment>Label: LOINC DOC code 38980-9</comment>
         <value lang="en-us">VA C&amp;P exam.miscellaneous respiratory diseases ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.miscellaneous respiratory diseases ({Instelling})</value>
+        <value lang="nl-nl">VA C&amp;P exam.miscellaneous respiratory diseases
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38981-7">
         <comment>Label: LOINC DOC code 38981-7</comment>
-        <value lang="en-us">VA C&amp;P exam.review evaluation post-traumatic stress disorder ({Provider})</value>
-        <value lang="nl-nl">VA C&amp;P exam.review evaluation post-traumatic stress disorder ({Instelling})</value>
+        <value lang="en-us">VA C&amp;P exam.review evaluation post-traumatic stress disorder
+            ({Provider})</value>
+        <value lang="nl-nl">VA C&amp;P exam.review evaluation post-traumatic stress disorder
+            ({Instelling})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-38982-5">
         <comment>Label: LOINC DOC code 38982-5</comment>
@@ -6902,9 +6985,9 @@
         <comment>Label: LOINC DOC code 38984-1</comment>
         <value lang="en-us">VA C&amp;P exam.skin diseases other than scars ({Provider})</value>
         <value lang="nl-nl">VA C&amp;P exam.skin diseases other than scars ({Instelling})</value>
-    </translation>    
+    </translation>
     <!-- US VA (Veterans Affairs) documents: End -->
-    
+
     <translation key="2.16.840.1.113883.6.1-46208-5">
         <comment>Label: LOINC DOC code 46208-5</comment>
         <value lang="en-us">Nursing notes</value>
@@ -6947,7 +7030,8 @@
         <comment>Label: LOINC DOC code 46264-8</comment>
         <value lang="en-us">History of medical device use ({Provider})</value>
         <value lang="nl-nl">History of medical device use ({Instelling})</value>
-        <value lang="fr-fr">Antécédents d'utilisation de dispositifs médicaux ({Fournisseurs})</value>
+        <value lang="fr-fr">Antécédents d'utilisation de dispositifs médicaux
+            ({Fournisseurs})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47039-3">
         <comment>Label: LOINC DOC code 47039-3</comment>
@@ -7005,7 +7089,8 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-47048-4">
         <comment>Label: LOINC DOC code 47048-4</comment>
-        <value lang="en-us">Diagnostic interventional study report (Interventional radiology)</value>
+        <value lang="en-us">Diagnostic interventional study report (Interventional
+            radiology)</value>
         <value lang="fr-fr">Compte-rendu (Radiologie interventionnelle)</value>
     </translation>
     <!-- Deprecated LOINC Code: Start -->
@@ -7042,25 +7127,29 @@
         <comment>Label: LOINC DOC code 47521-0</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Ponction mammaire (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Ponction mammaire (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47522-8">
         <comment>Label: LOINC DOC code 47522-8</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Écoulement du mamelon (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Écoulement du mamelon (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47523-6">
         <comment>Label: LOINC DOC code 47523-6</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Fluide corporel (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Fluide corporel (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47524-4">
         <comment>Label: LOINC DOC code 47524-4</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Ponction de la thyroïde (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Ponction de la thyroïde (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47525-1">
         <comment>Label: LOINC DOC code 47525-1</comment>
@@ -7078,13 +7167,15 @@
         <comment>Label: LOINC DOC code 47527-7</comment>
         <value lang="en-us">Cytology report (Cyto stain.thin prep)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain.thin prep)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47528-5">
         <comment>Label: LOINC DOC code 47528-5</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Frottis cervical ou vaginal (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-47529-3">
         <comment>Label: LOINC DOC code 47529-3</comment>
@@ -7096,7 +7187,8 @@
         <comment>Label: LOINC DOC code 47530-1</comment>
         <value lang="en-us">Cytology report (Cyto stain)</value>
         <value lang="nl-nl">Cytologieverslag (Cyto stain)</value>
-        <value lang="fr-fr">Compte-rendu cytologique Lavage canalaire mammaire (Coloration cytologique)</value>
+        <value lang="fr-fr">Compte-rendu cytologique Lavage canalaire mammaire (Coloration
+            cytologique)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-48768-6">
         <comment>Label: LOINC DOC code 48768-6</comment>
@@ -7173,7 +7265,8 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-52038-7">
         <comment>Label: LOINC DOC code 52038-7</comment>
-        <value lang="en-us">Subscriber Information including retroactive and presumptive eligibility attachment</value>
+        <value lang="en-us">Subscriber Information including retroactive and presumptive eligibility
+            attachment</value>
         <value lang="fr-fr">Informations sur l'abonné pour l'éligibilité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52039-5">
@@ -7201,7 +7294,8 @@
         <comment>Label: LOINC DOC code 51897-7</comment>
         <value lang="en-us">Healthcare Associated Infection report ({Provider})</value>
         <value lang="nl-nl">Healthcare Associated Infection report ({Instelling})</value>
-        <value lang="fr-fr">Compte-rendu sur les infections associées aux soins ({Fournisseur})</value>
+        <value lang="fr-fr">Compte-rendu sur les infections associées aux soins
+            ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-51898-5">
         <comment>Label: LOINC DOC code 51898-5</comment>
@@ -7309,7 +7403,8 @@
     <translation key="2.16.840.1.113883.6.1-52042-9">
         <comment>Label: LOINC DOC code 52042-9</comment>
         <value lang="en-us">Continuous positive airway pressure attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge de la ventilation en pression positive continue (PPC)</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la ventilation en pression
+            positive continue (PPC)</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52043-7">
         <comment>Label: LOINC DOC code 52043-7</comment>
@@ -7319,7 +7414,8 @@
     <translation key="2.16.840.1.113883.6.1-52044-5">
         <comment>Label: LOINC DOC code 52044-5</comment>
         <value lang="en-us">External infusion pump attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge de la pompe à perfusion externe</value>
+        <value lang="fr-fr">Informations pour la prise en charge de la pompe à perfusion
+            externe</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52045-2">
         <comment>Label: LOINC DOC code 52045-2</comment>
@@ -7344,12 +7440,14 @@
     <translation key="2.16.840.1.113883.6.1-52049-4">
         <comment>Label: LOINC DOC code 52049-4</comment>
         <value lang="en-us">Manual wheelchair attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant manuel</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant
+            manuel</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52050-2">
         <comment>Label: LOINC DOC code 52050-2</comment>
         <value lang="en-us">Motorized wheelchair attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant motorisé</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un fauteuil roulant
+            motorisé</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52051-0">
         <comment>Label: LOINC DOC code 52051-0</comment>
@@ -7359,7 +7457,8 @@
     <translation key="2.16.840.1.113883.6.1-52052-8">
         <comment>Label: LOINC DOC code 52052-8</comment>
         <value lang="en-us">Osteogenesis stimulators attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'un stimulateur de croissance osseuse</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un stimulateur de croissance
+            osseuse</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52053-6">
         <comment>Label: LOINC DOC code 52053-6</comment>
@@ -7379,12 +7478,14 @@
     <translation key="2.16.840.1.113883.6.1-52056-9">
         <comment>Label: LOINC DOC code 52056-9</comment>
         <value lang="en-us">Repair of durable medical equipment attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'une réparation de matériel médical durable</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'une réparation de matériel
+            médical durable</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52057-7">
         <comment>Label: LOINC DOC code 52057-7</comment>
         <value lang="en-us">Seat lift mechanism attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'un mécanisme de levage du siège</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un mécanisme de levage du
+            siège</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52058-5">
         <comment>Label: LOINC DOC code 52058-5</comment>
@@ -7399,7 +7500,8 @@
     <translation key="2.16.840.1.113883.6.1-52060-1">
         <comment>Label: LOINC DOC code 52060-1</comment>
         <value lang="en-us">Standers + standing frames attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge d'un dispositif de stabilisation</value>
+        <value lang="fr-fr">Informations pour la prise en charge d'un dispositif de
+            stabilisation</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52061-9">
         <comment>Label: LOINC DOC code 52061-9</comment>
@@ -7409,7 +7511,8 @@
     <translation key="2.16.840.1.113883.6.1-52062-7">
         <comment>Label: LOINC DOC code 52062-7</comment>
         <value lang="en-us">Transcutaneous electrical neural stimulation attachment</value>
-        <value lang="fr-fr">Informations pour la prise en charge de neurostimulation électrique transcutanée</value>
+        <value lang="fr-fr">Informations pour la prise en charge de neurostimulation électrique
+            transcutanée</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52063-5">
         <comment>Label: LOINC DOC code 52063-5</comment>
@@ -7439,7 +7542,8 @@
     <translation key="2.16.840.1.113883.6.1-52068-4">
         <comment>Label: LOINC DOC code 52068-4</comment>
         <value lang="en-us">Property and casualty state mandated forms attachment</value>
-        <value lang="fr-fr">Formulaires obligatoires de l'État pour les biens et les accidents</value>
+        <value lang="fr-fr">Formulaires obligatoires de l'État pour les biens et les
+            accidents</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-52069-2">
         <comment>Label: LOINC DOC code 52069-2</comment>
@@ -7483,7 +7587,8 @@
     <translation key="2.16.840.1.113883.6.1-53244-0">
         <comment>Label: LOINC DOC code 53244-0</comment>
         <value lang="en-us">Notice of privacy practices receipt attachment</value>
-        <value lang="fr-fr">Accusé de réception d'information sur la politique de confidentialité</value>
+        <value lang="fr-fr">Accusé de réception d'information sur la politique de
+            confidentialité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-53245-7">
         <comment>Label: LOINC DOC code 53245-7</comment>
@@ -7587,7 +7692,8 @@
     </translation>
     <translation key="2.16.840.1.113883.6.1-55184-6">
         <comment>Label: LOINC DOC code 55184-6</comment>
-        <value lang="en-us">Quality Reporting Document Architecture calculated summary report</value>
+        <value lang="en-us">Quality Reporting Document Architecture calculated summary
+            report</value>
         <value lang="fr-fr">Résumé des rapports de mesures de la qualité</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-55185-3">
@@ -7646,7 +7752,8 @@
     <translation key="2.16.840.1.113883.6.1-57056-4">
         <comment>Label: LOINC DOC code 57056-4</comment>
         <value lang="en-us">Labor and delivery admission history and physical ({Provider})</value>
-        <value lang="nl-nl">Voorgeschiedenis en lichamelijke conditie bij opname zwangerschap en geboorte ({Instelling})</value>
+        <value lang="nl-nl">Voorgeschiedenis en lichamelijke conditie bij opname zwangerschap en
+            geboorte ({Instelling})</value>
         <value lang="fr-fr">Synthèse d'admission pour l'accouchement ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57057-2">
@@ -7715,7 +7822,8 @@
         <comment>Label: LOINC DOC code 57054-9</comment>
         <value lang="en-us">Triage and nursing note ({Provider})</value>
         <value lang="nl-nl">Verslag triage en verpleging ({Instelling})</value>
-        <value lang="fr-fr">Note de triage et infirmier du service des urgences ({Fournisseur})</value>
+        <value lang="fr-fr">Note de triage et infirmier du service des urgences
+            ({Fournisseur})</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57055-6">
         <comment>Label: LOINC DOC code 57055-6</comment>
@@ -7726,7 +7834,8 @@
     <translation key="2.16.840.1.113883.6.1-57129-9">
         <comment>Label: LOINC DOC code 57129-9</comment>
         <value lang="en-us">Full newborn screening summary report for display or printing</value>
-        <value lang="nl-nl">Volledig verslag screening nieuwgeborene voor weergave en afdrukken</value>
+        <value lang="nl-nl">Volledig verslag screening nieuwgeborene voor weergave en
+            afdrukken</value>
         <value lang="fr-fr">Synthèse du dépistage néonatal</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-57133-1">
@@ -8515,8 +8624,10 @@
     <translation key="2.16.840.1.113883.6.1-46240-8">
         <comment>Label: LOINC DOC code 46240-8</comment>
         <value lang="en-us">History of hospitalizations+History of outpatient visits</value>
-        <value lang="nl-nl">Geschiedenis van ziekenhuisopnames+Geschiedenis van poliklinische bezoeken</value>
-        <value lang="fr-fr">Historique des hospitalisations + Historique des consultations ambulatoires</value>
+        <value lang="nl-nl">Geschiedenis van ziekenhuisopnames+Geschiedenis van poliklinische
+            bezoeken</value>
+        <value lang="fr-fr">Historique des hospitalisations + Historique des consultations
+            ambulatoires</value>
     </translation>
     <translation key="2.16.840.1.113883.6.1-46241-6">
         <comment>Label: LOINC DOC code 46241-6</comment>
@@ -9023,23 +9134,23 @@
     <translation key="2.16.840.1.113883.2.4.6.70">
         <comment>Label: OID SBV-Z Identificatiedocumenttypes</comment>
         <value lang="nl-nl">SBV-Z Identificatiedocumenttypes</value>
-    </translation>    
+    </translation>
     <!-- OID NL: End -->
-    
+
     <!-- OID Military Health System (MHS): Start -->
     <translation key="2.16.840.1.113883.3.42">
         <comment>Label: DoD Military Health System (MHS)</comment>
         <value lang="en-us">DoD MHS</value>
-    </translation>    
+    </translation>
     <!-- OID Military Health System (MHS): End -->
-    
+
     <!-- OID HL7 Inc Demo OID: Start -->
     <translation key="2.16.840.1.113883.3.933">
         <comment>Label: HL7 Inc Demo OID</comment>
         <value lang="en-us">HL7 Demo</value>
     </translation>
     <!-- OID HL7 Inc Demo OID: End -->
-    
+
     <!-- OID United States: Start -->
     <translation key="2.16.840.1.113883.4.1">
         <comment>Label: OID US Social Security Number</comment>
@@ -9050,7 +9161,7 @@
         <value lang="en-us">NPI</value>
     </translation>
     <!-- OID United States: End -->
-    
+
     <!-- OID HL7 v3 codeSystems: Start -->
     <translation key="2.16.840.1.113883.5.1">
         <comment>Label: OID AdministrativeGender</comment>
@@ -9197,9 +9308,9 @@
     <translation key="2.16.840.1.113883.5.89">
         <comment>Label: OID ParticipationSignature</comment>
         <value lang="en-us">ParticipationSignature</value>
-    </translation>    
+    </translation>
     <!-- OID HL7 v3 codeSystems: End -->
-    
+
     <!-- OID externalCodeSystems: Start -->
     <translation key="2.16.840.1.113883.6.1">
         <comment>Label: OID LOINC</comment>
@@ -9244,36 +9355,54 @@
     </translation>
     <!-- OID externalCodeSystems: End -->
     <!-- End: OIDs -->
-    
+
     <translation key="iframe-warning-ie9">
         <comment>Label: unsupported browser for iframe</comment>
-        <value lang="en-us">WARNING: This browser does not support sandboxed iframes which makes rendering here potentially unsafe. Please try a different browser.</value>
-        <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen sandboxed iframes wat weergave op deze plaats onveilig maakt. Probeer een modernere browser.</value>
-        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes bac à sable, ce qui rend le rendu ici potentiellement dangereux. Veuillez essayer un autre navigateur.</value>
+        <value lang="en-us">WARNING: This browser does not support sandboxed iframes which makes
+            rendering here potentially unsafe. Please try a different browser.</value>
+        <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen sandboxed iframes wat
+            weergave op deze plaats onveilig maakt. Probeer een modernere browser.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes bac à
+            sable, ce qui rend le rendu ici potentiellement dangereux. Veuillez essayer un autre
+            navigateur.</value>
     </translation>
     <translation key="iframe-warning-pdf-ie9">
         <comment>Label: unsupported browser for iframe with pdf</comment>
-        <value lang="en-us">WARNING: This browser does not support (sandboxed) iframes with inline pdf which makes rendering here potentially unsafe and/or impossible. Please try a different browser.</value>
-        <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen (sandboxed) iframes met inline pdf wat weergave op deze plaats onveilig en/of onmogelijk maakt. Probeer een modernere browser.</value>
-        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes (sandbox) avec pdf en ligne, ce qui rend le rendu ici potentiellement dangereux et/ou impossible. Veuillez essayer un autre navigateur.</value>
+        <value lang="en-us">WARNING: This browser does not support (sandboxed) iframes with inline
+            pdf which makes rendering here potentially unsafe and/or impossible. Please try a
+            different browser.</value>
+        <value lang="nl-nl">WAARSCHUWING: Deze browser ondersteunt geen (sandboxed) iframes met
+            inline pdf wat weergave op deze plaats onveilig en/of onmogelijk maakt. Probeer een
+            modernere browser.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Ce navigateur ne prend pas en charge les iframes
+            (sandbox) avec pdf en ligne, ce qui rend le rendu ici potentiellement dangereux et/ou
+            impossible. Veuillez essayer un autre navigateur.</value>
     </translation>
     <translation key="iframe-warning-sandboxed-pdf">
         <comment>Label: unsupported browser for iframe with pdf (limit-pdf = yes)</comment>
-        <value lang="en-us">WARNING: Due to the security setting of this rendering, it is not possible to show the pdf.</value>
-        <value lang="nl-nl">WAARSCHUWING: Vanwege de beveiligingsinstellingen voor deze weergaven, is het niet mogelijk om de pdf weer te geven.</value>
-        <value lang="fr-fr">ATTENTION : En raison des paramètres de sécurité, il n'est pas possible d'afficher le pdf.</value>
+        <value lang="en-us">WARNING: Due to the security setting of this rendering, it is not
+            possible to show the pdf.</value>
+        <value lang="nl-nl">WAARSCHUWING: Vanwege de beveiligingsinstellingen voor deze weergaven,
+            is het niet mogelijk om de pdf weer te geven.</value>
+        <value lang="fr-fr">ATTENTION : En raison des paramètres de sécurité, il n'est pas possible
+            d'afficher le pdf.</value>
     </translation>
     <translation key="javascript-injection-warning">
         <comment>Label: security warning text</comment>
-        <value lang="en-us">WARNING: Javascript injection attempt detected in source CDA document. Terminating</value>
-        <value lang="nl-nl">WAARSCHUWING: Javascript-injectiepoging gedetecteerd in bron CDA-document. Einde verwerking</value>
-        <value lang="fr-fr">AVERTISSEMENT : Tentative d'injection Javascript détectée dans le document source CDA.</value>
+        <value lang="en-us">WARNING: Javascript injection attempt detected in source CDA document.
+            Terminating</value>
+        <value lang="nl-nl">WAARSCHUWING: Javascript-injectiepoging gedetecteerd in bron
+            CDA-document. Einde verwerking</value>
+        <value lang="fr-fr">AVERTISSEMENT : Tentative d'injection Javascript détectée dans le
+            document source CDA.</value>
     </translation>
     <translation key="malicious-content-warning">
         <comment>Label: security warning text</comment>
         <value lang="en-us">WARNING: Potentially malicious content found in CDA document.</value>
-        <value lang="nl-nl">WAARSCHUWING: potentieel gevaarlijke inhoud gevonden in CDA-document.</value>
-        <value lang="fr-fr">AVERTISSEMENT : contenu potentiellement malveillant trouvé dans le document CDA.</value>
+        <value lang="nl-nl">WAARSCHUWING: potentieel gevaarlijke inhoud gevonden in
+            CDA-document.</value>
+        <value lang="fr-fr">AVERTISSEMENT : contenu potentiellement malveillant trouvé dans le
+            document CDA.</value>
     </translation>
     <translation key="is-in-the-whitelist">
         <comment>Label: security warning text</comment>
@@ -9289,9 +9418,12 @@
     </translation>
     <translation key="non-local-image-found-2">
         <comment>Label: security warning text part2</comment>
-        <value lang="en-us">. Removing. If you wish to preserve non-local images please set the limit-external-images param to 'no'.</value>
-        <value lang="nl-nl">. Wordt niet verwerkt. Als u niet-lokale afbeelding wilt behouden, dan stelt u de parameter limit-external-images in op 'no'.</value>
-        <value lang="fr-fr">. Retrait. Si vous souhaitez conserver des images non locales, définissez le paramètre limit-external-images sur 'no'.</value>
+        <value lang="en-us">. Removing. If you wish to preserve non-local images please set the
+            limit-external-images param to 'no'.</value>
+        <value lang="nl-nl">. Wordt niet verwerkt. Als u niet-lokale afbeelding wilt behouden, dan
+            stelt u de parameter limit-external-images in op 'no'.</value>
+        <value lang="fr-fr">. Retrait. Si vous souhaitez conserver des images non locales,
+            définissez le paramètre limit-external-images sur 'no'.</value>
     </translation>
     <translation key="logicalOR">
         <comment>Label: logicalOR (e.g. query params with multiple value elements)</comment>
@@ -9381,25 +9513,38 @@
         <comment>Error message: Warning: Bundle type does not indicate it is a document.</comment>
         <value lang="en-us">Warning: Bundle type does not indicate it is a document.</value>
         <value lang="nl-nl">Waarschuwing: Bundle type zegt niet dat dit een document is.</value>
-        <value lang="fr-fr">AVERTISSEMENT : Le type de Bundle n'indique pas qu'il s'agit d'un document.</value>
+        <value lang="fr-fr">AVERTISSEMENT : Le type de Bundle n'indique pas qu'il s'agit d'un
+            document.</value>
     </translation>
     <translation key="err-fhir-4">
-        <comment>Error message: Error: The document composition includes a reference to a resource not contained inside the document bundle:</comment>
-        <value lang="en-us">Error: The document composition includes a reference to a resource not contained inside the document bundle: </value>
-        <value lang="nl-nl">Fout: Er is een verwijzing in de document Composition naar een resource die ontbreekt in de Bundle: </value>
-        <value lang="fr-fr">ERREUR : La composition du document inclut une référence à une ressource non contenue dans le Bundle :</value>
+        <comment>Error message: Error: The document composition includes a reference to a resource
+            not contained inside the document bundle:</comment>
+        <value lang="en-us">Error: The document composition includes a reference to a resource not
+            contained inside the document bundle: </value>
+        <value lang="nl-nl">Fout: Er is een verwijzing in de document Composition naar een resource
+            die ontbreekt in de Bundle: </value>
+        <value lang="fr-fr">ERREUR : La composition du document inclut une référence à une ressource
+            non contenue dans le Bundle :</value>
     </translation>
     <translation key="err-fhir-5">
-        <comment>Error message: Error: A referenced resource is not contained and is not fully qualified:</comment>
-        <value lang="en-us">Error: A referenced resource is not contained and is not fully qualified: </value>
-        <value lang="nl-nl">Fout: Er is een verwijzing naar een resource die ontbreekt en waarvan de verwijzing niet volledig is: </value>
-        <value lang="fr-fr">ERREUR : Une ressource référencée n'est pas contenue et n'est pas entièrement qualifiée : </value>
+        <comment>Error message: Error: A referenced resource is not contained and is not fully
+            qualified:</comment>
+        <value lang="en-us">Error: A referenced resource is not contained and is not fully
+            qualified: </value>
+        <value lang="nl-nl">Fout: Er is een verwijzing naar een resource die ontbreekt en waarvan de
+            verwijzing niet volledig is: </value>
+        <value lang="fr-fr">ERREUR : Une ressource référencée n'est pas contenue et n'est pas
+            entièrement qualifiée : </value>
     </translation>
     <translation key="err-fhir-6">
-        <comment>Error message: Warning: Headings exceed 6 levels deep. Remaining headings converted to simple paragraphs</comment>
-        <value lang="en-us">Warning: Headings exceed 6 levels deep. Remaining headings converted to simple paragraphs</value>
-        <value lang="nl-nl">Waarschuwing: Kopniveau's gaan dieper dan 6. De overgebleven kopniveau's worden omgezet naar normale paragrafen</value>
-        <value lang="fr-fr">AVERTISSEMENT : Les titres dépassent 6 niveaux de profondeur. Titres restants convertis en paragraphes simples.</value>
+        <comment>Error message: Warning: Headings exceed 6 levels deep. Remaining headings converted
+            to simple paragraphs</comment>
+        <value lang="en-us">Warning: Headings exceed 6 levels deep. Remaining headings converted to
+            simple paragraphs</value>
+        <value lang="nl-nl">Waarschuwing: Kopniveau's gaan dieper dan 6. De overgebleven kopniveau's
+            worden omgezet naar normale paragrafen</value>
+        <value lang="fr-fr">AVERTISSEMENT : Les titres dépassent 6 niveaux de profondeur. Titres
+            restants convertis en paragraphes simples.</value>
     </translation>
     <translation key="err-fhir-7">
         <comment>Error message: Source document must be a composition</comment>


### PR DESCRIPTION
- Gender: do not display translations.
- INS registration number: only display the label if there is an INS (several OIDs possible for INS).
- Secure e-mail address: delete "secure". At the bottom, the wording is "secure e-mail" to be replaced by "E-mail address"
- Replaced document: set the label according to the typeCode:
   <relatedDocument typeCode="XFRM">: "Reference document" and for this   value, display the id of the reference document
   <relatedDocument typeCode="RPLC">: "Replaced Document"
- Author: the author is not always a person (HP or patient), it can be a device (see Minimal structuring). In this case, the display does not seem to work well (no "Author" label and no device name).
- Empty line under author to delete.

For all the elements of the header, the modification is made at the top and at the bottom of the displayed document.

At the top of the document:

- Patient's name: add the use between square brackets to differentiate the types of surnames and first names
- Date of birth: add a space before "years"
- "Sex:" add a space between the age and the wording "Sex"
- Author: review the display order suffix, prefix, first name, last name (with a space between each)

At the bottom of the document:

- Patient's name: add the use between square brackets to differentiate the types of surnames and first names
- “Performer –”: remove the dash
- Performer: the name, first name, prefix and suffix seem to be displayed in the order of the CDA because we see that it is different between the 1st and the 2nd performer. They should be displayed in the order suffix, prefix, first name, last name (with a space between each)
- Performer: replace “of” in front of the organization with parentheses
- "translation" to be translated as "precision"

Responsible Party and admitting physician:
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- same rule on organization in parentheses.

Author :
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- same rule on organization in parentheses.

Participant:
- functionCode: we put:

<participant typeCode="RESP">
       <functionCode nullFlavor="NA">
           <!-- Commentaire sur le PS -->
           <originalText>Commentaire sur le Dr MEDIONI</originalText>
        </functionCode>

-> if nullFlavor="NA", it puts "no applicable value" => ok if nullFlavor alone to indicate the label of the nullFlavor -> if nullFlavor + originalText => put only the text (and not "no applicable value")

-> same rule on the display order suffix, prefix, first name, last name (with a space between each) + put a line break if functioncode before

dataEnterer
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- same rule on organization in parentheses.

Informant: Address
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- display <houseNumber> and <streetName> on the same line
- put a line break after use="H" "home", use="WP" "work", etc…
- put a line break after each telecom

informationRecipient
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- display <houseNumber> and <streetName> on the same line

Authenticator and legalAuthenticator:
- same rule on the display order suffix, prefix, first name, last name (with a space between each)
- display <houseNumber> and <streetName> on the same line.

+ add checks on all array for header and footer elements in case the element is empty