### PR TITLE
#18 Add support for Clinicaldocument/statusCode

### DIFF
--- a/CDA.xsl
+++ b/CDA.xsl
@@ -2488,6 +2488,19 @@
             <xsl:text> </xsl:text>
             <xsl:value-of select="$confidentialityText"/>
         </xsl:if>
+        <xsl:if test="*[local-name(.) = 'statusCode']">
+            <xsl:if test="hl7:confidentialityCode[@code[not(. = 'N')]]">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            <xsl:text> </xsl:text>
+            <xsl:call-template name="getLocalizedString">
+                <xsl:with-param name="key" select="'statusCode'"/>
+                <xsl:with-param name="post" select="': '"/>
+            </xsl:call-template>
+            <xsl:call-template name="getLocalizedString">
+                <xsl:with-param name="key" select="concat('status-', *[local-name(.) = 'statusCode']/@code)"/>
+            </xsl:call-template>
+        </xsl:if>
         <xsl:text>)</xsl:text>
     </xsl:template>
 

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -2488,7 +2488,7 @@
             <xsl:text> </xsl:text>
             <xsl:value-of select="$confidentialityText"/>
         </xsl:if>
-        <xsl:if test="*[local-name(.) = 'statusCode']">
+        <!--<xsl:if test="*[local-name(.) = 'statusCode']">
             <xsl:if test="hl7:confidentialityCode[@code[not(. = 'N')]]">
                 <xsl:text>,</xsl:text>
             </xsl:if>
@@ -2500,7 +2500,7 @@
             <xsl:call-template name="getLocalizedString">
                 <xsl:with-param name="key" select="concat('status-', *[local-name(.) = 'statusCode']/@code)"/>
             </xsl:call-template>
-        </xsl:if>
+        </xsl:if>-->
         <xsl:text>)</xsl:text>
     </xsl:template>
 
@@ -3064,6 +3064,26 @@
                         <xsl:call-template name="show-timestamp">
                             <xsl:with-param name="in" select="hl7:effectiveTime"/>
                         </xsl:call-template>
+                        <xsl:if test="*[local-name(.) = 'statusCode']">
+                            <table class="table_simple">
+                                <tbody>
+                                    <tr>
+                                        <td class="td_label">
+                                            <xsl:call-template name="getLocalizedString">
+                                                <xsl:with-param name="key" select="'statusCode'"/>
+                                            </xsl:call-template>
+                                        </td>
+                                        <td>
+                                            <b>
+                                                <xsl:call-template name="getLocalizedString">
+                                                    <xsl:with-param name="key" select="concat('status-', *[local-name(.) = 'statusCode']/@code)"/>
+                                                </xsl:call-template>
+                                            </b>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </xsl:if>
                     </td>
                 </tr>
             </tbody>

--- a/CDA.xsl
+++ b/CDA.xsl
@@ -3076,7 +3076,7 @@
                                         <td>
                                             <b>
                                                 <xsl:call-template name="getLocalizedString">
-                                                    <xsl:with-param name="key" select="concat('status-', *[local-name(.) = 'statusCode']/@code)"/>
+                                                    <xsl:with-param name="key" select="concat('statusCode-', *[local-name(.) = 'statusCode']/@code)"/>
                                                 </xsl:call-template>
                                             </b>
                                         </td>

--- a/cda_l10n.xml
+++ b/cda_l10n.xml
@@ -2418,6 +2418,11 @@
         <value lang="nl-nl">Actief</value>
         <value lang="fr-fr">Actif</value>
     </translation>
+    <translation key="statusCode-held">
+        <comment>Label: Status held</comment>
+        <value lang="en-us">Held</value>
+        <value lang="nl-nl">Gepauzeerd</value>
+    </translation>
     <translation key="statusCode-completed">
         <comment>Label: Status completed</comment>
         <value lang="en-us">Completed</value>


### PR DESCRIPTION
Adds support for ClinicalDocument/statusCode if it occurs in the title of the document as "Status: statusCode/@code" where all parts are localizable. Sample in Dutch attached
<img width="976" alt="image" src="https://github.com/HL7/CDA-core-xsl/assets/5390573/c5d9a0ca-e2fb-448d-9abe-ef520c8ba871">
